### PR TITLE
Re-target Yokozuna to Riak 1.4.0

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -92,7 +92,7 @@ described above.
 
 Clone the Yokozuna branch of Riak.
 
-    git clone -b yz-merge-1.3.0 git://github.com/basho/riak.git
+    git clone -b rz-yz-merge-1.4.0 git://github.com/basho/riak.git
     cd riak
 
 Compile.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,7 +17,7 @@ The rest is like the [Yokozuna Getting Started][yz_gs] guide but
 checkout riak as `riak_yz`.  Don't start the cluster.  Just build the
 devrel.
 
-    git clone -b yz-merge-1.3.0 git://github.com/basho/riak.git riak_yz
+    git clone -b rz-yz-merge-1.4.0 git://github.com/basho/riak.git riak_yz
     cd riak_yz
     make stagedevrel
 

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
   {ibrowse, ".*",
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v3.0.4"}}},
   {riak_kv, ".*",
-   {git, "git://github.com/basho/riak_kv", {branch, "yz-merge-1.4.0"}}},
+   {git, "git://github.com/basho/riak_kv", {branch, "rz-yz-merge-1.4.0"}}},
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {rebar_vsn_plugin, "",

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
   {ibrowse, ".*",
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v3.0.4"}}},
   {riak_kv, ".*",
-   {git, "git://github.com/basho/riak_kv", {branch, "yz-merge-1.3.0"}}},
+   {git, "git://github.com/basho/riak_kv", {branch, "yz-merge-1.4.0"}}},
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {rebar_vsn_plugin, "",

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -85,7 +85,7 @@ test_escaped_key(Cluster) ->
     ok.
 
 http_get({Host, Port}, Bucket, Key) ->
-    URL = lists:flatten(io_lib:format("http://~s:~s/riak/~s/~s",
+    URL = lists:flatten(io_lib:format("http://~s:~s/buckets/~s/keys/~s",
                                       [Host, integer_to_list(Port), Bucket, Key])),
     Headers = [{"accept", "text/plain"}],
     {ok, "200", _, _} = ibrowse:send_req(URL, Headers, get, [], []),
@@ -148,7 +148,7 @@ test_tagging(Cluster) ->
 
 write_with_tag({Host, Port}) ->
     lager:info("Tag the object tagging/test"),
-    URL = lists:flatten(io_lib:format("http://~s:~s/riak/tagging/test",
+    URL = lists:flatten(io_lib:format("http://~s:~s/buckets/tagging/keys/test",
                                       [Host, integer_to_list(Port)])),
     Opts = [],
     Body = <<"testing tagging">>,

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -55,6 +55,8 @@ expect_bad_json(Cluster) ->
     ok = create_index(Cluster, HP, <<"bad_json">>),
     lager:info("Write bad json"),
     URL = bucket_url(HP, "bad_json", "test"),
+    lager:error("URL: ~p~n", [URL]),
+    io:fwrite("URL: ~p~n", [URL]),
     Opts = [],
     CT = "application/json",
     Headers = [{"content-type", CT}],
@@ -111,7 +113,7 @@ index_url({Host,Port}, Index) ->
     ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, Bucket, Key) ->
-    ?FMT("http://~s:~B/riak/~s/~s", [Host, Port, Bucket, Key]).
+    ?FMT("http://~s:~B/buckets/~s/keys/~s", [Host, Port, Bucket, Key]).
 
 search_url({Host,Port}, Bucket) ->
     ?FMT("http://~s:~B/search/~s", [Host, Port, Bucket]).

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -55,8 +55,6 @@ expect_bad_json(Cluster) ->
     ok = create_index(Cluster, HP, <<"bad_json">>),
     lager:info("Write bad json"),
     URL = bucket_url(HP, "bad_json", "test"),
-    lager:error("URL: ~p~n", [URL]),
-    io:fwrite("URL: ~p~n", [URL]),
     Opts = [],
     CT = "application/json",
     Headers = [{"content-type", CT}],

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -74,7 +74,7 @@ write_obj(Cluster) ->
     Node = yz_rt:select_random(Cluster),
     {Host, Port} = riak_hp(Node, Cluster),
     lager:info("write obj to node ~p", [Node]),
-    URL = ?FMT("http://~s:~s/riak/~s/~s",
+    URL = ?FMT("http://~s:~s/buckets/~s/keys/~s",
                [Host, integer_to_list(Port), ?INDEX, ?INDEX]),
     Headers = [{"content-type", "text/plain"}],
     Body = <<"yokozuna">>,

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -160,7 +160,7 @@ confirm_delete_409(Cluster, Index) ->
 %%%===================================================================
 
 bucket_url({Host, Port}, Bucket) ->
-    ?FMT("http://~s:~B/riak/~s", [Host, Port, Bucket]).
+    ?FMT("http://~s:~B/buckets/~s/props", [Host, Port, Bucket]).
 
 check_list(Indexes, Body) ->
     Decoded = mochijson2:decode(Body),

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -63,7 +63,7 @@ search_url({Host,Port}, Bucket, Term) ->
     ?FMT("http://~s:~B/search/~s?wt=json&omitHeader=true&q=~s", [Host, Port, Bucket, Term]).
 
 bucket_url({Host,Port}, Bucket, Key) ->
-    ?FMT("http://~s:~B/riak/~s/~s", [Host, Port, Bucket, Key]).
+    ?FMT("http://~s:~B/buckets/~s/keys/~s", [Host, Port, Bucket, Key]).
 
 http(Method, URL, Headers, Body) ->
     Opts = [],

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -52,7 +52,7 @@ index_url({Host,Port}, Index) ->
     ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, Bucket, Key) ->
-    ?FMT("http://~s:~B/riak/~s/~s", [Host, Port, Bucket, Key]).
+    ?FMT("http://~s:~B/buckets/~s/keys/~s", [Host, Port, Bucket, Key]).
 
 http(Method, URL, Headers, Body) ->
     Opts = [],

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -232,8 +232,7 @@ confirm_bad_ct(Cluster, Name, RawSchema) ->
     URL = schema_url(HP, Name),
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),
-    ?assertEqual("415", Status),
-    ?assertEqual(<<>>, Body).
+    ?assertEqual("415", Status).
 
 %% @doc Confirm that truncated schema fails, returning 400.
 confirm_truncated(Cluster, Name, RawSchema) ->

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -80,7 +80,7 @@ verify_reconcile(HP) ->
     ok.
 
 http_put({Host, Port}, Bucket, Key, VClock, Value) ->
-    URL = lists:flatten(io_lib:format("http://~s:~s/riak/~s/~s",
+    URL = lists:flatten(io_lib:format("http://~s:~s/buckets/~s/keys/~s",
                                       [Host, integer_to_list(Port), Bucket, Key])),
     Opts = [],
     Headers = [{"content-type", "text/plain"},
@@ -89,7 +89,7 @@ http_put({Host, Port}, Bucket, Key, VClock, Value) ->
     ok.
 
 http_get({Host, Port}, Bucket, Key) ->
-    URL = lists:flatten(io_lib:format("http://~s:~s/riak/~s/~s",
+    URL = lists:flatten(io_lib:format("http://~s:~s/buckets/~s/keys/~s",
                                       [Host, integer_to_list(Port), Bucket, Key])),
     Opts = [],
     Headers = [{"accept", "multipart/mixed"}],
@@ -112,7 +112,7 @@ index_url({Host,Port}, Index) ->
     ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, Bucket, Key) ->
-    ?FMT("http://~s:~B/riak/~s/~s", [Host, Port, Bucket, Key]).
+    ?FMT("http://~s:~B/buckets/~s/keys/~s", [Host, Port, Bucket, Key]).
 
 http(Method, URL, Headers, Body) ->
     Opts = [],

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -24,6 +24,7 @@
 -module(yz_kv).
 -compile(export_all).
 -include("yokozuna.hrl").
+-include_lib("riak_kv/include/riak_kv_vnode.hrl").
 
 -define(ONE_SECOND, 1000).
 -define(WAIT_FLAG(Index), {wait_flag, Index}).
@@ -290,7 +291,7 @@ first_partition([{Partition, _}|_]) ->
 %%
 %% @doc Get the partition from the `VNodeState'.
 get_partition(VNodeState) ->
-    riak_kv_vnode:get_state_partition(VNodeState).
+    VNodeState#riak_kv_vnode_state.idx.
 
 %% @private
 %%

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -24,7 +24,6 @@
 -module(yz_kv).
 -compile(export_all).
 -include("yokozuna.hrl").
--include_lib("riak_kv/include/riak_kv_vnode.hrl").
 
 -define(ONE_SECOND, 1000).
 -define(WAIT_FLAG(Index), {wait_flag, Index}).
@@ -291,7 +290,7 @@ first_partition([{Partition, _}|_]) ->
 %%
 %% @doc Get the partition from the `VNodeState'.
 get_partition(VNodeState) ->
-    VNodeState#riak_kv_vnode_state.idx.
+    riak_kv_vnode:get_state_partition(VNodeState).
 
 %% @private
 %%

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -234,7 +234,7 @@ sanity_check
 YZ_SRC=git://github.com/basho/yokozuna.git
 YZ_BRANCH=master
 RIAK_SRC=git://github.com/basho/riak.git
-RIAK_BRANCH=yz-merge-1.4.0
+RIAK_BRANCH=rz-yz-merge-1.4.0
 TEST_ONLY=
 
 while [ $# -gt 0 ]

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -234,7 +234,7 @@ sanity_check
 YZ_SRC=git://github.com/basho/yokozuna.git
 YZ_BRANCH=master
 RIAK_SRC=git://github.com/basho/riak.git
-RIAK_BRANCH=yz-merge-1.3.0
+RIAK_BRANCH=yz-merge-1.4.0
 TEST_ONLY=
 
 while [ $# -gt 0 ]

--- a/tools/yokozuna-ami.sh
+++ b/tools/yokozuna-ami.sh
@@ -77,7 +77,7 @@ fi
 pushd riak
 
 if [ ! -d rel/riak ]; then
-    git checkout yz-merge-1.3.0
+    git checkout rz-yz-merge-1.4.0
     make
     make stage
 fi


### PR DESCRIPTION
_This PR isn't ready to be merged_

Update yokozuna to work against the 1.4 master changes. This branch relies on:
- <del>[KV yz-merge-1.4.0 branch](https://github.com/basho/riak_kv/compare/yz-merge-1.4.0)</del>
- <del>[Riak yz-merge-1.4.0 branch](https://github.com/basho/riak/compare/yz-merge-1.4.0)</del>

NOTE: These test still fail for me
- yz_pb-bitcask
- yz_mapreduce-bitcask
- yz_flag_transitions-bitcask
