### PR TITLE
JSON extractor that adds suffixes to fields based on value type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ priv/lucene-solr
 riak_test/ebin
 tests/20*
 tests/current
+.eunit

--- a/src/yz_json_extractor_with_suffix.erl
+++ b/src/yz_json_extractor_with_suffix.erl
@@ -1,0 +1,125 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc An extractor for JSON.  Nested objects have their fields concatenated
+%% with `field_separator'.  An array is converted into a multi-valued field.
+%% Fields are suffixed to match dynamic field definitions in the default
+%% schema.
+%%
+%% Example:
+%%
+%%   {"name":"ryan",
+%%    "info":{"city":"Baltimore",
+%%            "visited":["Boston", "New York", "San Francisco"]}}
+%%
+%%   [{<<"info_visited_txt">>,<<"San Francisco">>},
+%%    {<<"info_visited_txt">>,<<"New York">>},
+%%    {<<"info_visited_txt">>,<<"Boston">>},
+%%    {<<"info_city_t">>,<<"Baltimore">>},
+%%    {<<"name_t">>,<<"ryan">>}]
+%%
+%% Options:
+%%
+%%   `field_separator' - Use a different field separator than the
+%%                       default of `_'.
+
+-module(yz_json_extractor_with_suffix).
+
+-export([extract/1,
+         extract/2]).
+
+-include("yokozuna.hrl").
+-define(DEFAULT_FIELD_SEPARATOR, <<"_">>).
+
+-record(state, {fields = [],
+                field_separator = ?DEFAULT_FIELD_SEPARATOR,
+                multivalue = false
+               }).
+-type state() :: #state{}.
+
+-spec extract(binary()) -> fields() | {error, any()}.
+extract(Value) ->
+    extract(Value, ?NO_OPTIONS).
+
+-spec extract(binary(), proplist()) -> fields() | {error, any()}.
+extract(Value, Opts) ->
+    Sep = proplists:get_value(field_separator, Opts, ?DEFAULT_FIELD_SEPARATOR),
+    extract_fields(Value, #state{field_separator=Sep}).
+
+-spec extract_fields(binary(), state()) -> fields().
+extract_fields(Value, S) ->
+    Struct = mochijson2:decode(Value),
+    S2 = extract_fields(undefined, Struct, S),
+    S2#state.fields.
+
+extract_fields(Name, Value, State) when is_binary(Value) ->
+    extract_field(Name, string, Value, State);
+
+extract_fields(Name, Value, State) when is_number(Value) ->
+    Number = if
+        is_float(Value) -> float_to_list(Value);
+        is_integer(Value) -> integer_to_list(Value)
+    end,
+    extract_field(Name, number, list_to_binary(Number), State);
+
+extract_fields(Name, Value, State) when is_boolean(Value) ->
+    extract_field(Name, boolean, atom_to_binary(Value, utf8), State);
+
+extract_fields(Name, Values, State) when is_list(Values) ->
+    Fun = fun(InnerValue, InnerState) ->
+            extract_fields(Name, InnerValue, InnerState)
+    end,
+    State1 = lists:foldl(Fun, State#state{multivalue=true}, Values),
+    case State#state.multivalue of
+        true ->
+            State1;
+        false ->
+            State1#state{multivalue=false}
+    end;
+
+extract_fields(Name, {struct, PropList}, State) ->
+    Fun = fun({InnerName, InnerValue}, InnerState) ->
+            InnerName1 = concat_field_name(Name, InnerName, State#state.field_separator),
+            extract_fields(InnerName1, InnerValue, InnerState)
+    end,
+    lists:foldl(Fun, State, PropList);
+
+extract_fields(_, _, State) ->
+    State.
+
+extract_field(Name, Type, Value, State) ->
+    Name1 = field_name(Name, Type, State#state.multivalue),
+    Fields = [{Name1, Value}|State#state.fields],
+    State#state{fields=Fields}.
+
+field_name(Name, Type, MultiValue) ->
+    <<Name/binary, (suffix(Type, MultiValue))/binary>>.
+
+suffix(string, true) -> <<"_txt">>;
+suffix(number, true) -> <<"_ds">>;
+suffix(boolean, true) -> <<"_bs">>;
+suffix(string, _) -> <<"_t">>;
+suffix(number, _) -> <<"_d">>;
+suffix(boolean, _) -> <<"_b">>.
+
+concat_field_name(undefined, Name, _) ->
+    Name;
+concat_field_name(Name, Name1, Separator) ->
+    <<Name/binary, Separator/binary, Name1/binary>>.

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -131,8 +131,7 @@ get_vclocks(Core, Before, Continue, N) when N > 0 ->
 %% @doc Index the given `Docs'.
 index(Core, Docs) ->
     BaseURL = base_url() ++ "/" ++ Core ++ "/update",
