### PR TITLE
Add Kill Switch

### DIFF
--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -46,3 +46,22 @@ search(Index, Query, Mapping) ->
 
 solr_port(Node, Ports) ->
     proplists:get_value(Node, Ports).
+
+
+%% @doc get an associated flag, true if some action
+%%      (eg indexing, searching) should be supressed
+-spec noop_flag(atom()) -> binary() | undefined.
+noop_flag(index) ->
+    app_helper:get_env(?YZ_APP_NAME, index_noop, false);
+noop_flag(search) ->
+    app_helper:get_env(?YZ_APP_NAME, search_noop, false).
+
+%% @doc set an associated flag, true if some action
+%%      (eg indexing, searching) should be supressed
+-spec noop_flag(atom(), boolean()) -> binary() | undefined.
+noop_flag(index, Switch) ->
+    ?INFO("Indexing Objects in yokozuna has been changed to ~s", [Switch]),
+    application:set_env(?YZ_APP_NAME, index_noop, true);
+noop_flag(search, Switch) ->
+    ?INFO("Ability to search yokozuna has been changed to ~s", [Switch]),
+    application:set_env(?YZ_APP_NAME, search_noop, true).

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -48,6 +48,13 @@ content_types_provided(Req, S) ->
     Types = [{"text/xml", search}],
     {Types, Req, S}.
 
+%% if search_noop is true, then search service is unavailable
+service_available(_Req, _S) ->
+    case yokozuna:noop_flag(search) of
+        true -> false;
+        _    -> true
+    end.
+
 %% Treat POST as GET in order to work with existing Solr clients.
 process_post(Req, S) ->
     case search(Req, S) of

--- a/test/yz_noop_tests.erl
+++ b/test/yz_noop_tests.erl
@@ -1,0 +1,13 @@
+-module(yz_noop_tests).
+-compile(export_all).
+
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+index_noop_test()->
+  yokozuna:noop_flag(index, true),
+  ?assertEqual(yz_kv:index({},delete,{}), ok).
+
+search_noop_test()->
+  yokozuna:noop_flag(search, true),
+  ?assertEqual(yz_wm_search:service_available({},{}), false).


### PR DESCRIPTION
There may be cases where the user wants to temporarily disable any further indexing of objects.
- Heavy cluster load.
- Hunting down performance issues in production.
- Solr issues causing indexing to fail.
- Etc.

This **SHOULD NOT** be implemented by setting `yz_index_content` to `false`.  This will still index objects and cause the AAE trees to be cleared.

I think two potential implementations are:
1. Hot-swap `yz_kv:index` function to be a no-op.
2. Use a flag stored in process dict and check it each time.

I like the first option a little more because a) doesn't rely on fact that indexing is done on KV vnode and thus there are long-lived process dict entries and b) premature optimization says this method is less overhead.
