### PR TITLE
Use mochiglobal to cache + get coverage plans

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -114,6 +114,7 @@
 
 -define(DATA_DIR, application:get_env(riak_core, platform_data_dir)).
 
+-define(YZ_COVER_TICK_INTERVAL, app_helper:get_env(?YZ_APP_NAME, cover_tick, 2000)).
 -define(YZ_DEFAULT_SOLR_PORT, "8983").
 -define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 15).
 -define(YZ_DEFAULT_TICK_INTERVAL, 60000).

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2012-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,6 +20,13 @@
 
 -module(yz_cover).
 -compile(export_all).
+-behavior(gen_server).
+-export([code_change/3,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         init/1,
+         terminate/2]).
 -include("yokozuna.hrl").
 
 %% @doc This module contains functionality related to creating
@@ -34,7 +41,82 @@ logical_partitions(Ring, Partitions) ->
     LI = logical_index(Ring),
     ordsets:from_list([logical_partition(LI, P) || P <- Partitions]).
 
+%% @doc Get the coverage plan for `Index'.
+-spec plan(index_name()) -> {term(), term()}.
 plan(Index) ->
+    case mochiglobal:get(list_to_atom(Index), undefined) of
+        undefined -> calc_plan(Index);
+        Plan -> Plan
+    end.
+
+-spec reify_partitions(ring(), ordset(lp())) -> ordset(p()).
+reify_partitions(Ring, LPartitions) ->
+    LI = logical_index(Ring),
+    ordsets:from_list([partition(LI, LP) || LP <- LPartitions]).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% Callbacks
+%%%===================================================================
+
+init([]) ->
+    schedule_tick(),
+    {ok, none}.
+
+handle_cast(update_all_plans, S) ->
+    update_all_plans(),
+    {noreply, S}.
+
+handle_info(tick, S) ->
+    update_all_plans(),
+    schedule_tick(),
+    {noreply, S};
+
+handle_info(Req, S) ->
+    lager:warning("Unexpected request ~p", [Req]),
+    {noreply, S}.
+
+handle_call(Req, _, S) ->
+    lager:warning("Unexpected request ~p", [Req]),
+    {noreply, S}.
+
+code_change(_, S, _) ->
+    {ok, S}.
+
+terminate(_, _) ->
+    ok.
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+%% @doc Create a covering set using logical partitions and add
+%%      filtering information to eliminate overlap.
+-spec add_filtering(n(), q(), logical_idx(), cover_set()) ->
+                           [{lp_node(), logical_filter()}].
+add_filtering(N, Q, LPI, CS) ->
+    CS2 = make_logical(LPI, CS),
+    CS3 = yz_misc:make_pairs(CS2),
+    CS4 = make_distance_pairs(Q, CS3),
+    make_filter_pairs(N, Q, CS4).
+
+%% @private
+%%
+%% @doc Calculate a plan for the `Index' and then store an entry in
+%%      the plan-cache.
+-spec cache_plan(index_name()) -> ok.
+cache_plan(Index) ->
+    Plan = calc_plan(Index),
+    mochiglobal:put(list_to_atom(Index), Plan),
+    ok.
+
+%% @private
+%%
+%% @doc Calculate a plan for the `Index'.
+-spec calc_plan(index_name()) -> {term(), term()}.
+calc_plan(Index) ->
     Ring = yz_misc:get_ring(transformed),
     Q = riak_core_ring:num_partitions(Ring),
     BProps = riak_core_bucket:get_bucket(Index, Ring),
@@ -58,25 +140,6 @@ plan(Index) ->
             LogicalCoverSet = add_filtering(NVal, Q, LPI, CoverSet),
             {UniqNodes, LogicalCoverSet}
     end.
-
--spec reify_partitions(ring(), ordset(lp())) -> ordset(p()).
-reify_partitions(Ring, LPartitions) ->
-    LI = logical_index(Ring),
-    ordsets:from_list([partition(LI, LP) || LP <- LPartitions]).
-
-%%%===================================================================
-%%% Private
-%%%===================================================================
-
-%% @doc Create a covering set using logical partitions and add
-%%      filtering information to eliminate overlap.
--spec add_filtering(n(), q(), logical_idx(), cover_set()) ->
-                           [{lp_node(), logical_filter()}].
-add_filtering(N, Q, LPI, CS) ->
-    CS2 = make_logical(LPI, CS),
-    CS3 = yz_misc:make_pairs(CS2),
-    CS4 = make_distance_pairs(Q, CS3),
-    make_filter_pairs(N, Q, CS4).
 
 %% @doc Get the distance between the logical partition `LPB' and
 %%      `LPA'.
@@ -157,3 +220,22 @@ make_logical(LogicalIndex, Cover) ->
 partition(LogicalIndex, LP) ->
     {_, P} = lists:keyfind(LP, 1, LogicalIndex),
     P.
+
+%% @private
+%%
+%% @doc Schedule next tick to be sent to this server.
+-spec schedule_tick() -> ok.
+schedule_tick() ->
+    erlang:send_after(2000, ?MODULE, tick),
+    ok.
+
+%% @private
+%%
+%% @doc Iterate through the list of indexes, calculate a new coverage
+%%      plan, and update the cache entry.
+-spec update_all_plans() -> ok.
+update_all_plans() ->
+    Ring = yz_misc:get_ring(transformed),
+    Indexes = [Name || {Name,_} <- yz_index:get_indexes_from_ring(Ring)],
+    lists:foreach(fun ?MODULE:cache_plan/1, Indexes),
+    ok.

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -226,7 +226,7 @@ partition(LogicalIndex, LP) ->
 %% @doc Schedule next tick to be sent to this server.
 -spec schedule_tick() -> ok.
 schedule_tick() ->
-    erlang:send_after(2000, ?MODULE, tick),
+    erlang:send_after(?YZ_COVER_TICK_INTERVAL, ?MODULE, tick),
     ok.
 
 %% @private

--- a/src/yz_sup.erl
+++ b/src/yz_sup.erl
@@ -53,6 +53,10 @@ init(_Args) ->
                   {yz_entropy_mgr, start_link, []},
                   permanent, 5000, worker, [yz_entropy_mgr]},
 
-    Children = [SolrProc, Events, HashtreeSup, EntropyMgr],
+    Cover = {yz_cover,
+             {yz_cover, start_link, []},
+             permanent, 5000, worker, [yz_cover]},
+
+    Children = [SolrProc, Events, HashtreeSup, EntropyMgr, Cover],
 
     {ok, {{one_for_one, 5, 10}, Children}}.


### PR DESCRIPTION
Creating a coverage plan consumes a lot of CPU and creates potentially
large lists (garbage) on the process potentially leading to GC.  This
gets worse as the ring size increases.

Currently Yokozuna creates a coverage plan _per_ request.  I.e. every
search request must first pay the expensive cost of calculating a plan
before running the search.  But it doesn't have to be this way.  The
plans could be periodically calculated in an out-of-band process and
cached in a good read-heavy solution like mochiglobal.

There is no reason to calc a plan per request.  The argument could be
made that this is the only way to avoid sending requests to downed
nodes but that is false.  Coverage relies on nodewatcher which uses
net-kernel tick which runs on a delay of ~15s.

The other argument could be ring change (join/remove a node).  In this
case the cached plan might be in disagreement with the ring.  The
divergence would last for a maximum upper bound of T where T is the
period of time before a new plan is written to the index.  This is
already a problem in Riak where the ring changes between the time a
coordinator fires of a request and the vnodes see it.  I'm just going
to punt and assume vnode forwarding should take care of this.  Even if
this isn't the case this scenario is made more rare by the fact that
the partition that has moved must be part of the plan.  This can also
be made even more rare by invalidating the cache on ring change events.

This patch makes the following changes:
- A new plan is generated for each index every 2 seconds.
- During a search request the cache is first checked.  The cache uses
  mochiglobal which generates BEAM code dynamically so that the cost
  of a fetch is that of a function call.
- If the cache doesn't have a plan stored for the index then a plan
  will be generated as part of the request.
- The `yz_cover` module is now a `gen_sever`.  It's responsibility is
  to periodically re-generate plans for each index and cache them.

NOTE: Another thing that might worry someone about this patch is that
using the same plan means not load-balancing well.  But this matters
less re Yokozuna for two reasons.
1. Yokozuna doesn't have vnodes, so balancing across vnodes doesn't
   matter.
2. Coverage currently seems to always select all nodes.  Once coverage
   gets better at optimizing for nodes then it would be wise to cache
   multiple plans and round-robin them.
