### PR TITLE
Use application env for component API

### DIFF
--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -34,21 +34,21 @@
 %%      investigating latency issues.
 -spec disable(component()) -> ok.
 disable(Component) ->
-    mochiglobal:put(Component, false).
+    application:set_env(?YZ_APP_NAME, {component, Component}, false).
 
 %% @doc Enabled the given `Component'.  This only needs to be called
 %%      if a component was previously disabled as all components are
 %%      considered enabled by default.
 -spec enable(component()) -> ok.
 enable(Component) ->
-    mochiglobal:put(Component, true).
+    application:set_env(?YZ_APP_NAME, {component, Component}, true).
 
 %% @doc Determine if the given `Component' is enabled or not.  If a
 %%      component is not explicitly disabled then it is considered
 %%      enabled.
 -spec is_enabled(component()) -> boolean().
 is_enabled(Component) ->
-    mochiglobal:get(Component, true).
+    app_helper:get_env(?YZ_APP_NAME, {component, Component}, true).
 
 %% @doc Use the results of a search as input to a map-reduce job.
 %%


### PR DESCRIPTION
It turns out that mochiglobal is a really bad idea if you often read
keys that are undefined.  This is because `mochiglobal:get` uses
try/catch to check for undefined and that becomes really expensive
when every call causes an `undef` error.

In the cases of Yokozuna, even when disabled, the KV vnode is making a
call to the `yz_kv:index` function which is doing a get for an
undefined key.  On my development machine I saw an order of magnitude
drop from ~1600 ops/s to ~150 ops/s.

This patch uses application env instead which brings the write
throughput back up to speed.
