### PR TITLE
Remove 32-bit libc from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,5 @@ notifications:
   email: eng@basho.com
 before_script:
   - "ulimit -n 4096"
-before_install:
-  - sudo apt-get install -qq libc6-dev-i386
 otp_release:
   - R15B02


### PR DESCRIPTION
With rebar upgraded the proper arch flags are now be passed to
erlang_js and 32bit libc is not needed.
