### PR TITLE
Add Administration Support to PB

### DIFF
--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -2,6 +2,9 @@
 -module(yz_pb).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
+-include("yokozuna.hrl").
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
@@ -13,6 +16,7 @@ confirm() ->
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = prepare_cluster(4),
+    confirm_admin_index(Cluster),
     confirm_basic_search(Cluster),
     confirm_encoded_search(Cluster),
     confirm_multivalued_field(Cluster),
@@ -22,7 +26,7 @@ confirm() ->
 prepare_cluster(NumNodes) ->
     Nodes = rt:deploy_nodes(NumNodes, ?CFG),
     Cluster = join(Nodes),
-    wait_for_joins(Cluster),
+    yz_rt:wait_for_joins(Cluster),
     rt:wait_for_cluster_service(Cluster, yokozuna),
     Cluster.
 
@@ -30,12 +34,6 @@ join(Nodes) ->
     [NodeA|Others] = Nodes,
     [rt:join(Node, NodeA) || Node <- Others],
     Nodes.
-
-%% TODO: replace with rt:wait_for_joins
-wait_for_joins(Cluster) ->
-    lager:info("Waiting for ownership handoff to finish"),
-    rt:wait_until_nodes_ready(Cluster),
-    rt:wait_until_no_pending_changes(Cluster).
 
 select_random(List) ->
     Length = length(List),
