### PR TITLE
Add map-reduce support

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -30,6 +30,7 @@
 -type proplist() :: proplists:proplist().
 -type ring() :: riak_core_ring:riak_core_ring().
 -type timestamp() :: erlang:timestamp().
+-type pipe() :: riak_pipe:pipe().
 
 -type index_set() :: ordset(index_name()).
 -type base64() :: binary().

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,8 @@
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v3.0.4"}}},
   {riak_kv, ".*",
    {git, "git://github.com/basho/riak_kv", {branch, "yz-merge-1.3.0"}}},
+  {kvc, ".*",
+   {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {rebar_vsn_plugin, "",
    {git, "git://github.com/erlware/rebar_vsn_plugin.git",
     {tag, "master"}}},

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -47,7 +47,8 @@ confirm() ->
     yz_rt:wait_for_joins(Cluster),
     verify_index_add(Cluster, YZBenchDir),
     verify_index_remove(Cluster),
-    verify_many_to_one_index_remove(Cluster).
+    verify_many_to_one_index_remove(Cluster),
+    pass.
 
 %% @doc When an index is associated the indexes for the bucket should
 %%      be removed from the default index and AAE should re-index

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -92,7 +92,7 @@ search(HP, Index, Term) ->
 
 verify_count(Expected, Resp) ->
     Struct = mochijson2:decode(Resp),
-    NumFound = yz_driver:get_path(Struct, [<<"response">>, <<"numFound">>]),
+    NumFound = kvc:path([<<"response">>, <<"numFound">>], Struct),
     Expected == NumFound.
 
 store_and_search(Cluster, Bucket, CT, Body, Search) ->

--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -1,0 +1,90 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc Test Yokozuna's map/reduce integration.
+-module(yz_mapreduce).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-include("yokozuna.hrl").
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+
+-type host() :: string().
+-type portnum() :: integer().
+
+-define(CFG,
+        [{riak_core,
+          [
+           {ring_creation_size, 16}
+          ]},
+         {riak_kv,
+          [
+           %% make handoff happen faster
+           {handoff_concurrency, 16},
+           {inactivity_timeout, 2000}
+          ]},
+         {yokozuna,
+          [
+	   {enabled, true}
+          ]}
+        ]).
+
+-spec confirm() -> pass.
+confirm() ->
+    Index = "mr_index",
+    random:seed(now()),
+    Cluster = rt:build_cluster(4, ?CFG),
+    yz_rt:create_index(yz_rt:select_random(Cluster), Index),
+    yz_rt:set_index(yz_rt:select_random(Cluster), list_to_binary(Index)),
+    yz_rt:wait_for_index(Cluster, Index),
+    write_100_objs(Cluster, Index),
+    verify_100_objs_mr(Cluster, Index),
+    pass.
+
+-spec verify_100_objs_mr(list(), string()) -> ok.
+verify_100_objs_mr(Cluster, Index) ->
+    MakeTick = [{map, [{language, <<"javascript">>},
+                       {keep, false},
+                       {source, <<"function(v) { return [1]; }">>}]}],
+    ReduceSum = [{reduce, [{language, <<"javascript">>},
+                           {keep, true},
+                           {name, <<"Riak.reduceSum">>}]}],
+    MR = [{inputs, [{module, <<"yokozuna">>},
+                    {function, <<"mapred_search">>},
+                    {arg, [list_to_binary(Index), <<"name_s:yokozuna">>]}]},
+          {'query', [MakeTick, ReduceSum]}],
+    F = fun(Node) ->
+                HP = hd(yz_rt:host_entries(rt:connection_info([Node]))),
+                R = http_mr(HP, MR),
+                100 == hd(mochijson2:decode(R))
+        end,
+    yz_rt:wait_until(Cluster, F).
+
+-spec write_100_objs([node()], index_name()) -> ok.
+write_100_objs(Cluster, Index) ->
+    lager:info("Writing 100 objects"),
+    lists:foreach(write_obj(Cluster, Index), lists:seq(1,100)).
+
+-spec write_obj([node()], index_name()) -> fun().
+write_obj(Cluster, Index) ->
+    fun(N) ->
+            PL = [{name_s,<<"yokozuna">>}, {num_i,N}],
+            Key = list_to_binary(io_lib:format("key_~B", [N])),
+            Body = mochijson2:encode(PL),
+            HP = yz_rt:select_random(yz_rt:host_entries(rt:connection_info(Cluster))),
+            CT = "application/json",
+            lager:info("Writing object with bkey ~p [~p]", [{Index,Key}, HP]),
+            yz_rt:http_put(HP, list_to_binary(Index), Key, CT, Body)
+    end.
+
+-spec http_mr({host(), portnum()}, term()) -> binary().
+http_mr({Host,Port}, MR) ->
+    lager:info("Running map-reduce job [~p]", [{Host,Port}]),
+    URL = ?FMT("http://~s:~s/mapred", [Host, integer_to_list(Port)]),
+    Opts = [],
+    Headers = [{"content-type", "application/json"}],
+    Body = mochijson2:encode(MR),
+    {ok, "200", _, RBody} = ibrowse:send_req(URL, Headers, post, Body, Opts),
+    RBody.

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -31,7 +31,7 @@ create_index(Node, Index, SchemaName) ->
 
 get_count(Resp) ->
     Struct = mochijson2:decode(Resp),
-    yz_driver:get_path(Struct, [<<"response">>, <<"numFound">>]).
+    kvc:path([<<"response">>, <<"numFound">>], Struct).
 
 -spec get_yz_conn_info(node()) -> {string(), string()}.
 get_yz_conn_info(Node) ->

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -81,7 +81,7 @@ partition_list(Index) ->
     Resp = yz_solr:partition_list(Index),
     Struct = mochijson2:decode(Resp),
     Path = [<<"facet_counts">>, <<"facet_fields">>, ?YZ_PN_FIELD_B],
-    Facets = yz_solr:get_path(Struct, Path),
+    Facets = kvc:path(Path, Struct),
     %% Facets is a list of field values followed by their
     %% corresponding count.  The `is_binary' filter is done to remove
     %% the counts and leave only the partitions.

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -17,15 +17,62 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-
 -module(yokozuna).
 -include("yokozuna.hrl").
 -compile(export_all).
 
+-type fold_fun() :: fun(([term()], Acc::term()) -> Acc::term()).
 
 %%%===================================================================
 %%% API
 %%%===================================================================
+
+%% @doc Use the results of a search as input to a map-reduce job.
+%%
+%% `Pipe' - Reference to the Riak Pipe job responsible for running the
+%%   map/reduce job.
+%%
+%% `Index' - The name of the index to run the search against.
+%%
+%% `Query' - The query to run.
+%%
+%% `Filter' - The filter query to run.  This is passed as a filter
+%%   query (fq) to Solr meaning it doesn't affect scoring and may be
+%%   cached by Solr if caching is enabled.
+%%
+%% `Timeout' - This parameter is ignored.  It is only here for
+%%   backwards compatibility.
+%%
+%% TODO: The `Timeout' parameter is meant to act as a timeout for the
+%%   entire job.  However, this timeout should be tracked by the
+%%   process making the map/reduce request.  Accoding to Bryan Fink
+%%   both PB and HTTP already keep track of the timeout and teardown
+%%   the job if the limit is reached.  Rather than keep track of this
+%%   timeout in multiple places, potentially causing weird runtime
+%%   issues when the timeout is reached, Yokozuna chooses to ignore it
+%%   for now and assume an upstream process is dealing with it.  This
+%%   timeout value should be revisited in the future and see if it
+%%   can't be removed from the API completely.
+-spec mapred_search(pipe(), [term()], pos_integer()) -> ok.
+mapred_search(Pipe, [Index, Query], _Timeout) ->
+    mapred_search(Pipe, [Index, Query, <<"">>], _Timeout);
+mapred_search(Pipe, [Index, Query, Filter], _Timeout) ->
+    Index2 = case is_binary(Index) of
+                 false -> Index;
+                 true -> binary_to_list(Index)
+             end,
+    %% Function to convert `search_fold' results into pipe format.
+    Q = fun({Bucket,Key,Props}) ->
+                riak_pipe:queue_work(Pipe, {{Bucket, Key}, {struct, Props}})
+        end,
+    F = fun(Results, Acc) ->
+                %% TODO: is there a way to send a batch of results?
+                %% Avoiding the `foreach` would be nice.
+                lists:foreach(Q, Results),
+                Acc
+        end,
+    ok = search_fold(Index2, Query, Filter, F, ok),
+    riak_pipe:eoi(Pipe).
 
 %% @doc Return the set of unique logical partitions stored on this
 %%      node for the given `Index'.
@@ -41,12 +88,44 @@ partition_list(Index) ->
     Partitions = lists:filter(fun erlang:is_binary/1, Facets),
     ordsets:from_list([?BIN_TO_INT(P) || P <- Partitions]).
 
+%% @doc Executing a search folding over the results executing the
+%%      function `F' for each result.
+%%
+%% `Index' - The index to search.
+%%
+%% `Query' - The query to run.
+%%
+%% `Filter' - The filter to use.  This will be passed as a filter
+%%   query (fq) to Solr meaning it doesn't affect scoring and the
+%%   result may be cached for future use.
+%%
+%% `F' - The fold function which must be a two-arity.  The first
+%%   argument is a list of results.  The second is the accumulator
+%%   `Acc'.
+%%
+%% `Acc' - The initial value of the accumulator.  It may be any
+%%   arbitrary Erlang term.
+-spec search_fold(index_name(), binary(), binary(), fold_fun(), T::term()) ->
+                         T::term().
+search_fold(Index, Query, Filter, F, Acc) ->
+    Start = 0,
+    Params = [{q, Query},
+              {fq, Filter},
+              {start, Start},
+              {rows, 10},
+              {fl, <<?YZ_RB_FIELD_S,",",?YZ_RK_FIELD_S>>},
+              {omitHeader, <<"true">>},
+              {wt, <<"json">>}],
+    Mapping = yz_events:get_mapping(),
+    {_, Body} = yz_solr:dist_search(Index, Params, Mapping),
+    E = extract_results(Body),
+    search_fold(E, Start, Params, Mapping, Index, Query, Filter, F, Acc).
+
 search(Index, Query, Mapping) ->
     yz_solr:dist_search(Index, [{q, Query}], Mapping).
 
 solr_port(Node, Ports) ->
     proplists:get_value(Node, Ports).
-
 
 %% @doc get an associated flag, true if some action
 %%      (eg indexing, searching) should be supressed
@@ -65,3 +144,45 @@ noop_flag(index, Switch) ->
 noop_flag(search, Switch) ->
     ?INFO("Ability to search yokozuna has been changed to ~s", [Switch]),
     application:set_env(?YZ_APP_NAME, search_noop, Switch).
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+%% @private
+%%
+%% @doc Extract the bucket/key results from the `Body' of a search
+%%      result.
+-spec extract_results(binary()) -> [{binary(),binary(),[term()]}].
+extract_results(Body) ->
+    Obj = mochijson2:decode(Body),
+    Docs = kvc:path([<<"response">>, <<"docs">>], Obj),
+    %% N.B. This ugly hack is required because as far as I can tell
+    %% there is not defined order of the fields inside the results
+    %% returned by Solr.
+    [begin
+         case {X,Y} of
+             {{?YZ_RB_FIELD_B,B}, {?YZ_RK_FIELD_B,K}} ->
+                 {B,K,[]};
+             {{_,K},{_,B}} ->
+                 {B,K,[]}
+         end
+     end|| {struct,[X,Y]} <- Docs].
+
+%% @private
+%%
+%% @doc This is the interal part of `search_fold' where the actual
+%%      iteration happens.
+-spec search_fold(list(), non_neg_integer(), list(), list(), index_name(),
+                  binary(), binary(), fold_fun(), Acc::term()) ->
+                         Acc::term().
+search_fold([], _, _, _, _, _, _, _, Acc) ->
+    Acc;
+search_fold(Results, Start, Params, Mapping, Index, Query, Filter, F, Acc) ->
+    F(Results, Acc),
+    Start2 = Start + 10,
+    Params2 = lists:keystore(start, 1, Params, {start, Start2}),
+    {_, Body} = yz_solr:dist_search(Index, Params2, Mapping),
+    E = extract_results(Body),
+    search_fold(E, Start2, Params, Mapping, Index, Query, Filter, F, Acc).
+

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -280,7 +280,7 @@ sync_added(Bucket) ->
     case yz_solr:search(?YZ_DEFAULT_INDEX, [], Params) of
         {_, Resp} ->
             Struct = mochijson2:decode(Resp),
-            NumFound = yz_solr:get_path(Struct, [<<"response">>, <<"numFound">>]),
+            NumFound = kvc:path([<<"response">>, <<"numFound">>], Struct),
             if NumFound > 0 ->
                     lager:info("index flag enabled for bucket ~s with existing data", [Bucket]),
                     Ops = [{'query', <<?YZ_RB_FIELD_B/binary,":",Bucket/binary>>}],

--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -67,8 +67,8 @@ process(Msg, State) ->
                         R = mochijson2:decode(Body),
                         Resp = yz_solr:get_response(R),
                         Pairs = yz_solr:get_doc_pairs(Resp),
-                        MaxScore = yz_solr:json_get_key(<<"maxScore">>, Resp),
-                        NumFound = yz_solr:json_get_key(<<"numFound">>, Resp),
+                        MaxScore = kvc:path([<<"maxScore">>], Resp),
+                        NumFound = kvc:path([<<"numFound">>], Resp),
 
                         RPBResp = #rpbsearchqueryresp{
                             docs = [encode_doc(Doc) || Doc <- Pairs],


### PR DESCRIPTION
Add ability to use Yokozuna query as input for map-reduce job.
- Add a `mapred_search/3` API used to run map-reduce jobs with query
  results generating bucket/key pairs as input.
- Add a `search_fold/5` API used to fold over all results matching a
  query.  Thus, if a query has 143 matches all 143 will be iterated
  and fed to the fold function `F` passed as argument.
- Add a test to verify map-reduce support works.  It writes 100
  objects and runs a map-reduce job whose query matches all 100
  objects.  The job sums the number of objects matched and verifies
  that the value is 100.
- Added the KVC repo as a dependency.  It allows convenient extraction
  of proplists and mochijson structures.
- The `Timeout` parameter to `mapred_search` is ignored.  According to
  Bryan Fink this timeout is for the duration of the entire job, not
  per-batch (which is what Riak Search is using it for).  He also
  mentioned the existing endpoints such as PB and HTTP already enforce
  this timeout and it probably doesn't make sense to also track it in
  Yokozuna.  I think this makes sense because if Yokozuna also tracked
  it then what happens when both systems decide to deal with the
  timeout and kill various processes?  I imagine that could cause
  other complications.  In the future this parameter should be looked
  at carefully and potentially removed from this part of the
  map-reduce system completely.
- Yokozuna feeds results into pipe/map-reduce one at a time.  It would
  be nice to have a batch insert to save a bit of work.
- Yokozuna doesn't return positions and score in the `KeyData` but
  instead passes a hard-coded empty list (`[]`).  Passing in positions
  is expensive and not guaranteed to be available for every field in
  Yokozuna.  I'm not sure if anyone was actually using this key data
  so I opted to hard-code it to an empty list for now.
- The `search_fold` iteration is hard-coded to batches of 10.  In the
  future this should be configurable and benchmarked.
