### PR TITLE
Extractor UTF8 tests (plus fixes to XML extractor)

### DIFF
--- a/src/yz_xml_extractor.erl
+++ b/src/yz_xml_extractor.erl
@@ -95,7 +95,7 @@ sax_cb(_Event, _Location, State) ->
 make_attr_fields(_BaseName, [], Fields) ->
     Fields;
 make_attr_fields(BaseName, [{_Uri, _Prefix, AttrName, Value}|Attrs], Fields) ->
-    AttrNameB = list_to_binary(AttrName),
+    AttrNameB = unicode:characters_to_binary(AttrName),
     FieldName = <<BaseName/binary,$@,AttrNameB/binary>>,
     Field = {FieldName, unicode:characters_to_binary(Value)},
     make_attr_fields(BaseName, Attrs, [Field | Fields]).
@@ -106,12 +106,12 @@ make_name(Seperator, Stack) ->
 %% Make a name from a stack of visted tags (innermost tag at head of list)
 -spec make_name(binary(), [string()], binary()) -> binary().
 make_name(Seperator, [Inner,Outter|Rest], Name) ->
-    OutterB = list_to_binary(Outter),
-    InnerB = list_to_binary(Inner),
+    OutterB = unicode:characters_to_binary(Outter),
+    InnerB = unicode:characters_to_binary(Inner),
     Name2 = <<OutterB/binary,Seperator/binary,InnerB/binary,Name/binary>>,
     make_name(Seperator, Rest, Name2);
 make_name(Seperator, [Outter], Name) ->
-    OutterB = list_to_binary(Outter),
+    OutterB = unicode:characters_to_binary(Outter),
     case Name of
         <<>> -> OutterB;
         _ -> <<OutterB/binary,Seperator/binary,Name/binary>>

--- a/test/utf8.json
+++ b/test/utf8.json
@@ -1,0 +1,49 @@
+{"langs":
+ {"english": "The quick brown fox jumps over the lazy dog.",
+  "jamaican": "Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?",
+  "irish": "\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"",
+  "dutch": "Pa's wĳze lynx bezag vroom het fikse aquaduct.",
+  "german_1": "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.",
+  "german_2": "Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.",
+  "norwegian": "Blåbærsyltetøy.",
+  "danish": "Høj bly gom vandt fræk sexquiz på wc.",
+  "swedish": "Flygande bäckasiner söka strax hwila på mjuka tuvor.",
+  "icelandic": "Sævör grét áðan því úlpan var ónýt.",
+  "finnish": "Törkylempijävongahdus.",
+  "polish": "Pchnąć w tę łódź jeża lub osiem skrzyń fig.",
+  "czech": "Příliš žluťoučký kůň úpěl ďábelské kódy.",
+  "slovak": "Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.",
+  "greek_monotonic": "ξεσκεπάζω την ψυχοφθόρα βδελυγμία",
+  "greek_polytonic": "ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία",
+  "russian": "Съешь же ещё этих мягких французских булок да выпей чаю.",
+  "bulgarian": "Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.",
+  "sami": "Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.",
+  "hungarian": "Árvíztűrő tükörfúrógép.",
+  "spanish": "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.",
+  "portuguese": "O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.",
+  "french": "Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.",
+  "esperanto": "Eĥoŝanĝo ĉiuĵaŭde.",
+  "hebrew": "זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.",
+  "japanese_hiragana": "
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+  ",
+  "japanese_kanji": "
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+  ",
+  "английский": "The quick brown fox jumps over the lazy dog.",
+  "chinese": "
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处
+  "
+ }
+}

--- a/test/utf8.txt
+++ b/test/utf8.txt
@@ -1,0 +1,43 @@
+english: The quick brown fox jumps over the lazy dog.
+jamaican: Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?
+irish: "An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?" "D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ."
+dutch: Pa's wĳze lynx bezag vroom het fikse aquaduct.
+german_1: Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.
+german_2: Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.
+norwegian: Blåbærsyltetøy.
+danish: Høj bly gom vandt fræk sexquiz på wc.
+swedish: Flygande bäckasiner söka strax hwila på mjuka tuvor.
+icelandic: Sævör grét áðan því úlpan var ónýt.
+finnish: Törkylempijävongahdus.
+polish: Pchnąć w tę łódź jeża lub osiem skrzyń fig.
+czech: Příliš žluťoučký kůň úpěl ďábelské kódy.
+slovak: Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.
+greek_monotonic: ξεσκεπάζω την ψυχοφθόρα βδελυγμία
+greek_polytonic: ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία
+russian: Съешь же ещё этих мягких французских булок да выпей чаю.
+bulgarian: Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.
+sami: Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.
+hungarian: Árvíztűrő tükörfúrógép.
+spanish: El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.
+portuguese: O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.
+french: Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.
+esperanto: Eĥoŝanĝo ĉiuĵaŭde.
+hebrew: זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.
+japanese_hiragana:
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+japanese_kanji:
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+английский: The quick brown fox jumps over the lazy dog.
+chinese:
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处