-    Doc = {add, [], lists:map(fun encode_doc/1, Docs)},
-    XML = xmerl:export_simple([Doc], xmerl_xml),
+    XML = prepare_xml(Docs),
     Params = [],
     Encoded = mochiweb_util:urlencode(Params),
     URL = BaseURL ++ "?" ++ Encoded,
@@ -142,6 +141,10 @@ index(Core, Docs) ->
         {ok, "200", _, _} -> ok;
         Err -> throw({"Failed to index docs", Docs, Err})
     end.
+
+prepare_xml(Docs) ->
+    Content = {add, [], lists:map(fun encode_doc/1, Docs)},
+    xmerl:export_simple([Content], xmerl_xml).
 
 %% @doc Return the set of unique partitions stored on this node.
 -spec partition_list(string()) -> binary().

--- a/test/with_suffix.json
+++ b/test/with_suffix.json
@@ -1,0 +1,19 @@
+{"name":"ryan",
+ "age":29,
+ "pets":["smokey", "bandit"],
+ "books":[
+     {"title":"Introduction to Information Retrieval",
+      "authors":["Christopher D. Manning",
+                 "Prabhakar Raghavan",
+                 "Hinrich Schütze"]},
+     {"title":"Principles of Distributed Database Systems",
+      "authors":["M. Tamer Özsu", "Patrick Valduriez"]}
+ ],
+ "type":null,
+ "alive":true,
+ "married":false,
+ "a_number":1.1e6,
+ "lucky_numbers":[13,17,21],
+ "misc":{},
+ "kids":[]
+}

--- a/test/with_suffix.xml
+++ b/test/with_suffix.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<add>
+<doc>
+<field name="lucky_numbers_ds">21</field>
+<field name="lucky_numbers_ds">17</field>
+<field name="lucky_numbers_ds">13</field>
+<field name="a_number_d">1.10000000000000000000e+06</field>
+<field name="married_b">false</field>
+<field name="alive_b">true</field>
+<field name="books_authors_txt">Patrick Valduriez</field>
+<field name="books_authors_txt">M. Tamer Özsu</field>
+<field name="books_title_txt">Principles of Distributed Database Systems</field>
+<field name="books_authors_txt">Hinrich Schütze</field>
+<field name="books_authors_txt">Prabhakar Raghavan</field>
+<field name="books_authors_txt">Christopher D. Manning</field>
+<field name="books_title_txt">Introduction to Information Retrieval</field>
+<field name="pets_txt">bandit</field>
+<field name="pets_txt">smokey</field>
+<field name="age_d">29</field>
+<field name="name_t">ryan</field>
+</doc>
+</add>

--- a/test/yz_json_extractor_with_suffix_tests.erl
+++ b/test/yz_json_extractor_with_suffix_tests.erl
@@ -1,0 +1,13 @@
+-module(yz_json_extractor_with_suffix_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+json_extract_test() ->
+    %% Actual
+    {ok, TestJSON} = file:read_file("../test/with_suffix.json"),
+    Fields = yz_json_extractor_with_suffix:extract(TestJSON),
+    Xml = yz_solr:prepare_xml([{doc, Fields}]),
+    %% Expected
+    {ok, TestXML} = file:read_file("../test/with_suffix.xml"),
+    Xml1 = binary:replace(TestXML, <<"\n">>, <<"">>, [global]),
+    ?assertEqual(Xml1, iolist_to_binary(Xml)).


### PR DESCRIPTION
The extractor behaves very much like the existing JSON extractor. Arrays create multi-value fields and nested object field names are concatenated by a field separator (`_` by default). The only difference is the field names are suffixed according to the value type. The suffixes added to fields by this extractor correspond to the dynamic field definitions in the default schema.
- String - `*_t`
- Number - `*_d`
- Boolean - `*_b`
- Multi value
  - String - `*_txt`
  - Number - `*_ds`
  - Boolean - `*_bs`

Also, the function `yz_solr:prepare_xml/1` has been added to allow tests to generate XML data from extracted fields. While indexing documents I found that boolean and number values were not generated correctly. All values should be converted to binary in the extractor or the XML data will be incorrect. The included test extracts fields from sample JSON data and generates XML data.
