### PR TITLE
1:M index:bucket mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,18 @@ development cluster.
 
 ### Creating an Index ###
 
-An _index_ must be created in order for Yokozuna to index data.
+An _index_ must be created for bucket data to be indexed under.  Many
+buckets may use the same index.  To create an index via the HTTP
+interface the following.
 
-Currently the index name is a 1:1 mapping with the bucket name. This
-may eventually change to a 1:M mapping from index to bucket.
+    curl -XPUT -i 'http://localhost:10018/yz/index/my_index'
 
-You can create an index via the HTTP interface.
+### Associating a Bucket with an Index ###
 
-    curl -XPUT -i -H 'content-type: application/json' http://localhost:10018/yz/index/name_of_index
+A bucket property must be added to tell Yokozuna where to store the
+indexes for a given bucket.
 
-Optionally, you may create an index from the console.
+    curl -XPUT -i -H 'content-type: application/json' 'http://localhost:10018/buckets/my_bucket/props' -d '{"props":{"yz_index":"my_index"}}'
 
 ### Index Some Data ###
 

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -248,7 +248,7 @@
 -type index_name() :: string().
 
 -define(YZ_DEFAULT_INDEX, "_yz_default").
--define(YZ_INDEX_CONTENT, yz_index_content).
+-define(YZ_INDEX, yz_index).
 
 %%%===================================================================
 %%% Schemas

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -4,7 +4,7 @@
                 host_entries/1,
                 run_bb/2,
                 search_expect/5, search_expect/6,
-                set_index_flag/2,
+                set_index/2,
                 select_random/1, verify_count/2,
                 wait_for_joins/1, write_terms/2]).
 -include_lib("eunit/include/eunit.hrl").
@@ -257,13 +257,13 @@ setup_indexing(Cluster, YZBenchDir) ->
     RawSchema = read_schema(YZBenchDir),
     ok = store_schema(Node, ?FRUIT_SCHEMA_NAME, RawSchema),
     ok = create_index(Node, ?INDEX_S, ?FRUIT_SCHEMA_NAME),
-    ok = set_index_flag(Node, ?INDEX_B),
+    ok = set_index(Node, ?INDEX_B),
     ok = create_index(Node, "fruit_aae", ?FRUIT_SCHEMA_NAME),
-    ok = set_index_flag(Node, <<"fruit_aae">>),
+    ok = set_index(Node, <<"fruit_aae">>),
     ok = create_index(Node, "tagging"),
-    ok = set_index_flag(Node, <<"tagging">>),
+    ok = set_index(Node, <<"tagging">>),
     ok = create_index(Node, "siblings"),
-    ok = set_index_flag(Node, <<"siblings">>),
+    ok = set_index(Node, <<"siblings">>),
     %% Give Solr time to build index
     timer:sleep(5000).
 

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -43,7 +43,7 @@ check_fallbacks(Cluster) ->
 create_index(Cluster, Index) ->
     Node = yz_rt:select_random(Cluster),
     yz_rt:create_index(Node, Index),
-    ok = yz_rt:set_index_flag(Node, list_to_binary(Index)),
+    ok = yz_rt:set_index(Node, list_to_binary(Index)),
     timer:sleep(5000).
     
 make_logical(Node, Preflist) ->

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -52,16 +52,15 @@ verify_flag_add(Cluster, YZBenchDir) ->
     lager:info("Create fruit index + set flag"),
     yz_rt:create_index(yz_rt:select_random(Cluster), "fruit"),
     yz_rt:set_index(yz_rt:select_random(Cluster), <<"fruit">>),
-    %% Give Solr time to create index
-    timer:sleep(10000),
+    yz_rt:wait_for_index(Cluster, "fruit"),
+
     %% TODO: use YZ/KV AAE stats to determine when AAE has covered ring once.
