### PR TITLE
Rename install_hook to set_index_flag

### DIFF
--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -41,7 +41,7 @@ If you leave off the index name from the GET request, all installed
 indexes will be installed as a JSON array.
 
 Finally, when you are done with the index, you can issue a DELETE
-method with an index name. This will both remove the index.
+method with an index name to remove the index.
 
 ```bash
 curl -XDELETE http://localhost:8098/yz/index/my_bucket

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -3,10 +3,9 @@ Administration
 
 ## Index Creation
 
-Before Riak data may be indexed an _index_ must be created and
-Yokozuna must hook into the KV object modifications.  The easiest way
-to accomplish both of these things is to use the HTTP index resource.
-It performs both steps at once.
+Before Riak data may be indexed an _index_ must be created.
+The easiest way to accomplish this is to use the HTTP index
+resource.
 
 **NOTE:** Currently the index name is a 1:1 mapping with a KV bucket
           name. This may eventually change to a 1:M mapping from index
@@ -42,8 +41,7 @@ If you leave off the index name from the GET request, all installed
 indexes will be installed as a JSON array.
 
 Finally, when you are done with the index, you can issue a DELETE
-method with an index name. This will both remove the index and the
-hook into KV.
+method with an index name. This will both remove the index.
 
 ```bash
 curl -XDELETE http://localhost:8098/yz/index/my_bucket

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,8 @@
    {git, "git://github.com/basho/riak_kv", {branch, "yz-merge"}}},
   {rebar_vsn_plugin, "",
    {git, "git://github.com/erlware/rebar_vsn_plugin.git",
-    {tag, "master"}}}
+    {tag, "master"}}},
+  {meck, ".*", {git, "git://github.com/eproxus/meck"}}
  ]}.
 
 {pre_hooks, [{compile, "./priv/grab-solr.sh"},

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -276,9 +276,9 @@ delete_some_data(Cluster, ReapSleep) ->
 host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
-install_hook(Node, Index) ->
+set_index_flag(Node, Index) ->
     lager:info("Install index hook on bucket ~s [~p]", [Index, Node]),
-    rpc:call(Node, yz_kv, install_hook, [Index]).
+    rpc:call(Node, yz_kv, set_index_flag, [Index]).
 
 join_three(Nodes) ->
     [NodeA|Others] = All = lists:sublist(Nodes, 3),
@@ -336,13 +336,13 @@ setup_indexing(Cluster, YZBenchDir) ->
     RawSchema = read_schema(YZBenchDir),
     ok = store_schema(Node, ?FRUIT_SCHEMA_NAME, RawSchema),
     ok = create_index(Node, ?INDEX_S, ?FRUIT_SCHEMA_NAME),
-    ok = install_hook(Node, ?INDEX_B),
+    ok = set_index_flag(Node, ?INDEX_B),
     ok = create_index(Node, "fruit_aae", ?FRUIT_SCHEMA_NAME),
-    ok = install_hook(Node, <<"fruit_aae">>),
+    ok = set_index_flag(Node, <<"fruit_aae">>),
     ok = create_index(Node, "tagging"),
-    ok = install_hook(Node, <<"tagging">>),
+    ok = set_index_flag(Node, <<"tagging">>),
     ok = create_index(Node, "siblings"),
-    ok = install_hook(Node, <<"siblings">>),
+    ok = set_index_flag(Node, <<"siblings">>),
     %% Give Solr time to build index
     timer:sleep(5000).
 

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -195,16 +195,17 @@ update_hashtree(Action, Partition, IdxN, BKey) ->
             lager:debug("Failed to update hashtree: ~p ~p", [BKey, Reason])
     end.
 
-%% @doc Install the object modified hook on the given `Bucket'.
--spec install_hook(binary()) -> ok.
-install_hook(Bucket) when is_binary(Bucket) ->
+%% @doc Set's the yz_index_content flag to true on the given `Bucket',
+%% ensuring the object's value will be indexes.
+-spec set_index_flag(binary()) -> ok.
+set_index_flag(Bucket) when is_binary(Bucket) ->
     set_index_flag(Bucket, true).
 
-%% @doc Uninstall the object modified hook on the given `Bucket'.
--spec uninstall_hook(binary()) -> ok.
-uninstall_hook(Bucket) when is_binary(Bucket) ->
-    set_index_flag(Bucket, false).
-
+%% @doc Set's the yz_index_content flag to the boolean value
+%% on the given `Bucket'. If `false' then minimal object information
+%% is indexed (for AAE). If `true', then values in this bucket
+%% will be indexed.
+-spec set_index_flag(binary(), boolean()) -> ok.
 set_index_flag(Bucket, Bool) ->
     ok = riak_core_bucket:set_bucket(Bucket, [{?YZ_INDEX_CONTENT, Bool}]).
 

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -195,13 +195,13 @@ update_hashtree(Action, Partition, IdxN, BKey) ->
             lager:debug("Failed to update hashtree: ~p ~p", [BKey, Reason])
     end.
 
-%% @doc Set's the yz_index_content flag to true on the given `Bucket',
+%% @doc Set the yz_index_content flag to true on the given `Bucket',
 %% ensuring the object's value will be indexes.
 -spec set_index_flag(binary()) -> ok.
 set_index_flag(Bucket) when is_binary(Bucket) ->
     set_index_flag(Bucket, true).
 
-%% @doc Set's the yz_index_content flag to the boolean value
+%% @doc Set the yz_index_content flag to the boolean value
 %% on the given `Bucket'. If `false' then minimal object information
 %% is indexed (for AAE). If `true', then values in this bucket
 %% will be indexed.

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -111,7 +111,7 @@ delete_resource(RD, S) ->
     IndexName = S#ctx.index_name,
     case yz_index:exists(IndexName) of
         true  ->
-            ok = yz_kv:uninstall_hook(list_to_binary(IndexName)),
+            ok = yz_kv:set_index_flag(list_to_binary(IndexName), false),
             ok = yz_index:remove(IndexName),
             {true, RD, S};
         false -> {true, RD, S}
@@ -230,6 +230,6 @@ create_install_index(IndexName, SchemaName)->
         true  -> "exists";
         false ->
             ok = yz_index:create(IndexName, SchemaName),
-            ok = yz_kv:install_hook(list_to_binary(IndexName)),
+            ok = yz_kv:set_index_flag(list_to_binary(IndexName)),
             "ok"
     end.

--- a/test/yz_kv_tests.erl
+++ b/test/yz_kv_tests.erl
@@ -1,0 +1,18 @@
+-module(yz_kv_tests).
+-compile(export_all).
+
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+set_index_flag_test()->
+  meck:new(riak_core_bucket),
+  meck:expect(riak_core_bucket, set_bucket,
+    fun(Bucket, Props) when Bucket =:= <<"a">> ->
+      case Props of
+        [{?YZ_INDEX_CONTENT, true}] -> ok;
+        _ -> error
+      end
+    end),
+  ?assertEqual(yz_kv:set_index_flag(<<"a">>), ok),
+  ?assert(meck:validate(riak_core_bucket)),
+  meck:unload(riak_core_bucket).


### PR DESCRIPTION
Now that all data is indexed (otherwise AAE won't work) there is no longer a notion of a hook.  All data written to KV is passed to Yokozuna for minimal indexing.  But now there is a flag `yz_index_content` to indicate to Yokozuna that the content should also be indexed.
- Rename the code in the appropriate places: yz_kv and yz_wm_index
- Update documentation, explain that everything is indexed and what the index flag does.
