### PR TITLE
Don't crash cover on insufficient_vnodes_available

### DIFF
--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -108,8 +108,12 @@ add_filtering(N, Q, LPI, CS) ->
 %%      the plan-cache.
 -spec cache_plan(index_name()) -> ok.
 cache_plan(Index) ->
-    Plan = calc_plan(Index),
-    mochiglobal:put(list_to_atom(Index), Plan),
+    case calc_plan(Index) of
+        {error, _} ->
+            mochiglobal:put(list_to_atom(Index), undefined);
+        Plan ->
+            mochiglobal:put(list_to_atom(Index), Plan)
+    end,
     ok.
 
 %% @private
@@ -131,8 +135,8 @@ calc_plan(Index) ->
                                                  ReqId,
                                                  ?YZ_SVC_NAME),
     case Result of
-        {error, Error} ->
-            throw(Error);
+        {error, _} = Err ->
+            Err;
         {CoverSet, _} ->
             {_Partitions, Nodes} = lists:unzip(CoverSet),
             UniqNodes = lists:usort(Nodes),

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -77,11 +77,17 @@ search(Req, S) ->
     Mapping = yz_events:get_mapping(),
     ReqHeaders = mochiweb_headers:to_list(wrq:req_headers(Req)),
     try
-        {RespHeaders, Body} = yz_solr:dist_search(Index, ReqHeaders,
-                                                  Params, Mapping),
-        Req2 = wrq:set_resp_headers(scrub_headers(RespHeaders), Req),
-        ?IF(FProf, fprof_analyse(FProfFile)),
-        {Body, Req2, S}
+        Result = yz_solr:dist_search(Index, ReqHeaders,
+                                     Params, Mapping),
+        case Result of
+            {error, insufficient_vnodes_available} ->
+                ER1 = wrq:set_resp_header("Content-Type", "text/plain", Req),
+                ER2 = wrq:set_resp_body(?YZ_ERR_NOT_ENOUGH_NODES ++ "\n", ER1),
+                {{halt, 503}, ER2, S};
+            {RespHeaders, Body} ->
+                Req2 = wrq:set_resp_headers(scrub_headers(RespHeaders), Req),
+                {Body, Req2, S}
+        end
     catch
         throw:not_found ->
             ErrReq = wrq:append_to_response_body(
@@ -89,12 +95,9 @@ search(Req, S) ->
                 Req),
             ErrReq2 = wrq:set_resp_header("Content-Type", "text/plain",
                                         ErrReq),
-            {{halt, 404}, ErrReq2, S};
-        throw:insufficient_vnodes_available ->
-            ErrReq = wrq:set_resp_header("Content-Type", "text/plain", Req),
-            ErrReq2 = wrq:set_resp_body(?YZ_ERR_NOT_ENOUGH_NODES ++ "\n",
-                                        ErrReq),
-            {{halt, 503}, ErrReq2, S}
+            {{halt, 404}, ErrReq2, S}
+    after
+        ?IF(FProf, fprof_analyse(FProfFile))
     end.
 
 scrub_headers(RespHeaders) ->


### PR DESCRIPTION
- Change `calc_plan` to return error-tuple rather than match it and
  throw it.
- Check for error-tuple when generating cached coverage plans and
  store undefined.  That will prevent cover server from crashing.
- Check for error-tuple during search request and return proper error
  msg to user.
