### PR TITLE
Add Protobuf support to Yokozuna

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -133,6 +133,8 @@
         "Not enough nodes are up to service this request.").
 -define(YZ_ERR_INDEX_NOT_FOUND,
         "No index ~p found.").
+-define(YZ_ERR_QUERY_FAILURE,
+        "Query unsuccessful check the logs.").
 
 %%%===================================================================
 %%% Anti Entropy

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -38,15 +38,6 @@ wait_for_joins(Cluster) ->
     rt:wait_until_nodes_ready(Cluster),
     rt:wait_until_no_pending_changes(Cluster).
 
-%% @doc Confirm a custom schema may be added.
-confirm_create_schema(Cluster, Name, RawSchema) ->
-    HP = select_random(host_entries(rt:connection_info(Cluster))),
-    lager:info("confirm_create_schema ~s [~p]", [Name, HP]),
-    URL = schema_url(HP, Name),
-    Headers = [{"content-type", "application/xml"}],
-    {ok, Status, _, _} = http(put, URL, Headers, RawSchema),
-    ?assertEqual("204", Status).
-
 select_random(List) ->
     Length = length(List),
     Idx = random:uniform(Length),

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -82,8 +82,11 @@ store_and_search(Cluster, Bucket, Key, Body, Search, Params) ->
     lager:info("search_results"),
     {ok,{search_results,[{Bucket,Results}],Score,Found}} =
             riakc_pb_socket:search(Pid, Bucket, Search, Params),
