### PR TITLE
Searching Nonexistent Index - Better Error Msg

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -114,6 +114,8 @@
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
         "Not enough nodes are up to service this request.").
+-define(YZ_ERR_INDEX_NOT_FOUND,
+        "No index ~p found.").
 
 %%%===================================================================
 %%% Anti Entropy

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -219,7 +219,7 @@ search(Core, Headers, Params, Mapping) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, get, Body, Opts) of
         {ok, "200", RHeaders, Resp} -> {RHeaders, Resp};
-        {ok, "404", RHeaders, Resp} -> throw(not_found);
+        {ok, "404", _, _} -> throw(not_found);
         Err -> throw({"Failed to search", URL, Err})
     end.
 

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -219,6 +219,7 @@ search(Core, Headers, Params, Mapping) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, get, Body, Opts) of
         {ok, "200", RHeaders, Resp} -> {RHeaders, Resp};
+        {ok, "404", RHeaders, Resp} -> throw(not_found);
         Err -> throw({"Failed to search", URL, Err})
     end.
 

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -101,7 +101,8 @@ content_types_provided(RD, S) ->
     {Types, RD, S}.
 
 content_types_accepted(RD, S) ->
-    Types = [{"application/json", create_index}],
+    Types = [{"application/json", create_index},
+             {"application/octet-stream", create_index}],
     {Types, RD, S}.
 
 % Responsed to a DELETE request by removing the
@@ -173,10 +174,11 @@ malformed_request(RD, S) when S#ctx.method =:= 'PUT' ->
     case S#ctx.index_name of
         undefined -> {{halt, 404}, RD, S};
         _ ->
-            case wrq:get_req_header("Content-Type", RD) of
-                undefined ->
+            CT = wrq:get_req_header("Content-Type", RD),
+            case CT =:= undefined andalso (not(S#ctx.props =:= [])) of
+                true ->
                     text_response(true, "Missing Content-Type request header~n", [], RD, S);
-                _  ->
+                false  ->
                     schema_exists_response(RD, S)
             end
     end;


### PR DESCRIPTION
Searching on a non-existent index returns a cryptic error msg like the following.  Instead return a 404.

```
curl 'http://localhost:10018/search/blah?q=foofoo'                                                                                                                                                                                                                             
<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>{error,
    {throw,
        {"Failed to search",
         "http://localhost:10016/solr/blah/select?shards=127.0.0.1:10016/solr/blah,127.0.0.1:10026/solr/blah,127.0.0.1:10036/solr/blah,127.0.0.1:10046/solr/blah&q=foofoo&fq=%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A1%29+OR+%28_yz_node%3Adev4%40127.0.0.1+AND+_yz_pn%3A4%29+OR+%28_yz_node%3Adev3%40127.0.0.1+AND+_yz_pn%3A7%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A10%29+OR+%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A13%29+OR+%28_yz_node%3Adev4%40127.0.0.1+AND+_yz_pn%3A16%29+OR+%28_yz_node%3Adev3%40127.0.0.1+AND+_yz_pn%3A19%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A22%29+OR+%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A25%29+OR+%28_yz_node%3Adev4%40127.0.0.1+AND+_yz_pn%3A28%29+OR+%28_yz_node%3Adev3%40127.0.0.1+AND+_yz_pn%3A31%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A34%29+OR+%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A37%29+OR+%28_yz_node%3Adev4%40127.0.0.1+AND+_yz_pn%3A40%29+OR+%28_yz_node%3Adev3%40127.0.0.1+AND+_yz_pn%3A43%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A46%29+OR+%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A49%29+OR+%28_yz_node%3Adev4%40127.0.0.1+AND+_yz_pn%3A52%29+OR+%28_yz_node%3Adev3%40127.0.0.1+AND+_yz_pn%3A55%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A58%29+OR+%28_yz_node%3Adev1%40127.0.0.1+AND+_yz_pn%3A61%29+OR+%28_yz_node%3Adev2%40127.0.0.1+AND+_yz_pn%3A62+AND+%28_yz_fpn%3A62%29%29",
         {ok,"404",
             [{"Content-Type","text/html;charset=ISO-8859-1"},
              {"Cache-Control","must-revalidate,no-cache,no-store"},
              {"Content-Length","1381"}],
             <<"<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"/>\n<title>Error 404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Problem accessing /solr/blah/select. Reason:\n<pre>    Not Found</pre></p><hr /><i><small>Powered by Jetty://</small></i><br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n<br/>                                                \n\n</body>\n</html>\n">>}},
        [{yz_solr,search,3,[{file,"src/yz_solr.erl"},{line,220}]},
         {yz_wm_search,search,2,[{file,"src/yz_wm_search.erl"},{line,68}]},
         {webmachine_resource,resource_call,3,
             [{file,"src/webmachine_resource.erl"},{line,171}]},
         {webmachine_resource,do,3,
             [{file,"src/webmachine_resource.erl"},{line,130}]},
         {webmachine_decision_core,resource_call,1,
             [{file,"src/webmachine_decision_core.erl"},{line,48}]},
         {webmachine_decision_core,decision,1,
             [{file,"src/webmachine_decision_core.erl"},{line,555}]},
         {webmachine_decision_core,handle_request,2,
             [{file,"src/webmachine_decision_core.erl"},{line,33}]},
         {webmachine_mochiweb,loop,1,
             [{file,"src/webmachine_mochiweb.erl"},{line,97}]}]}}</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>
```
