### PR TITLE
protect against bad schemas

### DIFF
--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -85,11 +85,25 @@ handle_cast({ring_event, Ring}=RE, S) ->
     {noreply, S2}.
 
 handle_info(tick, S) ->
+    %% TODO: tick and ring_event should be merged, actions taken in
+    %% ring_event could fail and should be retried during tick, may
+    %% need to rely on something other than ring to determine when to
+    %% retry certain actions, e.g. if the `sync_data' call fails then
+    %% AAE trees will be incorrect until the next ring_event or until
+    %% tree rebuild
     ok = remove_non_owned_data(),
 
     Mapping = get_mapping(),
     Mapping2 = check_unkown(Mapping),
     ok = set_mapping(Mapping2),
+
+    %% Index creation may have failed during ring event.
+    PrevRing = ?PREV_RING(S),
+    Ring = yz_misc:get_ring(raw),
+    Previous = names(yz_index:get_indexes_from_ring(PrevRing)),
+    Current = names(yz_index:get_indexes_from_ring(Ring)),
+    {Removed, Added, Same} = yz_misc:delta(Previous, Current),
+    ok = sync_indexes(Ring, Removed, Added, Same),
 
     ok = set_tick(),
     {noreply, S}.
@@ -229,7 +243,9 @@ remove_nodes(Nodes, Mapping) ->
 %% @doc Remove documents for any data not owned by this node.
 -spec remove_non_owned_data() -> ok.
 remove_non_owned_data() ->
-    Indexes = ordsets:to_list(yz_solr:cores()),
+    %% TODO: yz_solr:cores() could return {error, T}
+    {ok, Cores} = yz_solr:cores(),
+    Indexes = ordsets:to_list(Cores),
     Removed = [{Index, yz_index:remove_non_owned_data(Index)}
                || Index <- Indexes],
     [maybe_log(R) || R <- Removed],

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -243,12 +243,15 @@ remove_nodes(Nodes, Mapping) ->
 %% @doc Remove documents for any data not owned by this node.
 -spec remove_non_owned_data() -> ok.
 remove_non_owned_data() ->
-    %% TODO: yz_solr:cores() could return {error, T}
-    {ok, Cores} = yz_solr:cores(),
-    Indexes = ordsets:to_list(Cores),
-    Removed = [{Index, yz_index:remove_non_owned_data(Index)}
-               || Index <- Indexes],
-    [maybe_log(R) || R <- Removed],
+    case yz_solr:cores() of
+        {ok, Cores} ->
+            Indexes = ordsets:to_list(Cores),
+            Removed = [{Index, yz_index:remove_non_owned_data(Index)}
+                       || Index <- Indexes],
+            [maybe_log(R) || R <- Removed];
+        _ ->
+            ok
+    end,
     ok.
 
 send_ring_event(Ring) ->

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -59,7 +59,7 @@ commit(Core) ->
     end.
 
 %% @doc Perform Core related actions.
--spec core(atom(), proplists:proplist()) -> {ok, any(), any()}.
+-spec core(atom(), proplists:proplist()) -> {ok, any(), any()} | {error, term()}.
 core(Action, Props) ->
     BaseURL = base_url() ++ "/admin/cores",
     Action2 = convert_action(Action),
@@ -73,14 +73,20 @@ core(Action, Props) ->
         {ok, "200", Headers, Body} ->
             {ok, Headers, Body};
         X ->
-            throw({error_calling_solr, core, Action, X})
+            {error, X}
     end.
 
--spec cores() -> ordset(index_name()).
+-spec cores() -> {ok, ordset(index_name())} | {error, term()}.
 cores() ->
-    {ok, _, Body} = yz_solr:core(status, [{wt,json}]),
-    Status = yz_solr:get_path(mochijson2:decode(Body), [<<"status">>]),
-    ordsets:from_list([binary_to_list(Name) || {Name, _} <- Status]).
+    case yz_solr:core(status, [{wt,json}]) of
+        {ok, _, Body} ->
+            Status = yz_solr:get_path(mochijson2:decode(Body), [<<"status">>]),
+            Cores = ordsets:from_list([binary_to_list(Name)
+                                       || {Name, _} <- Status]),
+            {ok, Cores};
+        {error,_} = Err ->
+            Err
+    end.
 
 -spec delete(string(), string()) -> ok.
 delete(Core, DocID) ->

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -88,7 +88,7 @@ cores() ->
             Err
     end.
 
--spec delete(string(), string()) -> ok.
+-spec delete(string(), binary()) -> ok.
 delete(Core, DocID) ->
     BaseURL = base_url() ++ "/" ++ Core ++ "/update",
     JSON = encode_delete({id, DocID}),

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -133,12 +133,14 @@ build_cmd(SolrPort, SolrJMXPort, Dir) ->
 get_pid(Port) ->
     proplists:get_value(os_pid, erlang:port_info(Port)).
 
+%% @private
+%%
+%% @doc Determine if Solr is running.
+-spec is_up() -> boolean().
 is_up() ->
-    try
-        _ = yz_solr:cores(),
-        true
-    catch throw:{error_calling_solr,core,_,_} ->
-            false
+    case yz_solr:cores() of
+        {ok, _} -> true;
+        _ -> false
     end.
 
 run_cmd(Cmd, Args) ->

--- a/test/yz_misc_tests.erl
+++ b/test/yz_misc_tests.erl
@@ -46,8 +46,6 @@ should_copy_update_test() ->
         ok = file:write_file(Newfile, "data"),
         ?assert(yz_misc:should_copy(update, Newfile, Thisfile)),
         ?assertNot(yz_misc:should_copy(update, Thisfile, Newfile))
-    catch _:_Err ->
-        ?assert(false)
     after
         file:delete(Newfile)
     end.


### PR DESCRIPTION
This addresses part 3 of #58.
- Avoid crashing `yz_events` server during index creation.
- Make best effort to create index, log on error and retry periodically.
- Add test to verify bad schema can be uploaded and corrected without bringing the cluster down.
- Remove catch from unit test to avoid masking failure.
- Fix spec.
- Handle error from `yz_solr:cores` during tick event.
