### PR TITLE
Don't pass any JVM args as default

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -112,7 +112,7 @@
 -define(YZ_DEFAULT_SOLR_PORT, "8983").
 -define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 15).
 -define(YZ_DEFAULT_TICK_INTERVAL, 60000).
--define(YZ_DEFAULT_SOLR_VM_ARGS, ["-XX:+UseStringCache","-XX:+UseCompressedStrings","-XX:+UseCompressedOops","-Xms1g","-Xmx1g"]).
+-define(YZ_DEFAULT_SOLR_VM_ARGS, []).
 -define(YZ_EVENTS_TAB, yz_events_tab).
 -define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir, "data/yz")).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).


### PR DESCRIPTION
If a user doesn't specify solr jvm args in app.config then the default
should be to pass no args.  I think this is the least surprising
behavior to have.  We can still ship pre-canned defaults in the
app.config such as larger heap but the fallback defaults should be
none.
