### PR TITLE
cleanup index on delete

### DIFF
--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -220,7 +220,7 @@ node_ops(Mapping, Nodes) ->
 
 -spec remove_index(index_name()) -> ok.
 remove_index(Name) ->
-    case yz_index:exists(Name) of
+    case yz_solr:ping(Name) of
         true -> ok = yz_index:local_remove(Name);
         false -> ok
     end.


### PR DESCRIPTION
When an index is deleted in Yokozuna its instance dir containing
configuration and actual index files should be deleted.  The
first step of deletion is to remove the index from the list of
indexes in the ring.  This is done on the node the receives the
delete request.  This removal from the ring is then propagated to
the other nodes via gossip.  As nodes notice index removal events
in `yz_events` a `local_remove` function is called that is
responsible for sending the delete request to the local Solr
instance.  But first it checks if the index exists.  If it goes
it simply does nothing.

The issue is that `yz_index:exists` returns true if and only if
the index is both a) in the ring and b) pingable from Solr.  The
problem is the index was already removed from the ring by the
time `local_remove` is called and thus `exists` will always
return false and the actual Solr Core will never be deleted.

This patch changes `local_remove` to only consider if the Solr
Core is still pingable.

Thanks to @neuhausler for discovering and reporting this bug.
