### PR TITLE
Send Delete & Update in Same Request

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -19,29 +19,6 @@
 %% -------------------------------------------------------------------
 
 %%%===================================================================
-%%% Records
-%%%===================================================================
-
--record(yz_index_cmd, {
-          doc :: doc(),
-          index :: string(),
-          req_id :: non_neg_integer()
-         }).
-
--record(yz_search_cmd, {
-          qry :: term(),
-          req_id :: non_neg_integer()
-         }).
-
-%% A reference to a merkle tree.
--record(tree_ref, {
-          index :: string(),
-          name :: tree_name(),
-          pid :: pid(),
-          ref :: reference()
-         }).
-
-%%%===================================================================
 %%% Types
 %%%===================================================================
 
@@ -60,7 +37,6 @@
 %% An iso8601 datetime as binary, e.g. <<"20121221T000000">>.
 -type iso8601() :: binary().
 -type tree_name() :: atom().
--type tree_ref() :: #tree_ref{}.
 
 %% Index into the ring
 -type idx() :: non_neg_integer().

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -71,6 +71,10 @@
 -type ring_event() :: {ring_event, riak_core_ring:riak_core_ring()}.
 -type event() :: ring_event().
 
+-type delete_op() :: {id, binary()}
+                   | {key, binary()}
+                   | {siblings, binary()}
+                   | {'query', binary()}.
 
 %%%===================================================================
 %%% Macros

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -296,7 +296,7 @@
 %% Riak bucket
 -define(YZ_RB_FIELD, '_yz_rb').
 -define(YZ_RB_FIELD_S, "_yz_rb").
--define(YZ_RB_FIELD_B, <<"_yz_rk">>).
+-define(YZ_RB_FIELD_B, <<"_yz_rb">>).
 -define(YZ_RB_FIELD_XML, ?YZ_FIELD_XML(?YZ_RB_FIELD_S)).
 -define(YZ_RB_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_rb\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
 

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -80,7 +80,7 @@ test_escaped_key(Cluster) ->
     Value = <<"Never gonna give you up">>,
     Bucket = "escaped",
     Key = edoc_lib:escape_uri("rick/astley-rolled:derp"),
-    ok = http_put({H, P}, Bucket, Key, Value),
+    ok = yz_rt:http_put({H, P}, Bucket, Key, Value),
     ok = http_get({H, P}, Bucket, Key),
     ok.
 
@@ -89,14 +89,6 @@ http_get({Host, Port}, Bucket, Key) ->
                                       [Host, integer_to_list(Port), Bucket, Key])),
     Headers = [{"accept", "text/plain"}],
     {ok, "200", _, _} = ibrowse:send_req(URL, Headers, get, [], []),
