### PR TITLE
Update README to use yz-setup rather than manual steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,38 +24,20 @@ you should be able to complete these steps.
 
 ### Building ###
 
-1. Clone my fork of Riak.
+1. Clone my fork of Riak's Yokozuna branch
 
-        git clone git://github.com/basho/riak.git
+        git clone -b rz-yokozuna-2 git://github.com/basho/riak.git
         cd riak
 
-2. Checkout the Yokozuna branch.
+2. Setup and compile yokozuna. Setup will replace riak_kv with
+   the correct YZ branch. Compile will take a long time because
+   it must clone Solr source and build it.  The first time you do
+   this is the longest as Ivy may have to download all the
+   dependencies if you don't regularly develop on Java projects.
 
-        git checkout rz-yokozuna-2
+        make yz-setup
 
-3. Download the dependencies.
-
-        make deps
-
-4. Replace the Riak KV dependency with my fork and checkout the
-   Yokozuna branch.
-
-        cd deps
-
-        rm -rf riak_kv
-        git clone git://github.com/basho/riak_kv.git
-        (cd riak_kv && git checkout rz-yokozuna-3)
-
-
-5. Compile.  This will take a long time because it must clone Solr
-   source and build it.  The first time you do this is the longest as
-   Ivy may have to download all the dependencies if you don't
-   regularly develop on Java projects.
-
-        cd ..
-        make
-
-6. Make a stage rel or stage devrel.  At this point it's no different
+3. Make a stage rel or stage devrel.  At this point it's no different
    from building a vanilla Riak release.
 
         make stagedevrel


### PR DESCRIPTION
PR basho/riak#264 adds a yz-setup build to the makefile that just encodes any manual steps needed to set up Yokozuna. This updates the README's build section to reflect that.