-    F = fun(Cluster2) ->
-                Hosts2 = yz_rt:host_entries(rt:connection_info(Cluster2)),
-                HP2 = yz_rt:select_random(Hosts2),
+    F = fun(Node) ->
+                lager:info("Verify that AAE re-indexes objects under fruit index [~p]", [Node]),
+                HP2 = hd(yz_rt:host_entries(rt:connection_info([Node]))),
                 yz_rt:search_expect(HP2, "fruit", "*", "*", ?NUM_KEYS)
         end,
-    lager:info("Verify that AAE re-indexes objects under fruit index"),
-    ?assertEqual(ok, yz_rt:wait_for_aae(Cluster, F)).
+    yz_rt:wait_until(Cluster, F).
 
 %% @doc When a flag is removed the indexes for that bucket's index
 %%      should be deleted and AAE should re-index objects under the
@@ -70,15 +69,14 @@ verify_flag_remove(Cluster) ->
     lager:info("Verify removing flag"),
     Node = yz_rt:select_random(Cluster),
     yz_rt:remove_index(Node, <<"fruit">>),
-    F = fun(Cluster2) ->
-                Hosts = yz_rt:host_entries(rt:connection_info(Cluster2)),
-                HP = yz_rt:select_random(Hosts),
+    F = fun(Node2) ->
+                lager:info("Verify fruit indexes are deleted + objects re-indexed under default index [~p]", [Node2]),
+                HP = hd(yz_rt:host_entries(rt:connection_info([Node2]))),
                 R1 = yz_rt:search_expect(HP, "fruit", "*", "*", 0),
                 R2 = yz_rt:search_expect(HP, "_yz_default", "_yz_rb", "fruit", ?NUM_KEYS),
                 R1 and R2
         end,
-    lager:info("Verify fruit indexes are deleted + objects re-indexed under default index"),
-    ?assertEqual(ok, yz_rt:wait_for_aae(Cluster, F)).
+    yz_rt:wait_until(Cluster, F).
 
 join(Nodes) ->
     [NodeA|Others] = Nodes,

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -64,7 +64,8 @@ create_index(Cluster, Index) ->
     URL = index_url(HP, Index),
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
-    timer:sleep(4000),
+    yz_rt:set_index(hd(Cluster), Index),
+    timer:sleep(5000),
     ?assertEqual("204", Status).
 
 store_and_search(Cluster, Bucket, Key, Body, Search, Params) ->
@@ -91,7 +92,7 @@ store_and_search(Cluster, Bucket, Key, Body, CT, Search, Params) ->
     ok.
 
 confirm_basic_search(Cluster) ->
-    Bucket = "basic",
+    Bucket = <<"basic">>,
     create_index(Cluster, Bucket),
     lager:info("confirm_basic_search ~s", [Bucket]),
     Body = "herp derp",
@@ -99,7 +100,7 @@ confirm_basic_search(Cluster) ->
     store_and_search(Cluster, Bucket, "test", Body, <<"text:herp">>, Params).
 
 confirm_encoded_search(Cluster) ->
-    Bucket = "encoded",
+    Bucket = <<"encoded">>,
     create_index(Cluster, Bucket),
     lager:info("confirm_encoded_search ~s", [Bucket]),
     Body = "א בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ",
@@ -107,7 +108,7 @@ confirm_encoded_search(Cluster) ->
     store_and_search(Cluster, Bucket, "וְאֵת", Body, <<"text:בָּרָא">>, Params).
 
 confirm_multivalued_field(Cluster) ->
-    Bucket = "basic",
+    Bucket = <<"basic">>,
     lager:info("cofirm multiValued=true fields decode properly"),
     Body = <<"{\"name_ss\":\"turner\", \"name_ss\":\"hooch\"}">>,
     Params = [],
