### PR TITLE
AAE Config

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -136,7 +136,32 @@
 -define(YZ_AE_DIR,
         application:get_env(?YZ_APP_NAME, anti_entropy_data_dir)).
 -define(YZ_ENTROPY_TICK,
-        app_helper:get_env(?YZ_APP_NAME, entropy_tick, 60000)).
+        app_helper:get_env(?YZ_APP_NAME, entropy_tick,
+            app_helper:get_env(riak_kv, anti_entropy_tick, 60000)
+        )).
+%% Time from build to expiration of tree, in microseconds.
+%% Defaults to 1 week.
+-define(YZ_ENTROPY_EXPIRE,
+        app_helper:get_env(?YZ_APP_NAME, anti_entropy_expire,
+            app_helper:get_env(riak_kv, anti_entropy_expire, 604800000)
+        )).
+%% Per state transition timeout used by certain transitions
+%% Defaults to 5 minutes
+-define(YZ_ENTROPY_TIMEOUT,
+        app_helper:get_env(?YZ_APP_NAME, anti_entropy_timeout,
+            app_helper:get_env(riak_kv, anti_entropy_timeout, 300000)
+        )).
+%% Defines the max number of concurrent AAE tree exchanges
+%% Defaults to 2
+-define(YZ_ENTROPY_CONCURRENCY,
+        app_helper:get_env(?YZ_APP_NAME, anti_entropy_concurrency,
+            app_helper:get_env(riak_kv, anti_entropy_concurrency, 2)
+        )).
+%% Defaults to once per hour
+-define(YZ_ENTROPY_BUILD_LIMIT,
+        app_helper:get_env(?YZ_APP_NAME, anti_entropy_build_limit,
+            app_helper:get_env(riak_kv, anti_entropy_build_limit, {1, 3600000})
+        )).
 
 -type hashtree() :: hashtree:hashtree().
 -type exchange() :: {p(), {p(), n()}}.

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -34,9 +34,6 @@
                 built :: integer(),
                 timeout :: pos_integer()}).
 
-%% Per state transition timeout used by certain transitions
--define(DEFAULT_ACTION_TIMEOUT, 300000). %% 5 minutes
-
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -53,10 +50,6 @@ start(Index, Preflist, YZTree, KVTree, Manager) ->
 %%%===================================================================
 
 init([Index, Preflist, YZTree, KVTree, Manager]) ->
-    Timeout = app_helper:get_env(riak_kv,
-                                 anti_entropy_timeout,
-                                 ?DEFAULT_ACTION_TIMEOUT),
-
     monitor(process, Manager),
     monitor(process, YZTree),
     monitor(process, KVTree),
@@ -66,7 +59,7 @@ init([Index, Preflist, YZTree, KVTree, Manager]) ->
                yz_tree=YZTree,
                kv_tree=KVTree,
                built=0,
-               timeout=Timeout},
+               timeout=?YZ_ENTROPY_TIMEOUT},
     gen_fsm:send_event(self(), start_exchange),
     lager:debug("Starting exchange between KV and Yokozuna: ~p", [Index]),
     {ok, prepare_exchange, S}.

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -36,9 +36,6 @@
 
 -compile(export_all).
 
-%% Time from build to expiration of tree, in microseconds.
--define(DEFAULT_EXPIRE, 604800000). %% 1 week
-
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -462,10 +459,7 @@ do_poke(S) ->
 
 maybe_clear(S=#state{lock=undefined, built=true}) ->
     Diff = timer:now_diff(os:timestamp(), S#state.build_time),
-    Expire = app_helper:get_env(riak_kv,
-                                anti_entropy_expire,
-                                ?DEFAULT_EXPIRE),
-    case Diff > (Expire * 1000)  of
+    case Diff > (?YZ_ENTROPY_EXPIRE * 1000)  of
         true -> clear_tree(S);
         false -> S
     end;

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -49,11 +49,12 @@ content_types_provided(Req, S) ->
     {Types, Req, S}.
 
 %% if search_noop is true, then search service is unavailable
-service_available(_Req, _S) ->
-    case yokozuna:noop_flag(search) of
+service_available(Req, S) ->
+    Available = case yokozuna:noop_flag(search) of
         true -> false;
         _    -> true
-    end.
+    end,
+    {Available, Req, S}.
 
 %% Treat POST as GET in order to work with existing Solr clients.
 process_post(Req, S) ->

--- a/test/yz_noop_tests.erl
+++ b/test/yz_noop_tests.erl
@@ -10,4 +10,5 @@ index_noop_test()->
 
 search_noop_test()->
   yokozuna:noop_flag(search, true),
-  ?assertEqual(yz_wm_search:service_available({},{}), false).
+  {Available, _, _} = yz_wm_search:service_available({},{}),
+  ?assertEqual(Available, false).


### PR DESCRIPTION
Currently Yokozuna takes on the same config values as KV for much of AAE.  Instead, first check for a Yokozuna specific config.  If that doesn't exist then fallback to KV config.
- [x] exchange tick
- [x] expire
- [x] concurrency
