### PR TITLE
yz_wm_extract making bad call to yz_extractor:is_registered

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -106,6 +106,7 @@
 -define(INT_TO_STR(I), integer_to_list(I)).
 -define(PARTITION_BINARY(S), S#state.partition_binary).
 -define(HEAD_CTYPE, "content-type").
+-define(YZ_HEAD_EXTRACTOR, "yz-extractor").
 
 -define(DATA_DIR, application:get_env(riak_core, platform_data_dir)).
 

--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -1,0 +1,50 @@
+%% @doc Test the index schema API in various ways.
+-module(yz_wm_extract_test).
+-compile(export_all).
+-import(yz_rt, [host_entries/1, select_random/1]).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+
+confirm() ->
+    Cluster = prepare_cluster(4),
+    confirm_check_if_registered_set_ct(Cluster),
+    pass.
+
+%% @doc Confirm yz-extractor header works as a string in
+%%      yz_wm_extract:check_if_registered_set_ct/4
+confirm_check_if_registered_set_ct(Cluster) ->
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    lager:info("confirm_check_if_registered_set_ct [~p]", [HP]),
+    URL = extract_url(HP),
+    Headers = [{?YZ_HEAD_EXTRACTOR,"yz_json_extractor"}],
+    {ok, Status, _, _} = http(put, URL, Headers, "{\"name\":\"ryan\"}"),
+    ?assertEqual("200", Status).
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+http(Method, URL, Headers, Body) ->
+    Opts = [{response_format, binary}],
+    ibrowse:send_req(URL, Headers, Method, Body, Opts).
+
+extract_url({Host,Port}) ->
+    ?FMT("http://~s:~B/extract", [Host, Port]).
+
+join(Nodes) ->
+    [NodeA|Others] = Nodes,
+    [rt:join(Node, NodeA) || Node <- Others],
+    Nodes.
+
+prepare_cluster(NumNodes) ->
+    %% Note: may need to use below call b/c of diff between
+    %% deploy_nodes/1 & /2
+    %%
+    %% Nodes = rt:deploy_nodes(NumNodes, ?CFG),
+    Nodes = rt:deploy_nodes(NumNodes),
+    Cluster = join(Nodes),
+    yz_rt:wait_for_joins(Cluster),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+    Cluster.

--- a/src/yz_wm_extract.erl
+++ b/src/yz_wm_extract.erl
@@ -27,7 +27,6 @@
           content :: binary(),
           extractor_name :: extractor_name()
          }).
--define(YZ_HEAD_EXTRACTOR, "yz-extractor").
 
 routes() ->
     [{["extract"], yz_wm_extract, []}].
@@ -40,7 +39,7 @@ allowed_methods(RD, S) ->
     {Methods, RD, S}.
 
 malformed_request(RD, S) ->
-    E = wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD),
+    E = list_to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
     CT = wrq:get_req_header(?HEAD_CTYPE, RD),
     Content = wrq:req_body(RD),
 
@@ -61,7 +60,7 @@ malformed_request(RD, S) ->
 %% Accept the mime-type provided by user, if one is not provided use
 %% extractor specified in header.
 content_types_accepted(RD, S) ->
-    E = wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD),
+    E = list_to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
     CT = wrq:get_req_header(?HEAD_CTYPE, RD),
 
     case {E, CT} of


### PR DESCRIPTION
The extractor name passed to `yz_wm_extract:check_if_registered_set_ct` is a string but `yz_extractor:is_registered` wants an atom.
