### PR TITLE
Files Overwritten on Core Failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ riak_test/ebin
 tests/20*
 tests/current
 .eunit
+log

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -88,7 +88,7 @@ local_create(Ring, Name) ->
             SchemaFile = filename:join([ConfDir, yz_schema:filename(SchemaName)]),
 
             yz_misc:make_dirs([ConfDir, DataDir]),
-            yz_misc:copy_files(ConfFiles, ConfDir),
+            yz_misc:copy_files(ConfFiles, ConfDir, update),
             ok = file:write_file(SchemaFile, RawSchema),
 
             CoreProps = [

--- a/test/yz_misc_tests.erl
+++ b/test/yz_misc_tests.erl
@@ -1,0 +1,60 @@
+%%--------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%--------------------------------------------------------------------
+
+%% @doc EUnit and Exercise yz_misc.
+-module(yz_misc_tests).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+should_copy_skip_test() ->
+    Thisfile = atom_to_list(?MODULE) ++ ".erl",
+    ?assertNot(yz_misc:should_copy(skip, Thisfile, Thisfile)),
+    ?assert(yz_misc:should_copy(skip, "<nofile>", "<nofile>")),
+    ?assert(yz_misc:should_copy(skip, Thisfile, "<nofile>")).
+
+should_copy_update_test() ->
+    Thisfile = atom_to_list(?MODULE) ++ ".erl",
+    %% same file and no file acts the same as skip
+    ?assertNot(yz_misc:should_copy(update, Thisfile, Thisfile)),
+    ?assert(yz_misc:should_copy(update, "<nofile>", "<nofile>")),
+    ?assert(yz_misc:should_copy(update, Thisfile, "<nofile>")),
+    %% No file to update
+    ?assertNot(yz_misc:should_copy(update, "<nofile>", Thisfile)),
+    %% Compare timestamps
+    Newfile = lists:flatten(io_lib:format("~p-~p",[
+                erlang:phash2(make_ref()),node()])),
+    try
+        ok = file:write_file(Newfile, "data"),
+        ?assert(yz_misc:should_copy(update, Newfile, Thisfile)),
+        ?assertNot(yz_misc:should_copy(update, Thisfile, Newfile))
+    catch _:_Err ->
+        ?assert(false)
+    after
+        file:delete(Newfile)
+    end.
+
+should_copy_overwrite_test() ->
+    Thisfile = atom_to_list(?MODULE) ++ ".erl",
+    ?assert(yz_misc:should_copy(overwrite, Thisfile, Thisfile)),
+    ?assert(yz_misc:should_copy(overwrite, "<nofile>", "<nofile>")),
+    ?assert(yz_misc:should_copy(overwrite, Thisfile, "<nofile>")).
+


### PR DESCRIPTION
If a Solr Core fails to initialize, or is not up for any reason, and a
ring event comes in then Yokozuna will try to create it because
`yz_index:exists` returns `false` if the Core is not running.  In most
cases this is harmless because the index data will not be lost.  But
in the case where modifications have been made to files living under
the `instanceDir` they will be lost.  This is because Yokozuna will
re-copy the configuration files overwriting any modifications made to
those local to the instance.
## Reproduce
- Run against Yokozuna commit `448fe02b1691b7943dcbdc87df4074d1b1fbde4a`
- Build a Riak rel, `make stage`, and start it
- Create a new index `yz_index:create("foo")`
- Stop Riak
- Edit `rel/riak/data/yz/foo/conf/config.xml` and remove the
  `startup="lazy"` from the `ExtractingRequestHandler`.
- Start Riak and tail -f `rel/riak/log/solr-0.log`
- You'll see a failure to load the class and then shortly after a
  successful creation of the core
- Reopen `rel/riak/data/yz/foo/conf/config.xml` and you'll see the
  `startup="lazy"` is there again.
## Potential Solutions
- Have `yz_index:exists` distinguish between a downed Solr Core and
  one that doesn't exist at all.  Take different actions depending on
  the situation.
- During file copy only overwrite files that don't already exist.
- Same as previous but only overwrite if the source file is newer.