-    Bucket == binary_to_list(proplists:get_value(<<"_yz_rk">>, Results)),
-    Found == 1,
+    ?assertEqual(
+        Key,
+        binary_to_list(proplists:get_value(<<"_yz_rk">>, Results))),
+    ?assertEqual(Found, 1),
+    ?assertNot(Score == 0.0),
     ok.
 
 confirm_basic_search(Cluster) ->

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -1,0 +1,114 @@
+%% Running this test requires the `riak-erlang-client' project
+%% in the yokozuna/deps directory.
+
+%% @doc Test the index adminstration API in various ways.
+-module(yz_pb).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+-define(NO_HEADERS, []).
+-define(NO_BODY, <<>>).
+
+confirm() ->
+    case riak_client_exists() of
+        true ->
+            YZBenchDir = rt:get_os_env("YZ_BENCH_DIR"),
+            code:add_path(filename:join([YZBenchDir, "ebin"])),
+            random:seed(now()),
+            Cluster = prepare_cluster(4),
+            confirm_basic_search(Cluster),
+            confirm_encoded_search(Cluster),
+            pass;
+        _ ->
+            pass
+    end.
+
+
+prepare_cluster(NumNodes) ->
+    %% Note: may need to use below call b/c of diff between
+    %% deploy_nodes/1 & /2
+    %%
+    % Nodes = rt:deploy_nodes(NumNodes, ?CFG),
+    Nodes = rt:deploy_nodes(NumNodes),
+    Cluster = join(Nodes),
+    wait_for_joins(Cluster),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+    Cluster.
+
+join(Nodes) ->
+    [NodeA|Others] = Nodes,
+    [rt:join(Node, NodeA) || Node <- Others],
+    Nodes.
+
+%% TODO: replace with rt:wait_for_joins
+wait_for_joins(Cluster) ->
+    lager:info("Waiting for ownership handoff to finish"),
+    rt:wait_until_nodes_ready(Cluster),
+    rt:wait_until_no_pending_changes(Cluster).
+
+select_random(List) ->
+    Length = length(List),
+    Idx = random:uniform(Length),
+    lists:nth(Idx, List).
+
+host_entries(ClusterConnInfo) ->
+    [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
+
+schema_url({Host,Port}, Name) ->
+    ?FMT("http://~s:~B/yz/schema/~s", [Host, Port, Name]).
+
+index_url({Host,Port}, Index) ->
+    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+
+bucket_url({Host,Port}, Bucket, Key) ->
+    ?FMT("http://~s:~B/riak/~s/~s", [Host, Port, Bucket, Key]).
+
+http(Method, URL, Headers, Body) ->
+    Opts = [],
+    ibrowse:send_req(URL, Headers, Method, Body, Opts).
+
+create_index(HP, Index) ->
+    lager:info("create_index ~s [~p]", [Index, HP]),
+    URL = index_url(HP, Index),
+    Headers = [{"content-type", "application/json"}],
+    {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
+    timer:sleep(4000),
+    ?assertEqual("204", Status).
+
+store_and_search(Cluster, Bucket, Body, Search) ->
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    create_index(HP, Bucket),
+    URL = bucket_url(HP, Bucket, "test"),
+    lager:info("Storing to bucket ~s", [URL]),
+    {Host, Port} = HP,
+    %% populate a value
+    {ok, "204", _, _} = ibrowse:send_req(URL, [{"Content-Type", "text/plain"}], put, Body),
+    %% Sleep for soft commit
+    timer:sleep(1100),
+    {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
+    lager:info("search_results"),
+    {ok,{search_results,[{Bucket,Results}],Score,Found}} =
+            riakc_pb_socket:search(Pid, Bucket, Search),
+    Bucket == binary_to_list(proplists:get_value(<<"_yz_rk">>, Results)),
+    Found == 1,
+    ok.
+
+confirm_basic_search(Cluster) ->
+    Bucket = "basic",
+    lager:info("confirm_basic_search ~s", [Bucket]),
+    Body = "herp derp",
+    store_and_search(Cluster, Bucket, Body, <<"text:herp">>).
+
+confirm_encoded_search(Cluster) ->
+    Bucket = "encoded",
+    lager:info("confirm_encoded_search ~s", [Bucket]),
+    Body = "א בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ",
+    store_and_search(Cluster, Bucket, Body, <<"text:בָּרָא">>).
+
+riak_client_exists() ->
+    try riakc_pb_socket:module_info() of
+        _InfoList -> true
+    catch
+        _:_       -> false
+    end.

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -24,6 +24,9 @@
 -compile(export_all).
 -include("yokozuna.hrl").
 
+%% 27 is message type rpbsearchqueryreq
+%% 28 is message type rpbsearchqueryresp
+-define(SERVICES, [{yz_pb_search, 27, 28}]).
 
 %%%===================================================================
 %%% Callbacks
@@ -35,6 +38,7 @@ start(_StartType, _StartArgs) ->
         {ok, Pid} ->
             Routes = yz_wm_search:routes() ++ yz_wm_extract:routes() ++ yz_wm_index:routes() ++ yz_wm_schema:routes(),
             yz_misc:add_routes(Routes),
+            ok = riak_api_pb_service:register(?SERVICES),
             riak_core_node_watcher:service_up(yokozuna, Pid),
             {ok, Pid};
         Error ->
@@ -42,4 +46,5 @@ start(_StartType, _StartArgs) ->
     end.
 
 stop(_State) ->
+    ok = riak_api_pb_service:deregister(?SERVICES),
     ok.

--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -1,0 +1,127 @@
+%% -------------------------------------------------------------------
+%%
+%% yz_pb_search: PB Service for Yokozuna queries
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Implements a `riak_api_pb_service' for performing search
+%% queries in Yokozuna.
+-module(yz_pb_search).
+
+-include_lib("riak_pb/include/riak_search_pb.hrl").
+-include("yokozuna.hrl").
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+-import(riak_pb_search_codec, [encode_search_doc/1]).
+
+-record(state, {client}).
+
+%% @doc init/0 callback. Returns the service internal start state.
+-spec init() -> any().
+init() ->
+    {ok, C} = riak_search:local_client(),
+    #state{client=C}.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) ->
+    {ok, riak_pb_codec:decode(Code, Bin)}.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% @doc process/2 callback. Handles an incoming request message.
+process(Msg, #state{client=_Client}=State) ->
+    #rpbsearchqueryreq{index=IndexBin, sort=_Sort0,
+                       fl=_FL0, presort=_Presort0}=Msg,
+    case extract_params(Msg) of
+        {ok, Params} ->
+            Mapping = yz_events:get_mapping(),
+            Index = binary_to_list(IndexBin),
+            try
+                {_Headers, Body} = yz_solr:dist_search(Index,
+                                                       [{content_type, "application/json"}],
+                                                       Params,
+                                                       Mapping),
+                R = mochijson2:decode(Body),
+                Resp = yz_solr:get_response(R),
+                Pairs = yz_solr:get_doc_pairs(Resp),
+                MaxScore = yz_solr:json_get_key(<<"maxScore">>, Resp),
+                NumFound = yz_solr:json_get_key(<<"numFound">>, Resp),
+
+                RPBResp = #rpbsearchqueryresp{
+                    docs = [encode_doc(Doc) || Doc <- Pairs],
+                    max_score = MaxScore,
+                    num_found = NumFound
+                },
+                {reply, RPBResp, State}
+            catch
+                throw:not_found ->
+                    ErrMsg = io_lib:format(?YZ_ERR_INDEX_NOT_FOUND, [Index]),
+                    {error, ErrMsg, State};
+                throw:insufficient_vnodes_available ->
+                    {error, ?YZ_ERR_NOT_ENOUGH_NODES, State}
+            end;
+        {error, missing_query} ->
+            {error, "Missing query", State}
+    end.
+
+%% @doc process_stream/3 callback. Ignored.
+process_stream(_,_,State) ->
+    {ignore, State}.
+
+%% ---------------------------------
+%% Internal functions
+%% ---------------------------------
+
+extract_params(#rpbsearchqueryreq{q = <<>>}) ->
+    {error, missing_query};
+extract_params(#rpbsearchqueryreq{q=Query,
+                                rows=Rows, start=Start,
+                                filter=Filter,
+                                df=DefaultField, op=_DefaultOp}) ->
+    {ok, [{q, Query},
+          {wt, "json"},
+          {omitHeader, true},
+          {fq, default(Filter, "")},
+          {fl, <<"*,score">>},
+          {df, default(DefaultField, "")},
+          {start, default(Start, 0)},
+          {rows, default(Rows, 10)}]}.
+
+default(undefined, Default) ->
+    Default;
+default(Value, _) ->
+    Value.
+
+encode_doc(Doc) ->
+    riak_pb_search_codec:encode_search_doc([{Prop, to_binary(Value)} || {Prop, Value} <- Doc]).
+
+to_binary(A) when is_atom(A) -> to_binary(atom_to_list(A));
+to_binary(B) when is_binary(B) -> B;
+to_binary(I) when is_integer(I) -> to_binary(integer_to_list(I));
+to_binary(F) when is_float(F) -> to_binary(float_to_list(F));
+to_binary(L) when is_list(L) -> list_to_binary(L).

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -316,6 +316,13 @@ get_pairs(R) ->
 to_pair({struct, [{_,Bucket},{_,Key},{_,Base64Hash}]}) ->
     {{Bucket,Key}, base64:decode(Base64Hash)}.
 
+get_doc_pairs(Resp) ->
+    Docs = json_get_key(<<"docs">>, Resp),
+    [to_doc_pairs(DocStruct) || DocStruct <- Docs].
+
+to_doc_pairs({struct, Values}) ->
+    Values.
+
 get_path({struct, PL}, Path) ->
     get_path(PL, Path);
 get_path(PL, [Name]) ->


### PR DESCRIPTION
Protocol buffers are a lower bandwidth alternative to the HTTP interface, and would be nice to implement any future clients (#37) against.

Currently this issue's aim is to match the functionality of RiakSearch. RS only supports a limited number of query params via PB, so this will mainly be of interest for existing RS users wishing to transition to Yokozuna. Also, RS only supports querying, and does not have PB support for creating/managing indexes.
