### PR TITLE
Serialize index creation through claimant

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -47,7 +47,7 @@ create(Name) ->
 %%
 %% NOTE: All create requests are serialized through the claimant node
 %%       to avoid races between disjoint nodes.  If the claimant is
-%%       down not indexes may be created.
+%%       down no indexes may be created.
 -spec create(string(), schema_name()) -> ok |
                                          {error, schema_not_found} |
                                          {error, {rpc_fail, node(), term()}}.

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -28,6 +28,16 @@
 %%% API
 %%%===================================================================
 
+%% @doc Extract the `Claimant' from the `Ring'.
+-spec get_claimant(ring()) -> Claimant::node().
+get_claimant(Ring) ->
+    riak_core_ring:claimant(Ring).
+
+%% @doc Check if the given `Node' is the claimant according to `Ring'.
+-spec is_claimant(ring(), node()) -> boolean().
+is_claimant(Ring, Node) ->
+    Node == get_claimant(Ring).
+
 %% @doc Add list of webmachine routes to the router.
 add_routes(Routes) ->
     [webmachine_router:add_route(R) || R <- Routes].


### PR DESCRIPTION
If index creation events are executed on disjoint nodes in a tight enough time span then the operations can create data races on the ring and false removal events can be generated by the `yz_events` delta logic.  Rather than try to get clever and allow concurrent operations instead serialize all index operations through the claimant.  This means that index creation/removal cannot be performed if the claimant is down, but avoids the data race.
