### PR TITLE
handle object siblings

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -188,6 +188,11 @@
 -define(YZ_FPN_FIELD_S, "_yz_fpn").
 -define(YZ_FPN_FIELD_B, <<"_yz_fpn">>).
 
+%% Sibling VTags
+-define(YZ_VTAG_FIELD, '_yz_vtag').
+-define(YZ_VTAG_FIELD_S, "_yz_vtag").
+-define(YZ_VTAG_FIELD_B, <<"_yz_vtag">>).
+
 %% Node
 -define(YZ_NODE_FIELD, '_yz_node').
 -define(YZ_NODE_FIELD_S, "_yz_node").

--- a/misc/bench/schemas/fruit_schema.xml
+++ b/misc/bench/schemas/fruit_schema.xml
@@ -19,6 +19,9 @@ rue"/>
         preflist, used for further filtering on overlapping partitions. -->
    <field name="_yz_fpn" type="string" indexed="true" stored="true"/>
 
+   <!-- If there is a sibling, use vtag to differentiate them -->
+   <field name="_yz_vtag" type="string" indexed="true" stored="true"/>
+
    <!-- Node: The name of the node that this doc was created on. -->
    <field name="_yz_node" type="string" indexed="true" stored="true"/>
 

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -157,6 +157,9 @@
         preflist, used for further filtering on overlapping partitions. -->
    <field name="_yz_fpn" type="string" indexed="true" stored="true"/>
 
+   <!-- If there is a sibling, use vtag to differentiate them -->
+   <field name="_yz_vtag" type="string" indexed="true" stored="true"/>
+
    <!-- Node: The name of the node that this doc was created on. -->
    <field name="_yz_node" type="string" indexed="true" stored="true"/>
 

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -23,7 +23,53 @@ confirm() ->
     ok = test_tagging(Cluster),
     KeysDeleted = delete_some_data(Cluster2, reap_sleep()),
     verify_deletes(Cluster2, KeysDeleted, YZBenchDir),
+    ok = test_siblings(Cluster),
     pass.
+
+test_siblings(Cluster) ->
+    lager:info("Test siblings"),
+    Node = hd(Cluster),
+    ok = allow_mult(Cluster, <<"siblings">>),
+    HP = hd(host_entries(rt:connection_info(Cluster))),
+    ok = write_sibs(HP),
+    %% Verify 10 times because of non-determinism in coverage
+    [ok = verify_sibs(HP) || _ <- lists:seq(1,10)],
+    ok.
+
+verify_sibs(HP) ->
+    lager:info("Verify siblings are indexed"),
+    R1 = search(HP, "siblings", "_yz_rk", "test"),
+    verify_count(4, R1),
+    Values = ["alpha", "beta", "charlie", "delta"],
+    [verify_count(1, search(HP, "siblings", "text", S)) || S <- Values],
+    ok.
+
+write_sibs({Host, Port}) ->
+    lager:info("Write siblings"),
+    URL = lists:flatten(io_lib:format("http://~s:~s/riak/siblings/test",
+                                      [Host, integer_to_list(Port)])),
+    Opts = [],
+    Headers = [{"content-type", "text/plain"}],
+    Body1 = <<"This is value alpha">>,
+    Body2 = <<"This is value beta">>,
+    Body3 = <<"This is value charlie">>,
+    Body4 = <<"This is value delta">>,
+    [{ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, B, Opts)
+     || B <- [Body1, Body2, Body3, Body4]],
+    %% Sleep for soft commit
+    timer:sleep(1000),
+    ok.
+
+allow_mult(Cluster, Bucket) ->
+    Args = [Bucket, [{allow_mult, true}]],
+    ok = rpc:call(hd(Cluster), riak_core_bucket, set_bucket, Args),
+    %% TODO: this should be a wait_for
+    timer:sleep(5000),
+    %% [begin
+    %%      BPs = rpc:call(N, riak_core_bucket, get_bucket, [Bucket]),
+    %%      ?assertEqual(true, proplists:get_bool(allow_mult, BPs))
+    %%  end || N <- Cluster],
+    ok.
 
 test_tagging(Cluster) ->
     lager:info("Test tagging"),
@@ -31,14 +77,15 @@ test_tagging(Cluster) ->
     ok = write_with_tag(HP),
     %% TODO: the test fails if this sleep isn't here
     timer:sleep(5000),
