### PR TITLE
fix index/extractor ring modification timestamp conflicts

### DIFF
--- a/src/yz_extractor.erl
+++ b/src/yz_extractor.erl
@@ -120,20 +120,26 @@ register(MimeType, Def) ->
 -spec register(mime_type(), extractor_def(), register_opts()) ->
                       extractor_map() | already_registered.
 register(MimeType, Def, Opts) ->
-    Map = get_map(),
+    case yz_misc:set_ring_meta(?META_EXTRACTOR_MAP,
+                               ?DEFAULT_MAP,
+                               fun register_map/2,
+                               {MimeType, Def, Opts}) of
+        {ok, Ring} ->
+            get_map(Ring);
+        not_changed ->
+            already_registered
+    end.
+
+register_map(Map, {MimeType, Def, Opts}) ->
     CurrentDef = get_def(Map, MimeType, []),
     Overwrite = proplists:get_bool(overwrite, Opts),
     case {CurrentDef, Overwrite} of
         {none, _} ->
-            Map2 = orddict:store(MimeType, Def, Map),
-            yz_misc:set_ring_meta(?META_EXTRACTOR_MAP, Map2),
-            Map2;
+            orddict:store(MimeType, Def, Map);
         {_, true} ->
-            Map2 = orddict:store(MimeType, Def, Map),
-            yz_misc:set_ring_meta(?META_EXTRACTOR_MAP, Map2),
-            Map2;
+            orddict:store(MimeType, Def, Map);
         {_, false} ->
-            already_registered
+            ignore
     end.
 
 %% @doc Run the extractor def against the `Value' to produce a list of


### PR DESCRIPTION
Before this change, if two index or extractor-map changes happened within
one second, one of the modifications may be lost. This is due to the
1-second resolution in the ring's meta_entry records.

This commit solves the issue in two ways:
1. Modifications are made inside the ring_trans call, to the ring passed
   into the function. The had been made in an always-clobber manner before.
2. The function sleeps for one second to ensure that the update will have
   a newer timestamp.

The second point is not the greatest because it blocks other calls to
the riak_core_ring_manager process for that second. Reads are not blocked,
since they look at an ETS table instead. An intermediate serialization+wait
process could be used instead if the temporary block causes major problems.
