### PR TITLE
Fix extractor resource

### DIFF
--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -1,4 +1,4 @@
-%% @doc Test the index schema API in various ways.
+%% @doc Test the extractor API in various ways.
 -module(yz_wm_extract_test).
 -compile(export_all).
 -import(yz_rt, [host_entries/1, select_random/1]).
@@ -6,22 +6,44 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
--define(CFG, [{yokozuna, [{enabled, true}]}]).
+-define(CFG,
+	[
+	 {riak_core,
+	  [
+	   {ring_creation_size, 8}
+	  ]},
+	 {yokozuna,
+	  [
+	   {enabled, true}
+	  ]}
+	]).
 
 confirm() ->
-    Cluster = prepare_cluster(4),
+    Cluster = rt:deploy_nodes(1, ?CFG),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
     confirm_check_if_registered_set_ct(Cluster),
+    confirm_extract_on_content_type(Cluster),
     pass.
 
 %% @doc Confirm yz-extractor header works as a string in
 %%      yz_wm_extract:check_if_registered_set_ct/4
 confirm_check_if_registered_set_ct(Cluster) ->
-    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    HP = hd(host_entries(rt:connection_info(Cluster))),
     lager:info("confirm_check_if_registered_set_ct [~p]", [HP]),
     URL = extract_url(HP),
     Headers = [{?YZ_HEAD_EXTRACTOR,"yz_json_extractor"}],
     {ok, Status, _, _} = http(put, URL, Headers, "{\"name\":\"ryan\"}"),
     ?assertEqual("200", Status).
+
+%% @doc Confirm that the extractor works based on content-type.
+confirm_extract_on_content_type(Cluster) ->
+    HP = hd(host_entries(rt:connection_info(Cluster))),
+    lager:info("confirm_check_if_registered_set_ct [~p]", [HP]),
+    URL = extract_url(HP),
+    Headers = [{"content-type", "application/json"}],
+    {ok, Status, _, Body} = http(put, URL, Headers, <<"{\"name\":\"ryan\"}">>),
+    ?assertEqual("200", Status),
+    ?assert(size(Body) > 0).
 
 %%%===================================================================
 %%% Helpers
@@ -33,15 +55,3 @@ http(Method, URL, Headers, Body) ->
 
 extract_url({Host,Port}) ->
     ?FMT("http://~s:~B/extract", [Host, Port]).
-
-join(Nodes) ->
-    [NodeA|Others] = Nodes,
-    [rt:join(Node, NodeA) || Node <- Others],
-    Nodes.
-
-prepare_cluster(NumNodes) ->
-    Nodes = rt:deploy_nodes(NumNodes, ?CFG),
-    Cluster = join(Nodes),
-    yz_rt:wait_for_joins(Cluster),
-    rt:wait_for_cluster_service(Cluster, yokozuna),
-    Cluster.

--- a/src/yz_wm_extract.erl
+++ b/src/yz_wm_extract.erl
@@ -39,7 +39,7 @@ allowed_methods(RD, S) ->
     {Methods, RD, S}.
 
 malformed_request(RD, S) ->
-    E = list_to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
+    E = to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
     CT = wrq:get_req_header(?HEAD_CTYPE, RD),
     Content = wrq:req_body(RD),
 
@@ -60,7 +60,7 @@ malformed_request(RD, S) ->
 %% Accept the mime-type provided by user, if one is not provided use
 %% extractor specified in header.
 content_types_accepted(RD, S) ->
-    E = list_to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
+    E = to_atom(wrq:get_req_header(?YZ_HEAD_EXTRACTOR, RD)),
     CT = wrq:get_req_header(?HEAD_CTYPE, RD),
 
     case {E, CT} of
@@ -129,3 +129,9 @@ no_extractor_registered(RD, CT) ->
 add_msg(RD, Msg) ->
     RD2 = wrq:append_to_response_body(Msg, RD),
     wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD2).
+
+-spec to_atom(undefined | string()) -> atom().
+to_atom(undefined) ->
+    undefined;
+to_atom(S) ->
+    list_to_atom(S).


### PR DESCRIPTION
A regression was introduced in the last patch to the extractor
resource: it breaks if the `yz-extractor` header is not passed.  This
patch fixes that and adds a test.  The test was also changed to use
only 1 node since there is nothing about it that is distributed.  This
helps cut down on testing time.