@@ -121,7 +122,7 @@ confirm_multivalued_field(Cluster) ->
     timer:sleep(1100),
     Search = <<"name_ss:turner">>,
     {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
-    {ok,{search_results,[{Bucket,Fields}],Score,Found}} =
+    {ok,{search_results,[{Bucket,Fields}],_Score,_Found}} =
             riakc_pb_socket:search(Pid, Bucket, Search, Params),
     ?assert(lists:member({<<"name_ss">>,<<"turner">>}, Fields)),
     ?assert(lists:member({<<"name_ss">>,<<"hooch">>}, Fields)).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -129,6 +129,7 @@ wait_for_aae(Cluster, F, Tries) ->
             wait_for_aae(Cluster, F, Tries + 1)
     end.
 
+-spec wait_for_index(list(), string()) -> term().
 wait_for_index(Cluster, Index) ->
     IsIndexUp =
         fun(Node) ->

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -317,13 +317,13 @@ confirm_bad_schema(Cluster) ->
 
     lager:info("upload corrected schema ~s", [Name]),
     {ok, Status3, _, _} = http(put, URL, Headers, ?TEST_SCHEMA),
-    ?assertEqual("204", Status),
+    ?assertEqual("204", Status3),
 
     lager:info("wait for yz to retry creation of core ~s", [Name]),
     Node = select_random(Cluster),
-    F = fun(Node) ->
+    F = fun(Node2) ->
                 lager:info("try to ping core ~s", [Name]),
-                rpc:call(Node, yz_solr, ping, [binary_to_list(Name)])
+                rpc:call(Node2, yz_solr, ping, [binary_to_list(Name)])
         end,
     ?assertEqual(ok, rt:wait_until(Node, F)).
 

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -162,10 +162,11 @@ destroy_events_table() ->
     true = ets:delete(?YZ_EVENTS_TAB),
     ok.
 
+-spec flagged_buckets(ring()) -> [bucket()].
 flagged_buckets(Ring) ->
     Buckets = riak_core_bucket:get_buckets(Ring),
     [proplists:get_value(name, BProps)
-     || BProps <- Buckets, proplists:get_bool(?YZ_INDEX_CONTENT, BProps)].
+     || BProps <- Buckets, yz_kv:index_content(yz_kv:which_index(BProps))].
 
 get_tick_interval() ->
     app_helper:get_env(?YZ_APP_NAME, tick_interval, ?YZ_DEFAULT_TICK_INTERVAL).

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -233,9 +233,16 @@ set_index(Bucket, Index) ->
 
 %% @doc Extract the index name from `BProps' or return the default
 %%      index name if there is none.
+%%
+%% TODO: Convert `index_name()' to be binary everywhere.
 -spec which_index(term()) -> index_name().
 which_index(BProps) ->
-    proplists:get_value(?YZ_INDEX, BProps, ?YZ_DEFAULT_INDEX).
+    case proplists:get_value(?YZ_INDEX, BProps, ?YZ_DEFAULT_INDEX) of
+        B when is_binary(B) ->
+            binary_to_list(B);
+        S ->
+            S
+    end.
 
 %%%===================================================================
 %%% Private

--- a/test/yz_kv_tests.erl
+++ b/test/yz_kv_tests.erl
@@ -9,10 +9,10 @@ set_index_flag_test()->
   meck:expect(riak_core_bucket, set_bucket,
     fun(Bucket, Props) when Bucket =:= <<"a">> ->
       case Props of
-        [{?YZ_INDEX_CONTENT, true}] -> ok;
+        [{?YZ_INDEX, "index"}] -> ok;
         _ -> error
       end
     end),
-  ?assertEqual(yz_kv:set_index_flag(<<"a">>), ok),
+  ?assertEqual(yz_kv:set_index(<<"a">>, "index"), ok),
   ?assert(meck:validate(riak_core_bucket)),
   meck:unload(riak_core_bucket).


### PR DESCRIPTION
Allow a one-to-many index-to-bucket mapping.  This allows splitting data into logical buckets without requiring the use of multiple Solr Cores.
- Change the index content flag to instead be the name of the index for which the bucket indexes under.  I.e. change the bucket property name from `yz_index_content` to `yz_index`.
- The bucket property is already being pulled during index time so just change the index hook to use the value as the index to write to.
