### PR TITLE
Error: @yz_kv:index:172 failed to index object on non-indexed bucket ('make stage' only)

### DIFF
--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -114,7 +114,7 @@ get_md_entry(MD, Key) ->
     yz_misc:dict_get(Key, MD, none).
 
 index(Obj, Reason, VNodeState) ->
-    case yokozuna:noop_flag(index) of
+    case yokozuna:noop_flag(index) orelse not ?YZ_ENABLED of
         true ->
             ok;
         false ->


### PR DESCRIPTION
To reproduce:
1. build YZ 0.6.0 from riak-yokozuna-0.6.0-src.tar.gz, according to INSTALL docs. (make stage, specifically)
2. Do not create any indices -- this is merely a test of plain non-YZ writes to Riak
3. Issue a plain http PUT to a non-indexed bucket:
   `curl -XPUT -H 'content-type: text/plain' http://127.0.0.1:8098/buckets/mytest/keys/test1 -d "Test value 1"`
4. Error shows up in the error log:
   `2013-06-02 17:08:05.363 [error] <0.621.0>@yz_kv:index:172 failed to index object {<<"mytest">>,<<"test1">>} with error {"Failed to index docs",[{doc,[{'_yz_id',<<"test1_3">>},{'_yz_ed',<<"20130602T170805 3 mytest test1 g2ICuKnm">>},{'_yz_fpn',<<"3">>},{'_yz_node',<<"riak@127.0.0.1">>},{'_yz_pn',<<"3">>},{'_yz_rk',<<"test1">>},{'_yz_rb',<<"mytest">>}]}],{error,{conn_failed,{error,econnrefused}}}}`

So my question is two-fold.
One, why is Yokozuna trying to index an object for a non-indexed bucket? (Or is that expected behavior).
Two, I wonder why the 'connection refused error'. I can access the written value above via HTTP:

```
$ curl http://127.0.0.1:8098/buckets/mytest/keys/test1
Test value 1
```

but I can't connect to YZ, to create an index, for example:

```
$ curl -XPUT -i -H 'content-type: application/json' http://127.0.0.1:8098/yz/index/indexedbucket
HTTP/1.1 404 Object Not Found
```
