### PR TITLE
Cleanup old rzezeski references in docs

### DIFF
--- a/docs/EC2.md
+++ b/docs/EC2.md
@@ -98,8 +98,8 @@ the [commit log] [yz_commit_log].
 
 [five_nodes]: http://basho.com/blog/technical/2012/04/27/Why-Your-Riak-Cluster-Should-Have-At-Least-Five-Nodes/
 
-[gs]: https://github.com/rzezeski/yokozuna#creating-an-index
+[gs]: https://github.com/basho/yokozuna#creating-an-index
 
 [perf_aws]: http://docs.basho.com/riak/latest/cookbooks/Performance-Tuning-AWS/
 
-[yz_commit_log]: https://github.com/rzezeski/yokozuna/commits/master
+[yz_commit_log]: https://github.com/basho/yokozuna/commits/master


### PR DESCRIPTION
There were a couple links to the rzezeski/yokozuna repository in the EC2 documentation. They now point to basho/yokozuna
