### PR TITLE
set java.awt.headless to prevent Mac dock icons

### DIFF
--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -114,6 +114,7 @@ getpid() ->
 
 -spec build_cmd(string(), string(), string()) -> {string(), [string()]}.
 build_cmd(SolrPort, SolrJMXPort, Dir) ->
+    Headless = "-Djava.awt.headless=true",
     SolrHome = "-Dsolr.solr.home=" ++ Dir,
     JettyHome = "-Djetty.home=" ++ Dir,
     Port = "-Djetty.port=" ++ SolrPort,
@@ -132,7 +133,7 @@ build_cmd(SolrPort, SolrJMXPort, Dir) ->
             JMX = [JMXPortArg, JMXAuthArg, JMXSSLArg]
     end,
 
-    Args = [JettyHome, Port, SolrHome, CP, CP2, Logging, LibDir]
+    Args = [Headless, JettyHome, Port, SolrHome, CP, CP2, Logging, LibDir]
         ++ solr_vm_args() ++ JMX ++ [Class],
     {os:find_executable("java"), Args}.
 


### PR DESCRIPTION
Java 1.6 on Mac will add an icon to the dock and app switcher for each
JVM running. When the VM starts, this "app" comes to the foreground and
steals focus.

Setting "-Djava.awt.headless=true" runs the VM in headless mode, so it
does not connect to the windowing server, and thus does not create these
artifacts.