-    ok = query_tag(HP, "user_s", "rzezeski"),
-    ok = query_tag(HP, "desc_t", "description").
+    R1 = search(HP, "tagging", "user_s", "rzezeski"),
+    verify_count(1, R1),
+    R2 = search(HP, "tagging", "desc_t", "description"),
+    verify_count(1, R2).
 
 write_with_tag({Host, Port}) ->
     lager:info("Tag the object tagging/test"),
     URL = lists:flatten(io_lib:format("http://~s:~s/riak/tagging/test",
                                       [Host, integer_to_list(Port)])),
-    %% Opts = [{content_type, "text/plain"}],
     Opts = [],
     Body = <<"testing tagging">>,
     Headers = [{"content-type", "text/plain"},
@@ -48,16 +95,15 @@ write_with_tag({Host, Port}) ->
     {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body, Opts),
     ok.
 
-query_tag({Host, Port}, Name, Term) ->
-    URL = lists:flatten(io_lib:format("http://~s:~s/search/tagging?q=~s:~s&wt=json",
-                                      [Host, integer_to_list(Port), Name, Term])),
-    lager:info("Run query ~s", [URL]),
+search({Host, Port}, Index, Name, Term) ->
+    URL = lists:flatten(io_lib:format("http://~s:~s/search/~s?q=~s:~s&wt=json",
+                                      [Host, integer_to_list(Port), Index, Name, Term])),
+    lager:info("Run search ~s", [URL]),
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, [], get, [], Opts) of
         {ok, "200", _, Resp} ->
-            lager:info("Query resp ~p", [Resp]),
-            verify_count(1, Resp),
-            ok;
+            lager:info("Search resp ~p", [Resp]),
+            Resp;
         Other ->
             {bad_response, Other}
     end.
@@ -180,6 +226,8 @@ setup_indexing(Cluster, YZBenchDir) ->
     ok = install_hook(Node, ?INDEX_B),
     ok = create_index(Node, "tagging"),
     ok = install_hook(Node, <<"tagging">>),
+    ok = create_index(Node, "siblings"),
+    ok = install_hook(Node, <<"siblings">>),
     %% Give Solr time to build index
     timer:sleep(5000).
 

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -30,7 +30,7 @@
 %% @doc Index the given object `O'.
 -spec index(string(), riak_object:riak_object()) -> ok | {error, term()}.
 index(Index, O) ->
-    yz_solr:index(Index, [yz_doc:make_doc(O, <<"FPN">>, <<"Partition">>)]).
+    yz_solr:index(Index, yz_doc:make_docs(O, <<"FPN">>, <<"Partition">>)).
 
 %% @doc Return the set of unique logical partitions stored on this
 %%      node for the given `Index'.

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -45,7 +45,7 @@ doc_id(O, Partition, Sibling) ->
 has_siblings(O) -> riak_object:value_count(O) > 1.
 
 %% @doc Given an object generate the doc to be indexed by Solr.
--spec make_docs(riak_object:riak_object(), binary(), binary()) -> doc().
+-spec make_docs(riak_object:riak_object(), binary(), binary()) -> [doc()].
 make_docs(O, FPN, Partition) ->
     [make_doc(O, Content, FPN, Partition) || Content <- riak_object:get_contents(O)].
 
@@ -98,7 +98,7 @@ extract_fields({MD, V}) ->
 %% @private
 %%
 %% @doc Extract tags from object metadata.
--spec extract_tags(obj()) -> fields().
+-spec extract_tags(dict()) -> fields().
 extract_tags(MD) ->
     MD2 = get_user_meta(MD),
     TagNames = get_tag_names(MD2),

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -33,11 +33,13 @@
 add_to_doc({doc, Fields}, Field) ->
     {doc, [Field|Fields]}.
 
-% -spec doc_id(riak_object:riak_object(), binary()) -> binary().
+-spec doc_id(riak_object:riak_object(), binary()) -> binary().
 doc_id(O, Partition) ->
     <<(riak_object:key(O))/binary,"_",Partition/binary>>.
+
 doc_id(O, Partition, none) ->
     doc_id(O, Partition);
+
 doc_id(O, Partition, Sibling) ->
     <<(riak_object:key(O))/binary,"_",Partition/binary,"_",Sibling/binary>>.
 

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -53,12 +53,12 @@ get(C, Bucket, Key) ->
     end.
 
 %% @doc Get the content-type of the object.
