### PR TITLE
Port Latest AAE Changes

### DIFF
--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -51,15 +51,26 @@ start(Index, RPs) ->
 start_link(Index, RPs) ->
     gen_server:start_link(?MODULE, [Index, RPs], []).
 
-%% @doc Insert the given `Key' and `Hash' pair on `Tree' for the given `Id'
--spec insert({p(),n()}, {binary(),binary()}, binary(), tree(), list()) -> ok.
-insert(Id, BKey, Hash, Tree, Options) ->
-    gen_server:cast(Tree, {insert, Id, BKey, Hash, Options}).
+%% @doc Insert the given `Key' and `Hash' pair on `Tree' for the given
+%%      `Id'.  The result of a sync call should be ignored since it
+%%      uses `catch'.
+-spec insert(async | sync, {p(),n()}, bkey(), binary(), tree(), list()) ->
+                    ok | term().
+insert(async, Id, BKey, Hash, Tree, Options) ->
+    gen_server:cast(Tree, {insert, Id, BKey, Hash, Options});
 
-%% @doc Delete the `BKey' from `Tree'.  The id will be determined from `BKey'.
--spec delete({p(),n()}, {binary(),binary()}, tree()) -> ok.
-delete(Id, BKey, Tree) ->
-    gen_server:cast(Tree, {delete, Id, BKey}).
+insert(sync, Id, BKey, Hash, Tree, Options) ->
+    catch gen_server:call(Tree, {insert, Id, BKey, Hash, Options}, 1000).
+
+%% @doc Delete the `BKey' from `Tree'.  The id will be determined from
+%%      `BKey'.  The result of the sync call should be ignored since
+%%      it uses catch.
+-spec delete(async | sync, {p(),n()}, bkey(), tree()) -> ok.
+delete(async, Id, BKey, Tree) ->
+    gen_server:cast(Tree, {delete, Id, BKey});
+
+delete(sync, Id, BKey, Tree) ->
+    catch gen_server:call(Tree, {delete, Id, BKey}, 1000).
 
 -spec update({p(),n()}, tree()) -> ok.
 update(Id, Tree) ->
@@ -134,6 +145,14 @@ init([Index, RPs]) ->
             S2 = init_trees(RPs, S),
             {ok, S2}
     end.
+
+handle_call({insert, Id, BKey, Hash, Options}, _From, S) ->
+    S2 = do_insert(Id, term_to_binary(BKey), Hash, Options, S),
+    {reply, ok, S2};
+
+handle_call({delete, IdxN, BKey}, _From, S) ->
+    S2 = do_delete(IdxN, term_to_binary(BKey), S),
+    {reply, ok, S2};
 
 handle_call(get_index, _From, S) ->
     {reply, S#state.index, S};
@@ -257,7 +276,7 @@ fold_keys(Partition, Tree) ->
                 %% TODO: return _yz_fp from iterator and use that for
                 %%       more efficient get_index_N
                 IndexN = get_index_n(BKey),
-                insert(IndexN, BKey, Hash, Tree, [if_missing])
+                insert(async, IndexN, BKey, Hash, Tree, [if_missing])
         end,
     Filter = [{partition, LogicalPartition}],
     [yz_entropy:iterate_entropy_data(Name, Filter, F) || {Name,_} <- Indexes],

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -185,10 +185,10 @@ update_hashtree(Action, Partition, IdxN, BKey) ->
             Tree ->
                 case Action of
                     {insert, ObjHash} ->
-                        ok = yz_index_hashtree:insert(IdxN, BKey,
-                                                      ObjHash, Tree, []);
+                        yz_index_hashtree:insert(sync, IdxN, BKey,
+                                                 ObjHash, Tree, []);
                     delete ->
-                        ok = yz_index_hashtree:delete(IdxN, BKey, Tree)
+                        yz_index_hashtree:delete(sync, IdxN, BKey, Tree)
                 end
         end
     catch _:Reason ->


### PR DESCRIPTION
More changes were made during Riak 1.3 testing which must be ported to Yokozuna.  These are blockers on 0.3.0 release since yokozuna_essential is having AAE related failures.  Not all of these changes necessarily apply to Yokozuna AAE.
- <del>basho/riak_kv#460 (AAE Exchange Bug for N=1)</del>
- <del>basho/riak_kv#472 (Various AAE Changes Prompted by QA)</del>
- <del>basho/riak_kv#473 (Don't Repair Over and Over)</del>
- <del>basho/riak_kv#474 (Fix AAE Rehash When Data is Missing)</del>
