### PR TITLE
Various additions to bench driver + fprof header for search

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -100,6 +100,10 @@
 %%% Macros
 %%%===================================================================
 
+-define(IF(Expression, Action),
+        if Expression -> Action, ok;
+           true -> ok
+        end).
 -define(ATOM_TO_BIN(A), list_to_binary(atom_to_list(A))).
 -define(BIN_TO_INT(B), list_to_integer(binary_to_list(B))).
 -define(INT_TO_BIN(I), list_to_binary(integer_to_list(I))).

--- a/misc/bench/src/yz_driver.erl
+++ b/misc/bench/src/yz_driver.erl
@@ -155,10 +155,10 @@ valgen_i(search) ->
     yz_file_terms:get_ft().
 
 mfa_valgen(Id, LoadMFA, ReadMFA) ->
-    N = basho_bench_config:get(concurrent),
-    if Id == N ->
+    if Id == 1 ->
             {ok, _} = yz_file_terms:start_mfa(LoadMFA, ReadMFA);
-       true -> ok
+       true ->
+            ok
     end,
     fun ?MODULE:mfa_valgen_i/1.
 


### PR DESCRIPTION
Made various changes to help facilitate benchmarking and performance hunting.
- Added a `yz-fprof: <filename>` header to the search resource.  If this header is present the search request will be traced with fprof and the file `<filename>.analysis` will be written to that nodes CWD.
- Added a random fruit search operation to the bench driver.  This allows to run random conjunection queries against fruit data-load.  The max number of terms and max cardinality of a term can be bound.  A field list `FL` may also be passed.

``` erlang
{random_fruit_search, FL, MaxTerms, MaxCardinality}
```
- Fixed some bugs with the mfa/cache server (the poorly named `yz_file_terms`).  I'm going to be using this server more to benchmark Yokozuna against real data.
