### PR TITLE
Patch Solr Dist Search - No Stale Check or Nagle

### DIFF
--- a/priv/build-jar.sh
+++ b/priv/build-jar.sh
@@ -8,18 +8,22 @@ then
     cd priv
 fi
 
+echo "Build the yokozuna.jar..."
+
 SOLR_JAR_DIR=solr-jars/WEB-INF/lib
 
 if [ ! -e $SOLR_JAR_DIR ]; then
+    echo "Explode the WAR..."
     mkdir solr-jars
     cp solr/webapps/solr.war solr-jars
     pushd solr-jars
-    jar xvf solr.war
+    jar xf solr.war
     popd
 fi
 
+echo "Compile..."
 javac -cp "$SOLR_JAR_DIR/*" java/com/basho/yokozuna/handler/*.java java/com/basho/yokozuna/query/*.java
-jar cvf yokozuna.jar -C java/ .
-
+echo "Create yokozuna.jar..."
 mkdir java_lib
-cp yokozuna.jar java_lib
+jar cvf java_lib/yokozuna.jar -C java/ .
+echo "Finished building yokozuna.jar..."

--- a/priv/logging.properties
+++ b/priv/logging.properties
@@ -1,4 +1,4 @@
-.level = INFO
+.level = WARNING
 
 handlers = java.util.logging.FileHandler
 

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
   {meck, ".*", {git, "git://github.com/eproxus/meck"}}
  ]}.
 
-{pre_hooks, [{compile, "./priv/grab-solr.sh"},
+{pre_hooks, [{compile, "./priv/grab-solr.sh src-tar"},
              {compile, "./priv/build-jar.sh"}]}.
 
 {plugin_dir, ".rebar_plugins"}.

--- a/solr-patches/no-stale-check.patch
+++ b/solr-patches/no-stale-check.patch
@@ -1,0 +1,72 @@
+From 7ea3406740b6829174df3cb50b9cd1b80d61adc5 Mon Sep 17 00:00:00 2001
+From: Ryan Zezeski <rzezeski@gmail.com>
+Date: Tue, 12 Feb 2013 11:54:21 -0500
+Subject: [PATCH] Disable stale check and nagle
+
+* Apache HTTP's stale conn check causes additionall latency and
+  is not recommended for high-throughput/low-latency scenarios.
+
+* Disabling the stale check requires adding a periodic background
+  task which clears idles connections.  This prevents the client
+  from pulling a conn closed by the server which causes an IOException.
+
+* Disable nagle as it's meant for protocols that use many small messages.
+---
+ .../solr/handler/component/HttpShardHandlerFactory.java      |  3 +++
+ .../org/apache/solr/client/solrj/impl/HttpClientUtil.java    | 12 ++++++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+index 27f9f79..2537705 100644
+--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
++++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
+ import java.util.Random;
+ import java.util.concurrent.*;
+ 
++import org.apache.http.params.HttpConnectionParams;
+ import org.apache.http.client.HttpClient;
+ import org.apache.solr.client.solrj.impl.HttpClientUtil;
+ import org.apache.solr.client.solrj.impl.LBHttpSolrServer;
+@@ -132,6 +133,8 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements Plug
+     clientParams.set(HttpClientUtil.PROP_CONNECTION_TIMEOUT, connectionTimeout);
+     clientParams.set(HttpClientUtil.PROP_USE_RETRY, false);
+     this.defaultClient = HttpClientUtil.createClient(clientParams);
++    this.defaultClient.getParams().setParameter(HttpConnectionParams.STALE_CONNECTION_CHECK, false);
++    this.defaultClient.getParams().setParameter(HttpConnectionParams.TCP_NODELAY, true);
+ 
+     try {
+       loadbalancer = new LBHttpSolrServer(defaultClient);
+diff --git a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientUtil.java b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientUtil.java
+index cc78279..c07b03b 100644
+--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientUtil.java
++++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientUtil.java
+@@ -18,6 +18,9 @@ package org.apache.solr.client.solrj.impl;
+ 
+ import java.io.IOException;
+ import java.io.InputStream;
++import java.util.concurrent.Executors;
++import java.util.concurrent.ScheduledExecutorService;
++import java.util.concurrent.TimeUnit;
+ import java.util.zip.GZIPInputStream;
+ import java.util.zip.InflaterInputStream;
+ 
+@@ -102,6 +105,15 @@ public class HttpClientUtil {
+     logger.info("Creating new http client, config:" + config);
+     final ThreadSafeClientConnManager mgr = new ThreadSafeClientConnManager();
+     final DefaultHttpClient httpClient = new DefaultHttpClient(mgr);
++
++    // NOTE: The sweeper task is assuming hard-coded Jetty max-idle of 50s.
++    final Runnable sweeper = new Runnable() {
++            public void run() {
++                mgr.closeIdleConnections(40, TimeUnit.SECONDS);
++            }
++        };
++    final ScheduledExecutorService stp = Executors.newScheduledThreadPool(1);
++    stp.scheduleWithFixedDelay(sweeper, 5, 5, TimeUnit.SECONDS);
+     configureClient(httpClient, config);
+     return httpClient;
+   }
+-- 
+1.8.1
+


### PR DESCRIPTION
A few weeks ago while benchmarking Yokozuna I found that latency was much higher than I would have expected.  After much investigation I discovered that the Apache HTTP Client (which Solr uses for distributed search) stale check is a large contributor.
- Write an HTTP client for dist search up to spec with the HTTP client version being used.  I noticed currently some deprecated calls are being made.
- Disable the stale check.
- Disable nagle.  The packets being sent aren't small so no need to bother with nagle.
- Change yokozuna build to pull Solr 4.0 source and apply patch files.
- Post benchmarks proving improvement.
- Once settled, send patch to Solr mailing list and jira.
