### PR TITLE
Handle {error, Reason} in make_doc/index

### DIFF
--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -64,8 +64,13 @@ make_doc(O, {MD, V}, FPN, Partition, IndexContent) ->
             true -> extract_fields({MD, V});
             false -> []
         end,
-    Tags = extract_tags(MD),
-    {doc, lists:append([Tags, ExtractedFields, Fields])}.
+    case ExtractedFields of
+        {error, Reason} ->
+            {error, {extract, Reason}};
+        _ ->
+            Tags = extract_tags(MD),
+            {doc, lists:append([Tags, ExtractedFields, Fields])}
+    end.
 
 make_fields({DocId, Key, FPN, Partition, none, EntropyData}) ->
     [{id, DocId},

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -150,13 +150,14 @@ index(Obj, Reason, VNodeState) ->
     LFPN = yz_cover:logical_partition(LI, first_partition(PrimaryPL)),
     P = get_partition(VNodeState),
     LP = yz_cover:logical_partition(LI, P),
-    Docs = yz_doc:make_docs(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP),
+    AllDocs = yz_doc:make_docs(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP),
                             index_content(BProps)),
+    ValidDocs = [D || D <- AllDocs, element(1, D) == doc],
     IdxN = {first_partition(PrimaryPL), NVal},
 
     try
-        ok = yz_solr:index(Index, Docs),
-        ok = cleanup(length(Docs), {Index, Obj, Key, LP}),
+        ok = yz_solr:index(Index, ValidDocs),
+        ok = cleanup(length(ValidDocs), {Index, Obj, Key, LP}),
         ok = update_hashtree({insert, yz_kv:hash_object(Obj)}, P, IdxN, BKey)
     catch _:Err ->
         ?ERROR("failed to index object ~p with error ~p", [BKey, Err])


### PR DESCRIPTION
Refer to #112 as a replacement for this issue.

The `yz_doc:extract_fields` function can return `{error, any()}` yet `make_doc` assumes success.  This would blow up on the call to `lists:append` which would bubble to `yz_kv:index` which at that point is outside the try/catch and would crash vnode.  This is a sign of some sloppiness on my part in thinking about error handling during indexing.

The entire code path from the KV vnode call of `yz_kv:index` to its return should be gone over to check for common error conditions that might arise do to user input and decide how to deal with them.