@@ -58,47 +56,91 @@ http(Method, URL, Headers, Body) ->
     Opts = [],
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
-create_index(Cluster, Index) ->
-    HP = select_random(host_entries(rt:connection_info(Cluster))),
-    lager:info("create_index ~s [~p]", [Index, HP]),
-    URL = index_url(HP, Index),
-    Headers = [{"content-type", "application/json"}],
-    {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
-    yz_rt:set_index(hd(Cluster), Index),
-    timer:sleep(5000),
-    ?assertEqual("204", Status).
+create_index(Cluster, Index, Bucket) ->
+    Node = select_random(Cluster),
+    [{Host, Port}] = host_entries(rt:connection_info([Node])),
+    lager:info("create_index ~s for bucket ~s [~p]", [Index, Bucket, {Host, Port}]),
+    {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
+    F = fun(_) ->
+            %% set index in props with the same name as the bucket
+            Idx     = #rpbyokozunaindex{name = Index},
+            PutReq  = #rpbyokozunaindexputreq{index = Idx},
+            PutResp = gen_server:call(Pid, {req, PutReq, infinity}, infinity),
+            %% There is currently no admin driver impl in the erlang client
+            %% so capture the process_response error and check the reply
+            {error,{unknown_response,_,PutRespMsg}} = PutResp,
+            ?assertEqual(rpbputresp, PutRespMsg),
+
+            % Add the index to the bucket props
+            yz_rt:set_index(Node, Index, Bucket),
+
+            yz_rt:wait_for_index(Cluster, binary_to_list(Index)),
+
+            %% Check that the index exists
+            GetReq  = #rpbyokozunaindexgetreq{name = Index},
+            GetResp = gen_server:call(Pid, {req, GetReq, infinity}, infinity),
+            {error,{unknown_response,_,GetRespMsg}} = GetResp,
+
+            {rpbyokozunaindexgetresp,GestRespIndexes} = GetRespMsg,
+            [{rpbyokozunaindex,Index,Schema}] = GestRespIndexes,
+
+            ?YZ_DEFAULT_SCHEMA_NAME =:= Schema
+        end,
+    yz_rt:wait_until(Cluster, F),
+    riakc_pb_socket:stop(Pid),
+    ok.
 
 store_and_search(Cluster, Bucket, Key, Body, Search, Params) ->
     store_and_search(Cluster, Bucket, Key, Body, "text/plain", Search, Params).
 
 store_and_search(Cluster, Bucket, Key, Body, CT, Search, Params) ->
-    HP = select_random(host_entries(rt:connection_info(Cluster))),
-    URL = bucket_url(HP, Bucket, Key),
+    {Host, Port} = select_random(host_entries(rt:connection_info(Cluster))),
+    URL = bucket_url({Host, Port}, Bucket, Key),
     lager:info("Storing to bucket ~s", [URL]),
-    {Host, Port} = HP,
     %% populate a value
     {ok, "204", _, _} = ibrowse:send_req(URL, [{"Content-Type", CT}], put, Body),
     {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
     F = fun(_) ->
-                lager:info("Search for ~s [~p]", [Search, HP]),
-                {ok,{search_results,R,Score,Found}} =
-                    riakc_pb_socket:search(Pid, Bucket, Search, Params),
-                case Found of
-                    1 ->
-                        [{Bucket,Results}] = R,
-                        KeyCheck = (Key == binary_to_list(proplists:get_value(<<"_yz_rk">>, Results))),
-                        ScoreCheck = (Score =/= 0.0),
-                        KeyCheck and ScoreCheck;
-                    0 ->
-                        false
-                end
-        end,
+        lager:info("Search for ~s [~p:~p]", [Search, Host, Port]),
+        {ok,{search_results,R,Score,Found}} =
+            riakc_pb_socket:search(Pid, Bucket, Search, Params),
+        case Found of
+            1 ->
+                [{Bucket,Results}] = R,
+                KeyCheck = (Key == binary_to_list(proplists:get_value(<<"_yz_rk">>, Results))),
+                ScoreCheck = (Score =/= 0.0),
+                KeyCheck and ScoreCheck;
+            0 ->
+                false
+        end
+    end,
     yz_rt:wait_until(Cluster, F),
+    riakc_pb_socket:stop(Pid),
+    ok.
+
+confirm_admin_index(Cluster) ->
+    Index = <<"index">>,
+    create_index(Cluster, Index, Index),
+    Node = select_random(Cluster),
+    [{Host, Port}] = host_entries(rt:connection_info([Node])),
+    {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
+    F = fun(_) ->
+        %% Remove index from bucket props
+        yz_rt:set_index(Node, Index, <<>>),
+        DelReq  = #rpbyokozunaindexdeletereq{name = Index},
+        DelResp = gen_server:call(Pid, {req, DelReq, infinity}, infinity),
+        case DelResp of
+            {error,{unknown_response,_,rpbdelresp}} -> true;
+            {error,<<"notfound">>} -> true
+        end
+    end,
+    yz_rt:wait_until(Cluster, F),
+    riakc_pb_socket:stop(Pid),
     ok.
 
 confirm_basic_search(Cluster) ->
     Bucket = <<"basic">>,
-    create_index(Cluster, Bucket),
+    create_index(Cluster, Bucket, Bucket),
     lager:info("confirm_basic_search ~s", [Bucket]),
     Body = "herp derp",
     Params = [{sort, <<"score desc">>}, {fl, ["*","score"]}],
@@ -106,7 +148,7 @@ confirm_basic_search(Cluster) ->
 
 confirm_encoded_search(Cluster) ->
     Bucket = <<"encoded">>,
-    create_index(Cluster, Bucket),
+    create_index(Cluster, Bucket, Bucket),
     lager:info("confirm_encoded_search ~s", [Bucket]),
     Body = "א בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ",
     Params = [{sort, <<"score desc">>}, {fl, ["_yz_rk"]}],
@@ -115,6 +157,7 @@ confirm_encoded_search(Cluster) ->
 confirm_multivalued_field(Cluster) ->
     Bucket = <<"basic">>,
     lager:info("cofirm multiValued=true fields decode properly"),
+    create_index(Cluster, Bucket, Bucket),
     Body = <<"{\"name_ss\":\"turner\", \"name_ss\":\"hooch\"}">>,
     Params = [],
     HP = select_random(host_entries(rt:connection_info(Cluster))),

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -27,7 +27,7 @@
 %% 27 is message type rpbsearchqueryreq
 %% 28 is message type rpbsearchqueryresp
 -define(QUERY_SERVICES, [{yz_pb_search, 27, 28}]).
--define(ADMIN_SERVICES, [{yz_pb_admin, 54, 57}]).
+-define(ADMIN_SERVICES, [{yz_pb_admin, 54, 60}]).
 
 %%%===================================================================
 %%% Callbacks

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -1,0 +1,142 @@
+%% -------------------------------------------------------------------
+%%
+%% yz_pb_search: PB Service for Yokozuna queries
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Implements a `riak_api_pb_service' for performing
+%% administrative functions in Yokozuna, like managing
+%% indexes or schema
+-module(yz_pb_admin).
+
+-include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
+-include("yokozuna.hrl").
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+-compile(export_all).
+
+%% @doc init/0 callback. Returns the service internal start state.
+-spec init() -> any().
+init() ->
+    no_state.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) ->
+    {ok, riak_pb_codec:decode(Code, Bin)}.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% @doc process/2 callback. Handles an incoming request message.
+process(#rpbyokozunaindexdeletereq{name = IndexNameBin}, State) ->
+    Ring = yz_misc:get_ring(transformed),
+    IndexName = binary_to_list(IndexNameBin),
+    case yz_index:exists(IndexName) of
+        true  ->
+            case associated_buckets(IndexName, Ring) of
+                [] ->
+                    ok = yz_index:remove(IndexName),
+                    {reply, rpbdelresp, State};
+                Buckets ->
+                    Msg = "Can't delete index with associate buckets ~p",
+                    Msg2 = lists:flatten(io_lib:fwrite(Msg, [Buckets])),
+                    {error, Msg2, State}
+            end;
+        false ->
+            {error, "notfound", State}
+    end;
+
+process(#rpbyokozunaindexputreq{
+            index = #rpbyokozunaindex{
+                name = IndexName, schema = SchemaName}}, State) ->
+    case maybe_create_index(IndexName, SchemaName) of
+        ok ->
+            {reply, #rpbputresp{}, State};
+        {error, {rpc_fail, Claimant, _}} ->
+            Msg = "Cannot create index while claimant node "++Claimant++" is down~n",
+            {error, Msg, State};
+        {error, schema_not_found} ->
+            {error, "Schema not found", State}
+    end;
+
+process(#rpbyokozunaindexgetreq{name = IndexName}, State) ->
+    Ring = yz_misc:get_ring(transformed),
+    lager:warning("GET REQ IDX ~p~n", [IndexName]),
+    case IndexName of
+        undefined ->
+            Indexes = yz_index:get_indexes_from_ring(Ring),
+            Details = [index_details(Ring, IndexName)
+              || IndexName <- orddict:fetch_keys(Indexes)];
+        _ ->
+            IndexNameList = binary_to_list(IndexName),
+            case yz_index:exists(IndexNameList) of
+                true ->
+                    Details = [index_details(Ring, IndexNameList)];
+                 _ ->
+                    Details = []
+             end
+    end,
+    case Details of
+        [] ->
+            {error, "notfound", State};
+        _ ->
+            {reply, #rpbyokozunaindexgetresp{index=Details}, State}
+    end.
+
+%% @doc process_stream/3 callback. Ignored.
+process_stream(_,_,State) ->
+    {ignore, State}.
+
+%% ---------------------------------
+%% Internal functions
+%% ---------------------------------
+
+-spec associated_buckets(index_name(), ring()) -> [bucket()].
+associated_buckets(IndexName, Ring) ->
+    AllBucketProps = riak_core_bucket:get_buckets(Ring),
+    Indexes = lists:map(fun yz_kv:which_index/1, AllBucketProps),
+    lists:filter(fun(I) -> I == IndexName end, Indexes).
+
+-spec maybe_create_index(index_name(), schema_name() | undefined) -> ok |
+                                                         {error, schema_not_found} |
+                                                         {error, {rpc_fail, node(), term()}}.
+maybe_create_index(IndexName, SchemaName=undefined)->
+    maybe_create_index(IndexName, ?YZ_DEFAULT_SCHEMA_NAME);
+maybe_create_index(IndexName, SchemaName)->
+    lager:warning("MAYBE INDEX: ~p ~p~n", [IndexName, SchemaName]),
+    case yz_index:exists(binary_to_list(IndexName)) of
+        true  -> ok;
+        false ->
+            yz_index:create(binary_to_list(IndexName), SchemaName)
+    end.
+
+index_details(Ring, IndexName) ->
+    Info = yz_index:get_info_from_ring(Ring, IndexName),
+    #rpbyokozunaindex{
+        name = list_to_binary(IndexName),
+        schema = yz_index:schema_name(Info)
+    }.

--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -52,8 +52,7 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 %% @doc process/2 callback. Handles an incoming request message.
-process(Msg, State) ->
-    #rpbsearchqueryreq{index=IndexBin}=Msg,
+process(#rpbsearchqueryreq{index=IndexBin}=Msg, State) ->
     case extract_params(Msg) of
         {ok, Params} ->
             Mapping = yz_events:get_mapping(),


### PR DESCRIPTION
Add schema and index administration to the protobuff interface so that the official clients will work.

This relies on basho/riak_pb#51

After basho/riak-erlang-client#112 is merged, I'll update this PR to use the new client.
