### PR TITLE
Avoid HTTP and PB conflicts with Riak Search

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -118,6 +118,8 @@
 -define(YZ_ERR_QUERY_FAILURE,
         "Query unsuccessful check the logs.").
 
+-define(RS_SVC, riak_search).
+
 %%%===================================================================
 %%% Anti Entropy
 %%%===================================================================

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -53,7 +53,18 @@ maybe_setup(true, SupPid) ->
     Routes = yz_wm_search:routes() ++ yz_wm_extract:routes() ++
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
-    ok = riak_api_pb_service:register(?SERVICES),
+    maybe_register_pb(),
     riak_core_node_watcher:service_up(yokozuna, SupPid),
     ok.
+
+%% @doc Conditionally register PB service IFF Riak Search is not
+%%      enabled.
+-spec maybe_register_pb() -> ok.
+maybe_register_pb() ->
+    case yz_misc:is_riak_search_enabled() of
+        false ->
+            ok = riak_api_pb_service:register(?SERVICES);
+        true ->
+            ok
+    end.
 

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -28,6 +28,11 @@
 %%% API
 %%%===================================================================
 
+%% @doc Determine if Riak Search is enabled.
+-spec is_riak_search_enabled() -> boolean().
+is_riak_search_enabled() ->
+    app_helper:get_env(?RS_SVC, enabled, false).
+
 %% @doc Add list of webmachine routes to the router.
 add_routes(Routes) ->
     [webmachine_router:add_route(R) || R <- Routes].

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -29,9 +29,15 @@
 %%%===================================================================
 
 %% @doc Return the list of routes provided by this resource.
+-spec routes() -> [tuple()].
 routes() ->
-    [{["solr", index, "select"], ?MODULE, []},
-     {["search", index], ?MODULE, []}].
+    Routes1 = [{["search", index], ?MODULE, []}],
+    case yz_misc:is_riak_search_enabled() of
+        false ->
+            [{["solr", index, "select"], ?MODULE, []}|Routes1];
+        true ->
+            Routes1
+    end.
 
 
 %%%===================================================================


### PR DESCRIPTION
When both Riak Search and Yokozuna are enabled Yokozuna should yield the original Riak Search service endpoints to Riak Search.  This way during rolling upgrades Riak Search can continue handling requests.  Eventually a switch will be added that will tell Yokozuna to take over all query handling so a user can switch from one to the other after they are convinced a successful migration has been performed.