-    ok.
-
-http_put({Host, Port}, Bucket, Key, Value) ->
-    URL = lists:flatten(io_lib:format("http://~s:~s/riak/~s/~s",
-                                      [Host, integer_to_list(Port), Bucket, Key])),
-    Opts = [],
-    Headers = [{"content-type", "text/plain"}],
-    {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Value, Opts),
     ok.
 
 verify_aae(Cluster, YZBenchDir) ->

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -64,6 +64,8 @@ expect_bad_json(Cluster) ->
     timer:sleep(1100),
     %% still store the value in riak
     {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
+    %% Sleep for soft commit
+    timer:sleep(1100),
     ?assert(search_expect(HP, "bad_json", ?YZ_ERR_FIELD_S, "1", 1)),
     ok.
 
@@ -81,6 +83,8 @@ expect_bad_xml(Cluster) ->
     timer:sleep(1100),
     %% still store the value in riak
     {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
+    %% Sleep for soft commit
+    timer:sleep(1100),
     ?assert(search_expect(HP, "bad_xml", ?YZ_ERR_FIELD_S, "1", 1)),
     ok.
 

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -1,3 +1,16 @@
+%% @doc Test the addition or removal of the index entry from a bucket
+%%      that has data.  If a bucket already has data then associating
+%%      it with an index should cause the deletion of all entries for
+%%      this bucket in the default index and re-indexing under the
+%%      newly associated index.  Conversely, if an index is
+%%      dissociated from the bucket then that bucket's data should be
+%%      deleted from the index and re-indexed under the default index.
+%%
+%% NOTE: This is called "flag transition" because originally Yokozuna
+%%       had an implicit one-to-one mapping between bucket and index
+%%       name.  That is, the names were the same and a given index was
+%%       responsible for only one bucket (with the exception of the
+%%       _yz_default index).
 -module(yz_flag_transitions).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
@@ -32,14 +45,15 @@ confirm() ->
     Nodes = rt:deploy_nodes(4, ?CFG),
     Cluster = join(Nodes),
     yz_rt:wait_for_joins(Cluster),
-    verify_flag_add(Cluster, YZBenchDir),
-    verify_flag_remove(Cluster).
+    verify_index_add(Cluster, YZBenchDir),
+    verify_index_remove(Cluster),
+    verify_many_to_one_index_remove(Cluster).
 
-%% @doc When a flag is added the indexes for the bucket should be
-%%      removed from the default index and AAE should re-index objects
-%%      under the bucket's index.
-verify_flag_add(Cluster, YZBenchDir) ->
-    lager:info("Verify adding flag"),
+%% @doc When an index is associated the indexes for the bucket should
+%%      be removed from the default index and AAE should re-index
+%%      objects under the bucket's index.
+verify_index_add(Cluster, YZBenchDir) ->
+    lager:info("Verify adding index"),
     yz_rt:load_data(Cluster, "fruit", YZBenchDir, ?NUM_KEYS),
     %% Let 1s soft-commit catch up
     timer:sleep(1000),
@@ -64,11 +78,11 @@ verify_flag_add(Cluster, YZBenchDir) ->
         end,
     yz_rt:wait_until(Cluster, F).
 
-%% @doc When a flag is removed the indexes for that bucket's index
-%%      should be deleted and AAE should re-index objects under the
-%%      default index.
-verify_flag_remove(Cluster) ->
-    lager:info("Verify removing flag"),
+%% @doc When an index is dissociated the indexes for that bucket's
+%%      index should be deleted and AAE should re-index objects under
+%%      the default index.
+verify_index_remove(Cluster) ->
+    lager:info("Verify removing index"),
     Node = yz_rt:select_random(Cluster),
     yz_rt:remove_index(Node, <<"fruit">>),
     F = fun(Node2) ->
@@ -77,6 +91,33 @@ verify_flag_remove(Cluster) ->
                 R1 = yz_rt:search_expect(HP, "fruit", "*", "*", 0),
                 R2 = yz_rt:search_expect(HP, "_yz_default", "_yz_rb", "fruit", ?NUM_KEYS),
                 R1 and R2
+        end,
+    yz_rt:wait_until(Cluster, F).
+
+%% @doc Verify that removing the index entry for a bucket deletes only
+%%      that bucket's data in the associated index.
+verify_many_to_one_index_remove(Cluster) ->
+    lager:info("Verify removing index on a many-to-one index"),
+    Node = yz_rt:select_random(Cluster),
+    HP = hd(yz_rt:host_entries(rt:connection_info([Node]))),
+    yz_rt:create_index(Node, "many"),
+    yz_rt:set_index(Node, <<"b1">>, "many"),
+    yz_rt:set_index(Node, <<"b2">>, "many"),
+    yz_rt:wait_for_index(Cluster, "many"),
+    yz_rt:http_put(HP, <<"b1">>, <<"key">>, <<"somedata">>),
+    yz_rt:http_put(HP, <<"b2">>, <<"key">>, <<"somedata">>),
+    %% Wait for soft-commit
+    timer:sleep(1100),
+    ?assert(yz_rt:search_expect(HP, "many", "_yz_rb", "b1", 1)),
+    ?assert(yz_rt:search_expect(HP, "many", "_yz_rb", "b2", 1)),
+    yz_rt:remove_index(Node, <<"b1">>),
+    F = fun(Node2) ->
+                lager:info("Verify only 'b1' data is removed from 'many' index [~p]", [Node2]),
+                HP2 = hd(yz_rt:host_entries(rt:connection_info([Node2]))),
+                R1 = yz_rt:search_expect(HP2, "many", "_yz_rb", "b1", 0),
+                R2 = yz_rt:search_expect(HP2, "many", "_yz_rb", "b2", 1),
+                R3 = yz_rt:search_expect(HP2, "_yz_default", "_yz_rb", "b1", 1),
+                R1 and R2 and R3
         end,
     yz_rt:wait_until(Cluster, F).
 

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -58,6 +58,8 @@ verify_flag_add(Cluster, YZBenchDir) ->
     F = fun(Node) ->
                 lager:info("Verify that AAE re-indexes objects under fruit index [~p]", [Node]),
                 HP2 = hd(yz_rt:host_entries(rt:connection_info([Node]))),
+                %% Also verify that the data was deleted under default index
+                yz_rt:search_expect(HP2, "_yz_default", "_yz_rb", "fruit", 0),
                 yz_rt:search_expect(HP2, "fruit", "*", "*", ?NUM_KEYS)
         end,
     yz_rt:wait_until(Cluster, F).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -1,6 +1,7 @@
 -module(yz_rt).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 
 -type host() :: string().
 -type portnum() :: integer().
@@ -39,6 +40,15 @@ get_yz_conn_info(Node) ->
 -spec host_entries(conn_info()) -> [{host(), portnum()}].
 host_entries(ClusterConnInfo) ->
     [riak_http(I) || {_,I} <- ClusterConnInfo].
+
+-spec http_put({string(), portnum()}, binary(), binary(), binary()) -> ok.
+http_put({Host, Port}, Bucket, Key, Value) ->
+    URL = ?FMT("http://~s:~s/riak/~s/~s",
+               [Host, integer_to_list(Port), Bucket, Key]),
+    Opts = [],
+    Headers = [{"content-type", "text/plain"}],
+    {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Value, Opts),
+    ok.
 
 load_data(Cluster, Index, YZBenchDir, NumKeys) ->
     lager:info("Load data for index ~p onto cluster ~p", [Index, Cluster]),

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -280,8 +280,8 @@ sync_added(Bucket) ->
             NumFound = yz_solr:get_path(Struct, [<<"response">>, <<"numFound">>]),
             if NumFound > 0 ->
                     lager:info("index flag enabled for bucket ~s with existing data", [Bucket]),
-                    Qry = mochijson:encode({struct, [{delete, {struct, [{'query', list_to_binary("_yz_rb:" ++ Bucket)}]}}, {commit, {struct, []}}]}),
-                    ok = yz_solr:delete_by_query(?YZ_DEFAULT_INDEX, Qry),
+                    Ops = [{'query', list_to_binary("_yz_rb:" ++ Bucket)}],
+                    ok = yz_solr:delete(?YZ_DEFAULT_INDEX, Ops),
                     yz_entropy_mgr:clear_trees();
                true ->
                     ok
@@ -292,8 +292,7 @@ sync_added(Bucket) ->
 
 sync_removed(Bucket) ->
     lager:info("index flag disabled for bucket ~s", [Bucket]),
-    Qry = mochijson:encode({struct, [{delete, {struct, [{'query', <<"*:*">>}]}}, {commit, {struct, []}}]}),
-    ok = yz_solr:delete_by_query(binary_to_list(Bucket), Qry),
+    ok = yz_solr:delete(binary_to_list(Bucket), [{'query', <<"*:*">>}]),
     yz_entropy_mgr:clear_trees(),
     ok.
 

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -80,7 +80,9 @@ handle_cast({ring_event, Ring}=RE, S) ->
     {FlagsRemoved, FlagsAdded, _} = yz_misc:delta(PreviousFlags, CurrentFlags),
 
     ok = sync_indexes(Ring, Removed, Added, Same),
-    ok = sync_data(FlagsRemoved, FlagsAdded),
+    %% Pass `PrevRing' because need access to index name associated
+    %% with bucket.
+    ok = sync_data(PrevRing, FlagsRemoved, FlagsAdded),
 
     {noreply, S2}.
 
@@ -267,9 +269,10 @@ set_tick() ->
     erlang:send_after(Interval, ?MODULE, tick),
     ok.
 
-sync_data(Removed, Added) ->
+-spec sync_data(ring(), list(), list()) -> ok.
+sync_data(PrevRing, Removed, Added) ->
     [sync_added(Bucket) || Bucket <- Added],
-    [sync_removed(Bucket) || Bucket <- Removed],
+    [sync_removed(PrevRing, Bucket) || Bucket <- Removed],
     ok.
 
 sync_added(Bucket) ->
@@ -280,8 +283,9 @@ sync_added(Bucket) ->
             NumFound = yz_solr:get_path(Struct, [<<"response">>, <<"numFound">>]),
             if NumFound > 0 ->
                     lager:info("index flag enabled for bucket ~s with existing data", [Bucket]),
-                    Ops = [{'query', list_to_binary("_yz_rb:" ++ Bucket)}],
+                    Ops = [{'query', <<?YZ_RB_FIELD_B/binary,":",Bucket/binary>>}],
                     ok = yz_solr:delete(?YZ_DEFAULT_INDEX, Ops),
+                    yz_solr:commit(?YZ_DEFAULT_INDEX),
                     yz_entropy_mgr:clear_trees();
                true ->
                     ok
@@ -290,9 +294,12 @@ sync_added(Bucket) ->
             ok
     end.
 
-sync_removed(Bucket) ->
+-spec sync_removed(ring(), bucket()) -> ok.
+sync_removed(PrevRing, Bucket) ->
     lager:info("index flag disabled for bucket ~s", [Bucket]),
-    ok = yz_solr:delete(binary_to_list(Bucket), [{'query', <<"*:*">>}]),
+    Index = yz_kv:which_index(riak_core_bucket:get_bucket(Bucket, PrevRing)),
+    ok = yz_solr:delete(Index, [{'query', <<?YZ_RB_FIELD_B/binary,":",Bucket/binary>>}]),
+    yz_solr:commit(Index),
     yz_entropy_mgr:clear_trees(),
     ok.
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -137,8 +137,9 @@ remove_non_owned_data(Index) ->
     OwnedAndNext = yz_misc:owned_and_next_partitions(node(), Ring),
     NonOwned = ordsets:subtract(IndexPartitions, OwnedAndNext),
     LNonOwned = yz_cover:logical_partitions(Ring, NonOwned),
-    Query = yz_solr:build_partition_delete_query(LNonOwned),
-    ok = yz_solr:delete_by_query(Index, Query),
+    Queries = [{'query', <<?YZ_PN_FIELD_S, ":", (?INT_TO_BIN(LP))/binary>>}
+               || LP <- LNonOwned],
+    ok = yz_solr:delete(Index, Queries),
     lists:zip(NonOwned, LNonOwned).
 
 -spec schema_name(index_info()) -> schema_name().

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -143,8 +143,7 @@ index(Obj, Reason, VNodeState) ->
 index(_, delete, _, P, BKey, IdxN, Index, _) ->
     {_, Key} = BKey,
     try
-        Query = yz_solr:encode_delete({key, Key}),
-        ok = yz_solr:delete_by_query(Index, Query),
+        ok = yz_solr:delete(Index, [{key, Key}]),
         ok = update_hashtree(delete, P, IdxN, BKey)
     catch _:Err ->
             ?ERROR("failed to delete docid ~p with error ~p", [BKey, Err])
@@ -160,8 +159,8 @@ index(Obj, Reason, Ring, P, BKey, IdxN, Index, IndexContent) ->
     Docs = yz_doc:make_docs(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP),
                             IndexContent),
     try
-        ok = yz_solr:index(Index, Docs),
-        ok = cleanup(length(Docs), {Index, Obj, Key, LP}),
+        DelOp = cleanup(length(Docs), {Index, Obj, Key, LP}),
+        ok = yz_solr:index(Index, Docs, DelOp),
         ok = update_hashtree({insert, yz_kv:hash_object(Obj)},
                              P, IdxN, BKey)
     catch _:Err ->
@@ -269,20 +268,17 @@ check_flag(Flag) ->
     true == erlang:get(Flag).
 
 %% @private
-cleanup(1, {Index, _Obj, Key, _LP}) ->
+cleanup(1, {_Index, _Obj, Key, _LP}) ->
     %% Delete any siblings
-    JSON = yz_solr:encode_delete({key, Key, siblings}),
-    ok = yz_solr:delete_by_query(Index, JSON);
-
-cleanup(2, {Index, Obj, _Key, LP}) ->
+    [{siblings, Key}];
+cleanup(2, {_Index, Obj, _Key, LP}) ->
     %% An object has crossed the threshold from
     %% being a single value Object, to a sibling
     %% value Object, delete the non-sibling ID
     DocID = yz_doc:doc_id(Obj, ?INT_TO_BIN(LP)),
-    ok = yz_solr:delete(Index, DocID);
-
+    [{id, DocID}];
 cleanup(_, _) ->
-    ok.
+    [].
 
 %% @private
 %%

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -159,7 +159,7 @@ index(Obj, Reason, Ring, P, BKey, IdxN, Index, IndexContent) ->
     Docs = yz_doc:make_docs(Obj, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP),
                             IndexContent),
     try
-        DelOp = cleanup(length(Docs), {Index, Obj, Key, LP}),
+        DelOp = cleanup(length(Docs), {Obj, Key, LP}),
         ok = yz_solr:index(Index, Docs, DelOp),
         ok = update_hashtree({insert, yz_kv:hash_object(Obj)},
                              P, IdxN, BKey)
@@ -268,10 +268,10 @@ check_flag(Flag) ->
     true == erlang:get(Flag).
 
 %% @private
-cleanup(1, {_Index, _Obj, Key, _LP}) ->
+cleanup(1, {_Obj, Key, _LP}) ->
     %% Delete any siblings
     [{siblings, Key}];
-cleanup(2, {_Index, Obj, _Key, LP}) ->
+cleanup(2, {Obj, _Key, LP}) ->
     %% An object has crossed the threshold from
     %% being a single value Object, to a sibling
     %% value Object, delete the non-sibling ID

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -298,23 +298,12 @@ encode_delete({id, Id}) ->
     {struct, [{id, Id}]}.
 
 encode_doc({doc, Fields}) ->
-    {struct, [{doc, lists:map(fun encode_field/1,Fields)}]};
-
-encode_doc({doc, Boost, Fields}) ->
-    {struct, [{doc, [{boost, Boost}], lists:map(fun encode_field/1, Fields)}]}.
-
-% encode_field({Name,Value}) when is_binary(Value) ->
-%     {Name, Value};
+    {struct, [{doc, lists:map(fun encode_field/1,Fields)}]}.
 
 encode_field({Name,Value}) when is_list(Value) ->
     {Name, list_to_binary(Value)};
-
 encode_field({Name,Value}) ->
-    {Name, Value};
-
-encode_field({Name,Value,Boost}) ->
-    FieldContent = {struct, [{boost, Boost}, {value, Value}]},
-    {struct, [{Name, FieldContent}]}.
+    {Name, Value}.
 
 %% @doc Get the continuation value if there is one.
 get_continuation(false, _R) ->

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -88,10 +88,11 @@ cores() ->
             Err
     end.
 
--spec delete(string(), binary()) -> ok.
-delete(Core, DocID) ->
-    BaseURL = base_url() ++ "/" ++ Core ++ "/update",
-    JSON = encode_delete({id, DocID}),
+%% @doc Perform the delete `Ops' against the `Index'.
+-spec delete(index_name(), [delete_op()]) -> ok.
+delete(Index, Ops) ->
+    BaseURL = base_url() ++ "/" ++ Index ++ "/update",
+    JSON = mochijson2:encode({struct, [{delete, encode_delete(Op)} || Op <- Ops]}),
     Params = [],
     Encoded = mochiweb_util:urlencode(Params),
     URL = BaseURL ++ "?" ++ Encoded,
@@ -99,15 +100,7 @@ delete(Core, DocID) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, post, JSON, Opts) of
         {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to delete doc", DocID, Err})
-    end.
-
-delete_by_query(Core, JSON) ->
-    BaseURL = base_url() ++ "/" ++ Core ++ "/update",
-    Headers = [{content_type, "application/json"}],
-    case ibrowse:send_req(BaseURL, Headers, post, JSON, []) of
-        {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to delete by query", JSON, Err})
+        Err -> throw({"Failed to delete doc", Ops, Err})
     end.
 
 %% @doc Get slice of entropy data.  Entropy data is used to build
@@ -153,8 +146,15 @@ entropy_data(Core, Filter) ->
 
 %% @doc Index the given `Docs'.
 index(Core, Docs) ->
+    index(Core, Docs, []).
+
+-spec index(index_name(), list(), [delete_op()]) -> ok.
+index(Core, Docs, DelOps) ->
     BaseURL = base_url() ++ "/" ++ Core ++ "/update",
-    JSON = prepare_json(Docs),
+    Ops = {struct,
+           [{delete, encode_delete(Op)} || Op <- DelOps] ++
+               [{add, encode_doc(D)} || D <- Docs]},
+    JSON = mochijson2:encode(Ops),
     Params = [],
     Encoded = mochiweb_util:urlencode(Params),
     URL = BaseURL ++ "?" ++ Encoded,
@@ -162,7 +162,7 @@ index(Core, Docs) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, post, JSON, Opts) of
         {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to index docs", Docs, Err})
+        Err -> throw({"Failed to index docs", Ops, Err})
     end.
 
 prepare_json(Docs) ->
@@ -279,24 +279,29 @@ convert_action(remove) -> "UNLOAD".
 encode_commit() ->
     <<"{}">>.
 
+%% @private
+%%
+%% @doc Encode a delete operation into a mochijson2 compatiable term.
+-spec encode_delete(delete_op()) -> term().
 encode_delete({key,Key}) ->
     Query = ?YZ_RK_FIELD_S ++ ":" ++ ibrowse_lib:url_encode(binary_to_list(Key)),
-    mochijson2:encode({struct, [{delete, ?QUERY(list_to_binary(Query))}]});
-
-encode_delete({key,Key,siblings}) ->
+    ?QUERY(list_to_binary(Query));
+encode_delete({siblings,Key}) ->
     Query = ?YZ_RK_FIELD_S ++ ":" ++ ibrowse_lib:url_encode(binary_to_list(Key)) ++ " AND " ++ ?YZ_VTAG_FIELD_S ++ ":[* TO *]",
-    mochijson2:encode({struct, [{delete, ?QUERY(list_to_binary(Query))}]});
-
-%% NOTE: Solr uses the name `id' to represent the `uniqueKey' field of
-%%       the schema.  Thus `id' must be passed, not `YZ_ID_FIELD'.
+    ?QUERY(list_to_binary(Query));
+encode_delete({'query', Query}) ->
+    ?QUERY(Query);
 encode_delete({id, Id}) ->
-    mochijson2:encode({struct, [{delete, {struct, [{id, Id}]}}]}).
+    %% NOTE: Solr uses the name `id' to represent the `uniqueKey'
+    %%       field of the schema.  Thus `id' must be passed, not
+    %%       `YZ_ID_FIELD'.
+    {struct, [{id, Id}]}.
 
 encode_doc({doc, Fields}) ->
-    {struct, [{doc, lists:map(fun encode_field/1,Fields)}] };
+    {struct, [{doc, lists:map(fun encode_field/1,Fields)}]};
 
 encode_doc({doc, Boost, Fields}) ->
-	{struct, [{doc, [{boost, Boost}], lists:map(fun encode_field/1, Fields)}]}.
+    {struct, [{doc, [{boost, Boost}], lists:map(fun encode_field/1, Fields)}]}.
 
 % encode_field({Name,Value}) when is_binary(Value) ->
 %     {Name, Value};

--- a/src/yz_sup.erl
+++ b/src/yz_sup.erl
@@ -41,7 +41,7 @@ init([false]) ->
     %% Yokozuna is disabled, start a supervisor without any children.
     {ok, {{one_for_one, 5, 10}, []}};
 
-init([Enabled]) ->
+init([_Enabled]) ->
     SolrProc = {yz_solr_proc_sup,
                 {yz_solr_proc_sup, start_link, []},
                 permanent, infinity, supervisor, [yz_solr_proc_sup]},

--- a/test/yz_json_extractor_tests.erl
+++ b/test/yz_json_extractor_tests.erl
@@ -42,5 +42,5 @@ json_extract_test() ->
     ?assertEqual(length(Expect), length(Result)),
     Pairs = lists:zip(lists:sort(Expect), lists:sort(Result)),
     [?assertEqual(E,R) || {E,R} <- Pairs],
-    %% Verify XML conversion doesn't error
+    %% Verify conversion doesn't error
     ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).


### PR DESCRIPTION
Currently the `yz_kv:index` code uses two separate requests to a) cleanup siblings and b) index latest data.  This can be done in one request.
- Verify that the Solr XML/JSON update code performs operations in the order given.  If this doesn't hold true then 2 requests must be used to enforce correct ordering.
- Run a benchmark to compare 2 requests vs. 1 request and verify no regression (ideally, it should help performance).

I already have a branch for this code but it was written against Yokozuna when it still used XML update.  It needs to be updated for the latest.

https://github.com/rzezeski/yokozuna/tree/combine-index-and-del
