### PR TITLE
Use periodic sync for hashtree updates

### DIFF
--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -58,7 +58,7 @@ insert(async, Id, BKey, Hash, Tree, Options) ->
     gen_server:cast(Tree, {insert, Id, BKey, Hash, Options});
 
 insert(sync, Id, BKey, Hash, Tree, Options) ->
-    catch gen_server:call(Tree, {insert, Id, BKey, Hash, Options}, 1000).
+    catch gen_server:call(Tree, {insert, Id, BKey, Hash, Options}, infinity).
 
 %% @doc Delete the `BKey' from `Tree'.  The id will be determined from
 %%      `BKey'.  The result of the sync call should be ignored since
@@ -68,7 +68,7 @@ delete(async, Id, BKey, Tree) ->
     gen_server:cast(Tree, {delete, Id, BKey});
 
 delete(sync, Id, BKey, Tree) ->
-    catch gen_server:call(Tree, {delete, Id, BKey}, 1000).
+    catch gen_server:call(Tree, {delete, Id, BKey}, infinity).
 
 -spec update({p(),n()}, tree()) -> ok.
 update(Id, Tree) ->


### PR DESCRIPTION
While running the yokozuna_essential test I noticed vnodes crashing
because of unexpected `{ref(),ok}` messages being handled by
`riak_kv_vnode:handle_info`.  The yokozuna index function,
`yz_kv:index` runs on the KV vnode process.  Part of that function is
to update the Yokozuna hashtree.  It does that by making a
gen_server:call with a timeout of 1 second.  If this call times out
then the reply ends up being handled by the KV vnode `handle_info`
callback which has no function head for that reply.  Thus crashing the
vnode and causing pain.

This patch updates Yokozuna's hashtree update to be like KV.  It uses
mostly async updates followed by the occasional blocking call with
`infinity` timeout.  This a) reduces overhead of most updates and b)
prevents chance of an unexpected msg making it to the KV vnode
callback.

I also removed the try/catch around the hashtree update since there is
already one in the `index` function covering this call.
