### PR TITLE
Use `env` to find bash so tests & build can run on *BSD

### DIFF
--- a/priv/build-jar.sh
+++ b/priv/build-jar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Temporary script to build JAR file containing customer Solr request
 # handlers.

--- a/priv/grab-solr.sh
+++ b/priv/grab-solr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to grab Solr and embed in priv dir.
 #

--- a/tools/build-ami.sh
+++ b/tools/build-ami.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # The main script for building a custom AMI.  The actual customization
 # and AMI bundle creation is performed in a second script which is

--- a/tools/src-pkg.sh
+++ b/tools/src-pkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build a source package of Yokozuna.
 #
@@ -44,6 +44,3 @@ popd
 rm -f $TGZ
 tar -zcvf $TGZ $RIAK_DIR
 popd
-
-
-

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that Yokozuna...
 #

--- a/tools/yokozuna-ami.sh
+++ b/tools/yokozuna-ami.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds a Riak/Yokozuna AMI by running on an existing
 # instance created by build-ami.sh.  All actions should be idempotent


### PR DESCRIPTION
Simply converted fixed paths on the shebang line from
'/bin/bash' to '/usr/bin/env bash'.  `yokozuna-ami.sh`
also needed a +x flag that was not already set.

Some of the bash scripts can easily be converted to pure
/bin/sh implementations, but it is probably not needed
due to them being build or test related rather than
used in runtime or operations.

Addresses #74
