### PR TITLE
Create a Schema which indexes every value by default

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -105,6 +105,9 @@
    <dynamicField name="*_ig" type="ignored" multiValued="true"/>
    <dynamicField name="random_*" type="random" />
 
+   <!-- catch-all field -->
+   <dynamicField name="*" type="text_general" indexed="true" stored="false" multiValued="true" />
+
    <field name="_yz_id" type="_yz_str" indexed="true" stored="true" required="true"/>
 
    <!-- Entropy Data: Data related to anti-entropy -->


### PR DESCRIPTION
I've run into a few people who want all of the default yz index behavior, with a fallback where any field that doesn't match a dynamicField name is just indexed as a string. This could be done with the addition of a new schema that appends `<dynamicField name="*" type="string"...>`, and named perhaps `_yz_universal`.
