### PR TITLE
Fix field name creation in XML extractor

### DIFF
--- a/src/yz_xml_extractor.erl
+++ b/src/yz_xml_extractor.erl
@@ -108,7 +108,7 @@ make_name(Seperator, Stack) ->
 make_name(Seperator, [Inner,Outter|Rest], Name) ->
     OutterB = unicode:characters_to_binary(Outter),
     InnerB = unicode:characters_to_binary(Inner),
-    Name2 = <<OutterB/binary,Seperator/binary,InnerB/binary,Name/binary>>,
+    Name2 = concat(OutterB, Seperator, InnerB, Name),
     make_name(Seperator, Rest, Name2);
 make_name(Seperator, [Outter], Name) ->
     OutterB = unicode:characters_to_binary(Outter),
@@ -123,3 +123,9 @@ parsing_error({_, _, Line}, Reason) ->
     Msg = io_lib:format("failure parsing XML at line ~w with reason \"~s\"",
                         [Line, Reason]),
     {error, Msg}.
+
+-spec concat(binary(), binary(), binary(), binary()) -> binary().
+concat(Outter, Sep, Inner, <<>>) ->
+    <<Outter/binary,Sep/binary,Inner/binary>>;
+concat(Outter, Sep, Inner, Current) ->
+    <<Outter/binary,Sep/binary,Inner/binary,Sep/binary,Current/binary>>.

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -2,6 +2,17 @@
 -compile(export_all).
 -include_lib("yz_test.hrl").
 
+make_name_test() ->
+    Expect = <<"one_two_three_four">>,
+    Stack = ["four", "three", "two", "one"],
+    Result = yz_xml_extractor:make_name(<<"_">>, Stack),
+    ?assertEqual(Expect, Result),
+
+    Expect2 = <<"one_two_three_four_five">>,
+    Stack2 = ["five", "four", "three", "two", "one"],
+    Result2 = yz_xml_extractor:make_name(<<"_">>, Stack2),
+    ?assertEqual(Expect2, Result2).
+
 %% Verify that the XML extractor maintains UTF-8 encoding.
 utf8_test() ->
     {ok, SrcXML} = file:read_file("../test/utf8.xml"),


### PR DESCRIPTION
Fix the field name creation when there are an even number of elements
in the name stack.

e.g.

```
<one>
  <two>
    <three>
      <four>
      </four>
    </three>
  </two>
</one>
```

Should generate `one_two_three_four` not `one_twothree_four` as it did
up until this patch.
