### PR TITLE
Add catch-all field to default schema

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -105,6 +105,9 @@
    <dynamicField name="*_ig" type="ignored" multiValued="true"/>
    <dynamicField name="random_*" type="random" />
 
+   <!-- catch-all field -->
+   <dynamicField name="*" type="text_general" indexed="true" stored="false" multiValued="true" />
+
    <field name="_yz_id" type="_yz_str" indexed="true" stored="true" required="true"/>
 
    <!-- Entropy Data: Data related to anti-entropy -->


### PR DESCRIPTION
- Should be indexed so it can be searched on.
- Shouldn't be stored as value could be large.
- Should be multi-valued because the field could repeat.  This means
  sorting on these fields will not be possible.
- Should be treated as unstructured text and thus use an analyzed
  field type such as `text_general`.  Using `string` would store it
  as-is and thus reduce effectiveness of searching.

The upshot of all the points above is that the default schema will be able to
handle unknown fields but only basic searches will work against those fields.
 Things like sorting, faceting and highlighting on catch-all fields won't
work.
