### PR TITLE
Add `enabled` flag to config

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -119,6 +119,7 @@
 -define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 15).
 -define(YZ_DEFAULT_TICK_INTERVAL, 60000).
 -define(YZ_DEFAULT_SOLR_VM_ARGS, []).
+-define(YZ_ENABLED, app_helper:get_env(?YZ_APP_NAME, enabled, false)).
 -define(YZ_EVENTS_TAB, yz_events_tab).
 -define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir, "data/yz")).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).

--- a/src/yz_sup.erl
+++ b/src/yz_sup.erl
@@ -21,7 +21,7 @@
 -module(yz_sup).
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/1]).
 -export([init/1]).
 
 
@@ -29,15 +29,19 @@
 %%% API
 %%%===================================================================
 
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+start_link(Enabled) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Enabled]).
 
 
 %%%===================================================================
 %%% Callbacks
 %%%===================================================================
 
-init(_Args) ->
+init([false]) ->
+    %% Yokozuna is disabled, start a supervisor without any children.
+    {ok, {{one_for_one, 5, 10}, []}};
+
+init([Enabled]) ->
     SolrProc = {yz_solr_proc_sup,
                 {yz_solr_proc_sup, start_link, []},
                 permanent, infinity, supervisor, [yz_solr_proc_sup]},


### PR DESCRIPTION
Allow Yokozuna to be enabled/disable based on the `enabled` config.
If set to `true` then Yokozuna will be started, `false` and it will
not.
- When disabled, the `yz_sup` process is still started but it will
  have no children.  Furthermore the webmachine resource will not be
  registered and the yokozuna service will not be marked up.
- I think you could enable Yokozuna on-the-fly, i.e. without
  restarting the VM, by changing the enabled flag to true and then
  running `application:stop` followed by `application:start`.