--spec get_obj_ct(obj()) -> binary().
+-spec get_obj_ct(obj_metadata()) -> binary().
 get_obj_ct(MD) ->
     dict:fetch(<<"content-type">>, MD).
 
 %% @doc Determine if the `Obj' is a tombstone.
--spec is_tombstone(obj()) -> boolean().
+-spec is_tombstone(obj_metadata()) -> boolean().
 is_tombstone(MD) ->
     case yz_misc:dict_get(<<"X-Riak-Deleted">>, MD, false) of
         "true" -> true;

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -75,15 +75,8 @@ get_md_entry(MD, Key) ->
 %%
 %% NOTE: Index is doing double duty of index and delete.
 -spec index(obj(), write_reason(), term()) -> ok.
-index(Obj, delete, VNodeState) ->
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    LI = yz_cover:logical_index(Ring),
+index(Obj, delete, _) ->
     {Bucket, Key} = BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
-    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    AllowMult = proplists:get_value(allow_mult, BProps, false),
-    Partition = get_partition(VNodeState),
-    LP = yz_cover:logical_partition(LI, Partition),
-    DocID = binary_to_list(yz_doc:doc_id(Obj, ?INT_TO_BIN(LP))),
     try
         XML = yz_solr:encode_delete({key, Key}),
         yz_solr:delete_by_query(binary_to_list(Bucket), XML)

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -54,24 +54,23 @@ get(C, Bucket, Key) ->
 
 %% @doc Get the content-type of the object.
 -spec get_obj_ct(obj()) -> binary().
-get_obj_ct(Obj) ->
-    dict:fetch(<<"content-type">>, riak_object:get_metadata(Obj)).
+get_obj_ct(MD) ->
+    dict:fetch(<<"content-type">>, MD).
 
 %% @doc Determine if the `Obj' is a tombstone.
 -spec is_tombstone(obj()) -> boolean().
-is_tombstone(Obj) ->
-    case yz_misc:dict_get(<<"X-Riak-Deleted">>, metadata(Obj), false) of
+is_tombstone(MD) ->
+    case yz_misc:dict_get(<<"X-Riak-Deleted">>, MD, false) of
         "true" -> true;
         false -> false
     end.
 
-%% @doc Get the metadata of the `Obj'.
--spec metadata(obj()) -> obj_metadata().
-metadata(Obj) ->
-    riak_object:get_metadata(Obj).
-
 get_md_entry(MD, Key) ->
     yz_misc:dict_get(Key, MD, none).
+
+delete_siblings_by_key(Obj, Bucket, Key, AllowMult) ->
+    XML = yz_solr:encode_delete({key, Key}),
+    yz_solr:delete_by_query(binary_to_list(Bucket), XML).
 
 %% @doc An object modified hook to create indexes as object data is
 %% written or modified.
@@ -83,30 +82,51 @@ get_md_entry(MD, Key) ->
 index(Obj, delete, VNodeState) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     LI = yz_cover:logical_index(Ring),
-    {Bucket, _Key} = BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
-    LP = yz_cover:logical_partition(LI, get_partition(VNodeState)),
+    {Bucket, Key} = BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
+    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
+    AllowMult = proplists:get_value(allow_mult, BProps, false),
+    Partition = get_partition(VNodeState),
+    LP = yz_cover:logical_partition(LI, Partition),
     DocID = binary_to_list(yz_doc:doc_id(Obj, ?INT_TO_BIN(LP))),
     try
-        yz_solr:delete(binary_to_list(Bucket), DocID)
+        yz_solr:delete(binary_to_list(Bucket), DocID),
+        delete_siblings_by_key(Obj, Bucket, Key, AllowMult)
     catch _:Err ->
-            ?ERROR("failed to delete docid ~p with error ~p", [BKey, Err])
+        ?ERROR("failed to delete docid ~p with error ~p", [BKey, Err])
     end;
+
 index(Obj, Reason, VNodeState) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     LI = yz_cover:logical_index(Ring),
-    {Bucket, _} = BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
+    {Bucket, Key} = BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
     ok = maybe_wait(Reason, Bucket),
     BProps = riak_core_bucket:get_bucket(Bucket, Ring),
+    AllowMult = proplists:get_value(allow_mult, BProps),
     NVal = riak_core_bucket:n_val(BProps),
     Idx = riak_core_util:chash_key(BKey),
     IdealPreflist = lists:sublist(riak_core_ring:preflist(Idx, Ring), NVal),
     LFPN = yz_cover:logical_partition(LI, first_partition(IdealPreflist)),
     LP = yz_cover:logical_partition(LI, get_partition(VNodeState)),
-    Doc = yz_doc:make_doc(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP)),
+    Docs = yz_doc:make_docs(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP)),
+
     try
-        ok = yz_solr:index(binary_to_list(Bucket), [Doc])
+        ok = yz_solr:index(binary_to_list(Bucket), Docs),
+        case riak_object:value_count(Obj) of
+            2 ->
+                case AllowMult of
+                    true  ->
+                        % An object has crossed the threshold from being a single value
+                        % Object, to a sibling value Object, delete the non-sibling ID
+                        DocID = binary_to_list(yz_doc:doc_id(Obj, ?INT_TO_BIN(LP))),
+                        yz_solr:delete(binary_to_list(Bucket), DocID);
+                    _ -> ok
+                end;
+            % Delete any siblings
+            1 -> delete_siblings_by_key(Obj, Bucket, Key, AllowMult);
+            _ -> ok
+        end
     catch _:Err ->
-            ?ERROR("failed to index object ~p with error ~p", [BKey, Err])
+        ?ERROR("failed to index object ~p with error ~p", [BKey, Err])
     end.
 
 %% @doc Install the object modified hook on the given `Bucket'.

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -138,8 +138,7 @@ owned_and_next_partitions(Node, Ring) ->
     Next = lists:filter(is_owner(Node), riak_core_ring:all_next_owners(Ring)),
     ordsets:from_list([P || {P,_} <- Next ++ Owned]).
 