--- a/test/utf8.xml
+++ b/test/utf8.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding='UTF-8'?>
+
+<!-- Example text pulled from http://www.columbia.edu/~fdc/utf8/index.html#notes -->
+<langs>
+  <english attr="The quick">The quick brown fox jumps over the lazy dog.</english>
+  <jamaican>Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?</jamaican>
+  <irish>"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?" "D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ."</irish>
+  <dutch>Pa's wĳze lynx bezag vroom het fikse aquaduct.</dutch>
+  <german_1 attr="Falsches Üben">Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.</german_1>
+  <german_2>Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.</german_2>
+  <norwegian>Blåbærsyltetøy.</norwegian>
+  <danish>Høj bly gom vandt fræk sexquiz på wc.</danish>
+  <swedish>Flygande bäckasiner söka strax hwila på mjuka tuvor.</swedish>
+  <icelandic>Sævör grét áðan því úlpan var ónýt.</icelandic>
+  <finnish>Törkylempijävongahdus.</finnish>
+  <polish>Pchnąć w tę łódź jeża lub osiem skrzyń fig.</polish>
+  <czech>Příliš žluťoučký kůň úpěl ďábelské kódy.</czech>
+  <slovak>Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.</slovak>
+  <greek_monotonic>ξεσκεπάζω την ψυχοφθόρα βδελυγμία</greek_monotonic>
+  <greek_polytonic>ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία</greek_polytonic>
+  <russian>Съешь же ещё этих мягких французских булок да выпей чаю.</russian>
+  <bulgarian>Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.</bulgarian>
+  <sami>Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.</sami>
+  <hungarian>Árvíztűrő tükörfúrógép.</hungarian>
+  <spanish>El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.</spanish>
+  <portuguese>O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.</portuguese>
+  <french>Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.</french>
+  <esperanto>Eĥoŝanĝo ĉiuĵaŭde.</esperanto>
+  <hebrew>זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.</hebrew>
+  <japanese_hiragana>
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+  </japanese_hiragana>
+  <japanese_kanji>
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+  </japanese_kanji>
+  <английский>The quick brown fox jumps over the lazy dog.</английский>
+  <chinese 作者="Bai Juyi" title="The Bloom is not a Bloom">
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处
+  </chinese>
+</langs>

--- a/test/yz_json_extractor_tests.erl
+++ b/test/yz_json_extractor_tests.erl
@@ -1,20 +1,6 @@
 -module(yz_json_extractor_tests).
 -compile(export_all).
-
--include_lib("eunit/include/eunit.hrl").
-
--define(STACK_IF_FAIL(Expr),
-        ?IF(try
-                Expr, true
-            catch _:_ ->
-                    false
-            end,
-            ok,
-            begin
-                Trace = erlang:get_stacktrace(),
-                ?debugFmt("~n~p failed: ~p~n", [??Expr, Trace]),
-                throw({expression_failed, ??Expr})
-            end)).
+-include_lib("yz_test.hrl").
 
 json_extract_test() ->
     {ok, TestJSON} = file:read_file("../test/test.json"),
@@ -43,4 +29,66 @@ json_extract_test() ->
     Pairs = lists:zip(lists:sort(Expect), lists:sort(Result)),
     [?assertEqual(E,R) || {E,R} <- Pairs],
     %% Verify conversion doesn't error
