### PR TITLE
Fix wrong treatment of fields in case of unicode strings.

### DIFF
--- a/src/yz_xml_extractor.erl
+++ b/src/yz_xml_extractor.erl
@@ -97,7 +97,7 @@ make_attr_fields(_BaseName, [], Fields) ->
 make_attr_fields(BaseName, [{_Uri, _Prefix, AttrName, Value}|Attrs], Fields) ->
     AttrNameB = list_to_binary(AttrName),
     FieldName = <<BaseName/binary,$@,AttrNameB/binary>>,
-    Field = {FieldName, Value},
+    Field = {FieldName, unicode:characters_to_binary(Value)},
     make_attr_fields(BaseName, Attrs, [Field | Fields]).
 
 make_name(Seperator, Stack) ->


### PR DESCRIPTION
This patch fixes error when xml_extractor parses an attribute with unicode.

Example:

```
<page>
  <title foobar="漢字" />
</page>
```

Error log:

```
2013-07-11 11:34:02.976 [error] <0.1275.0>@yz_kv:index:168 failed to index object {<<"wikipedia">>,<<"0_3">>} with error badarg because [{erlang,list_to_binary,[[28450,23383]],[]},{yz_solr,encode_field,1,[{file,"src/yz_solr.erl"},{line,304}]},{lists,map,2,[{file,"lists.erl"},{line,1173}]},{yz_solr,encode_doc,1,[{file,"src/yz_solr.erl"},{line,301}]},{yz_solr,'-index/3-lc$^0/1-0-',1,[{file,"src/yz_solr.erl"},{line,156}]},{yz_solr,index,3,[{file,"src/yz_solr.erl"},{line,156}]},{yz_kv,index,8,[{file,"src/yz_kv.erl"},{line,163}]},{riak_kv_vnode,perform_put,3,[{file,"src/riak_kv_vnode.erl"},{line,906}]}]
```