-%% @doc Set the ring metadata for the given `Name' to the given
-%%      `Value'
+%% @doc Set the ring metadata for the given `Name' to `Value'
 -spec set_ring_meta(atom(), any()) -> ring().
 set_ring_meta(Name, Value) ->
     Ring = get_ring(raw),

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -139,7 +139,8 @@ index(Core, Docs) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, post, XML, Opts) of
         {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to index docs", Docs, Err})
+        Err -> throw({"Failed to index docs", Err})
+        % Err -> throw({"Failed to index docs", Docs, Err})
     end.
 
 prepare_xml(Docs) ->
@@ -228,8 +229,12 @@ convert_action(remove) -> "UNLOAD".
 encode_commit() ->
 	xmerl:export_simple([{commit, []}], xmerl_xml).
 
+encode_delete({key,Key})->
+    Query = "_yz_rk:" ++ binary_to_list(Key) ++ " AND _yz_vtag:[* TO *]",
+    xmerl:export_simple([{delete, [], [{'query', [], [Query]}]}], xmerl_xml);
+
 encode_delete({id,Id})->
-	xmerl:export_simple([{delete, [], [{id, [], [Id]}]}], xmerl_xml).
+    xmerl:export_simple([{delete, [], [{id, [], [Id]}]}], xmerl_xml).
 
 encode_doc({doc, Fields}) ->
 	{doc, [], lists:map(fun encode_field/1,Fields)};

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -139,8 +139,7 @@ index(Core, Docs) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, post, XML, Opts) of
         {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to index docs", Err})
-        % Err -> throw({"Failed to index docs", Docs, Err})
+        Err -> throw({"Failed to index docs", Docs, Err})
     end.
 
 prepare_xml(Docs) ->
@@ -230,6 +229,10 @@ encode_commit() ->
 	xmerl:export_simple([{commit, []}], xmerl_xml).
 
 encode_delete({key,Key})->
+    Query = "_yz_rk:" ++ binary_to_list(Key),
+    xmerl:export_simple([{delete, [], [{'query', [], [Query]}]}], xmerl_xml);
+
+encode_delete({key,Key,siblings})->
     Query = "_yz_rk:" ++ binary_to_list(Key) ++ " AND _yz_vtag:[* TO *]",
     xmerl:export_simple([{delete, [], [{'query', [], [Query]}]}], xmerl_xml);
 


### PR DESCRIPTION
Currently Yokozuna punts on object siblings.  It grabs all the values and takes the head.  It would be ideal to index all siblings so that a query matching any of them returns the object key.  There are probably multiple ways to handle this.  Here are two potential solutions off the cuff.
1. Use multiValued fields for everything.  All siblings would generate one document but that document could contain same field many times.
2. Generate a document for each sibling.  This would require changing the solr id key to include a sibling identifier.  After sibling resolution how are the documents cleaned up?  You could probably do delete by query and use `_yz_rk` (riak key) field.