+    ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).
+
+utf8_test() ->
+    {ok, JSON} = file:read_file("../test/utf8.json"),
+    Result = yz_json_extractor:extract(JSON),
+    case Result of
+        {error, Reason} ->
+            ?debugFmt("~nextract/1 failed: ~s~n", [Reason]),
+            throw(extract_failed);
+        _ ->
+            ok
+    end,
+    Expect =
+        [{<<"langs_english">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs_jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
+         {<<"langs_irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
+         {<<"langs_dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
+         {<<"langs_german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
+         {<<"langs_german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
+         {<<"langs_norwegian">>, <<"Blåbærsyltetøy.">>},
+         {<<"langs_danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
+         {<<"langs_swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
+         {<<"langs_icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
+         {<<"langs_finnish">>, <<"Törkylempijävongahdus.">>},
+         {<<"langs_polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
+         {<<"langs_czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
+         {<<"langs_slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
+         {<<"langs_greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
+         {<<"langs_greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
+         {<<"langs_russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
+         {<<"langs_bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
+         {<<"langs_sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
+         {<<"langs_hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
+         {<<"langs_spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
+         {<<"langs_portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
+         {<<"langs_french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
+         {<<"langs_esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
+         {<<"langs_hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
+         {<<"langs_japanese_hiragana">>, <<"
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+  ">>},
+        {<<"langs_japanese_kanji">>, <<"
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+  ">>},
+         {<<"langs_английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs_chinese">>, <<"
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处
+  ">>}],
+    ?assertEqual(length(Expect), length(Result)),
+    Pairs = lists:zip(lists:keysort(1, Expect), lists:keysort(1, Result)),
+    [?assertPairsEq(E,R) || {E,R} <- Pairs],
     ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).

--- a/test/yz_test.hrl
+++ b/test/yz_test.hrl
@@ -1,0 +1,31 @@
+%% Macros and functions to shared across tests.
+-include_lib("eunit/include/eunit.hrl").
+
+-define(STACK_IF_FAIL(Expr),
+        ?IF(try
+                Expr, true
+            catch _:_ ->
+                    false
+            end,
+            ok,
+            begin
+                Trace = erlang:get_stacktrace(),
+                ?debugFmt("~n~p failed: ~p~n", [??Expr, Trace]),
+                throw({expression_failed, ??Expr})
+            end)).
+
+%% A replacement for ?assertEqual that prints the entire binary so
+%% that bytes can be compared in case of mismatch.
+-define(assertPairsEq(S1,S2),
+        ?IF(begin
+                ?assertEqual(element(1, S1), element(1, S2)),
+                element(2, S1) =:= element(2, S2)
+            end,
+            ok,
+            begin
+                Field = element(1, S1),
+                ?debugFmt("~nfields not equal: ~s~n", [Field]),
+                ?debugFmt("expected: ~p~n", [element(2,S1)]),
+                ?debugFmt("actual: ~p~n", [element(2,S2)]),
+                throw(pairs_not_equal)
+            end)).

--- a/test/yz_text_extractor_tests.erl
+++ b/test/yz_text_extractor_tests.erl
@@ -1,0 +1,63 @@
+-module(yz_text_extractor_tests).
+-compile(export_all).
+-include_lib("yz_test.hrl").
+
+-define(UTF8_EXPECT,
+    <<"english: The quick brown fox jumps over the lazy dog.
+jamaican: Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?
+irish: \"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"
+dutch: Pa's wĳze lynx bezag vroom het fikse aquaduct.
+german_1: Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.
+german_2: Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.
+norwegian: Blåbærsyltetøy.
+danish: Høj bly gom vandt fræk sexquiz på wc.
+swedish: Flygande bäckasiner söka strax hwila på mjuka tuvor.
+icelandic: Sævör grét áðan því úlpan var ónýt.
+finnish: Törkylempijävongahdus.
+polish: Pchnąć w tę łódź jeża lub osiem skrzyń fig.
+czech: Příliš žluťoučký kůň úpěl ďábelské kódy.
+slovak: Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.
+greek_monotonic: ξεσκεπάζω την ψυχοφθόρα βδελυγμία
+greek_polytonic: ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία
+russian: Съешь же ещё этих мягких французских булок да выпей чаю.
+bulgarian: Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.
+sami: Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.
+hungarian: Árvíztűrő tükörfúrógép.
+spanish: El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.
+portuguese: O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.
+french: Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.
+esperanto: Eĥoŝanĝo ĉiuĵaŭde.
+hebrew: זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.
+japanese_hiragana:
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+japanese_kanji:
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+английский: The quick brown fox jumps over the lazy dog.
+chinese:
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处
+">>).
+
+
+utf8_test() ->
+    {ok, Txt} = file:read_file("../test/utf8.txt"),
+    Result = yz_text_extractor:extract(Txt),
+    case Result of
+        {error, Reason} ->
+            ?debugFmt("~nextract/1 failed: ~s~n", [Reason]),
+            throw(extract_failed);
+        _ ->
+            ok
+    end,
+    ?assertEqual([{text, ?UTF8_EXPECT}], Result),
+    ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -1,34 +1,6 @@
 -module(yz_xml_extractor_tests).
 -compile(export_all).
--include_lib("eunit/include/eunit.hrl").
--define(STACK_IF_FAIL(Expr),
-        ?IF(try
-                Expr, true
-            catch _:_ ->
-                    false
-            end,
-            ok,
-            begin
-                Trace = erlang:get_stacktrace(),
-                ?debugFmt("~n~p failed: ~p~n", [??Expr, Trace]),
-                throw({expression_failed, ??Expr})
-            end)).
-
-%% A replacement for ?assertEqual that prints the entire binary so
-%% that bytes can be compared in case of mismatch.
--define(assertPairsEq(S1,S2),
-        ?IF(begin
-                ?assertEqual(element(1, S1), element(1, S2)),
-                element(2, S1) =:= element(2, S2)
-            end,
-            ok,
-            begin
-                Field = element(1, S1),
-                ?debugFmt("~nfields not equal: ~s~n", [Field]),
-                ?debugFmt("expected: ~p~n", [element(2,S1)]),
-                ?debugFmt("actual: ~p~n", [element(2,S2)]),
-                throw(pairs_not_equal)
-            end)).
+-include_lib("yz_test.hrl").
 
 %% Verify that the XML extractor maintains UTF-8 encoding.
 utf8_test() ->

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -1,0 +1,98 @@
+-module(yz_xml_extractor_tests).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-define(STACK_IF_FAIL(Expr),
+        ?IF(try
+                Expr, true
+            catch _:_ ->
+                    false
+            end,
+            ok,
+            begin
+                Trace = erlang:get_stacktrace(),
+                ?debugFmt("~n~p failed: ~p~n", [??Expr, Trace]),
+                throw({expression_failed, ??Expr})
+            end)).
+
+%% A replacement for ?assertEqual that prints the entire binary so
+%% that bytes can be compared in case of mismatch.
+-define(assertPairsEq(S1,S2),
+        ?IF(begin
+                ?assertEqual(element(1, S1), element(1, S2)),
+                element(2, S1) =:= element(2, S2)
+            end,
+            ok,
+            begin
+                Field = element(1, S1),
+                ?debugFmt("~nfields not equal: ~s~n", [Field]),
+                ?debugFmt("expected: ~p~n", [element(2,S1)]),
+                ?debugFmt("actual: ~p~n", [element(2,S2)]),
+                throw(pairs_not_equal)
+            end)).
+
+%% Verify that the XML extractor maintains UTF-8 encoding.
+utf8_test() ->
+    {ok, SrcXML} = file:read_file("../test/utf8.xml"),
+    Result = yz_xml_extractor:extract(SrcXML),
+    case Result of
+        {error, Reason} ->
+            ?debugFmt("~nextract/1 failed: ~s~n", [Reason]),
+            throw(extract_failed);
+        _ ->
+            ok
+    end,
+    Expect =
+        [{<<"langs_english">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs_english@attr">>, <<"The quick">>},
+         {<<"langs_jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
+         {<<"langs_irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
+         {<<"langs_dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
+         {<<"langs_german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
+         {<<"langs_german_1@attr">>, <<"Falsches Üben">>},
+         {<<"langs_german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
+         {<<"langs_norwegian">>, <<"Blåbærsyltetøy.">>},
+         {<<"langs_danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
+         {<<"langs_swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
+         {<<"langs_icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
+         {<<"langs_finnish">>, <<"Törkylempijävongahdus.">>},
+         {<<"langs_polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
+         {<<"langs_czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
+         {<<"langs_slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
+         {<<"langs_greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
+         {<<"langs_greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
+         {<<"langs_russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
+         {<<"langs_bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
+         {<<"langs_sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
+         {<<"langs_hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
+         {<<"langs_spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
+         {<<"langs_portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
+         {<<"langs_french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
+         {<<"langs_esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
+         {<<"langs_hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
+         {<<"langs_japanese_hiragana">>, <<"
+    いろはにほへど　ちりぬるを
+    わがよたれぞ　つねならむ
+    うゐのおくやま　けふこえて
+    あさきゆめみじ　ゑひもせず
+  ">>},
+        {<<"langs_japanese_kanji">>, <<"
+    色は匂へど 散りぬるを
+    我が世誰ぞ 常ならむ
+    有為の奥山 今日越えて
+    浅き夢見じ 酔ひもせず
+  ">>},
+         {<<"langs_английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs_chinese">>, <<"
+    花非花
+    雾非雾
+    夜半来
+    天明去
+    来如春梦几多时
+    去似朝云无觅处
+  ">>},
+        {<<"langs_chinese@作者">>, <<"Bai Juyi">>},
+        {<<"langs_chinese@title">>, <<"The Bloom is not a Bloom">>}],
+    ?assertEqual(length(Expect), length(Result)),
+    Pairs = lists:zip(lists:keysort(1, Expect), lists:keysort(1, Result)),
+    [?assertPairsEq(E,R) || {E,R} <- Pairs],
+    ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).


### PR DESCRIPTION
- Add comprehensive UTF-8 verification for all three major extractors.
- Fix some areas in the XML extractor that were mangling UTF-8.
