### PR TITLE
Add JVM args setting via app.config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/20*
 tests/current
 .eunit
 log
+bb-*-fruit*

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -112,6 +112,7 @@
 -define(YZ_DEFAULT_SOLR_PORT, "8983").
 -define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 15).
 -define(YZ_DEFAULT_TICK_INTERVAL, 60000).
+-define(YZ_DEFAULT_SOLR_VM_ARGS, ["-XX:+UseStringCache","-XX:+UseCompressedStrings","-XX:+UseCompressedOops","-Xms1g","-Xmx1g"]).
 -define(YZ_EVENTS_TAB, yz_events_tab).
 -define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir, "data/yz")).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -126,7 +126,7 @@ build_cmd(SolrPort, SolrJMXPort, Dir) ->
             JMX = [JMXPortArg, JMXAuthArg, JMXSSLArg]
     end,
 
-    Args = [JettyHome, Port, SolrHome, Logging, LibDir, Jar, JarName] ++ JMX,
+    Args = [JettyHome, Port, SolrHome, Logging, LibDir, Jar, JarName] ++ solr_vm_args() ++ JMX,
     {os:find_executable("java"), Args}.
 
 -spec get_pid(port()) -> pos_integer().
@@ -148,6 +148,11 @@ solr_startup_wait() ->
     app_helper:get_env(?YZ_APP_NAME,
                        solr_startup_wait,
                        ?YZ_DEFAULT_SOLR_STARTUP_WAIT).
+
+solr_vm_args() ->
+    app_helper:get_env(?YZ_APP_NAME,
+                       solr_vm_args,
+                       ?YZ_DEFAULT_SOLR_VM_ARGS).
 
 wait_for_solr(0) ->
     throw({error, "Solr didn't start in alloted time"});


### PR DESCRIPTION
We can have reasonable defaults, however, different versions/implementations of the JVM can be optimized with different settings and args. For example:

``` erlang
{yokozuna, [
            {solr_vm_args, ["-server", "-XX:+UseStringCache"]},
]}
```

would append the string to the end of the `java` command which launches solr.
