### PR TITLE
Use `rt_config:get_os_env`

### DIFF
--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -14,7 +14,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(2, ?CFG),
     create_index(Cluster, ?INDEX),

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -25,7 +25,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Nodes = rt:deploy_nodes(4, ?CFG),

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -8,7 +8,7 @@
 -define(NO_BODY, <<>>).
 
 confirm() ->
-    YZBenchDir = rt:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = prepare_cluster(4),

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -13,7 +13,7 @@
 -define(NO_BODY, <<>>).
 
 confirm() ->
-    YZBenchDir = rt:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = prepare_cluster(4),


### PR DESCRIPTION
There was a recent change to riak test and `get_os_env` was moved to a
new module.  This might be a good sign to lock yokozuna to
version/commit of riak test.
