### PR TITLE
Remove the default index

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -52,6 +52,8 @@
 -type lp() :: pos_integer().
 %% Preflist, list of partition/owner pairs
 -type preflist() :: [{p(),term()}].
+%% Short representation of a preflist, partition + n_val
+-type short_preflist() :: {p(), n()}.
 %% Riak bucket
 -type bucket() :: binary().
 %% Riak key
@@ -249,7 +251,7 @@
 -type index_info() :: #index_info{}.
 -type index_name() :: string().
 
--define(YZ_DEFAULT_INDEX, "_yz_default").
+-define(YZ_INDEX_TOMBSTONE, "_dont_index_").
 -define(YZ_INDEX, yz_index).
 
 %%%===================================================================

--- a/rebar.config
+++ b/rebar.config
@@ -10,8 +10,8 @@
    {git, "git://github.com/basho/riak_kv", {branch, "develop"}}},
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
-  {meck, ".*",
-   {git, "git://github.com/eproxus/meck", {tag, "0.7.2-56-g8433cf2"}}}
+  {meck, "0.8.1",
+   {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"},

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -1,0 +1,89 @@
+-module(aae_test).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-define(NUM_KEYS, 10000).
+-define(INDEX_B, <<"fruit_aae">>).
+-define(INDEX_S, "fruit_aae").
+-define(CFG,
+        [{riak_core,
+          [
+           {ring_creation_size, 16}
+          ]},
+         {riak_kv,
+          [
+           %% allow AAE to build trees and exchange rapidly
+           {anti_entropy_build_limit, {100, 1000}},
+           {anti_entropy_concurrency, 12}
+          ]},
+         {yokozuna,
+          [
+	   {enabled, true},
+           {entropy_tick, 1000}
+          ]}
+        ]).
+
+
+confirm() ->
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    code:add_path(filename:join([YZBenchDir, "ebin"])),
+    random:seed(now()),
+    Cluster = rt:build_cluster(4, ?CFG),
+    setup_index(Cluster, YZBenchDir),
+    yz_rt:load_data(Cluster, ?INDEX_S, YZBenchDir, ?NUM_KEYS),
+    lager:info("Verify data was indexed"),
+    verify_num_match(Cluster, ?NUM_KEYS),
+    Keys = yz_rt:random_keys(?NUM_KEYS),
+    {DelKeys, _ChangeKeys} = lists:split(length(Keys) div 2, Keys),
+    lager:info("Deleting ~p keys", [length(DelKeys)]),
+    [delete_key_in_solr(Cluster, ?INDEX_S, K) || K <- DelKeys],
+    lager:info("Verify Solr indexes missing"),
+    verify_num_match(Cluster, ?NUM_KEYS - length(DelKeys)),
+    lager:info("Clear trees so AAE will notice missing indexes"),
+    [ok = rpc:call(Node, yz_entropy_mgr, clear_trees, []) || Node <- Cluster],
+    lager:info("Verify AAE repairs missing Solr documents"),
+    verify_num_match(Cluster, ?NUM_KEYS),
+    pass.
+
+%% TODO: I spent a while trying to get this to work only to realize
+%% there is no way to get total repair count.  Since the LastCount is
+%% only the count for the last {Idx,N} the sum was always 1/3 of
+%% length(DelKeys).  Will eventually move AAE testing into it's own
+%% module and find a way to verify the repair count but for now will
+%% just leave this here as reminder.
+%%
+%% check_repair_count(Cluster, ExpectedNumRepairs) ->
+%%     lager:info("Verify the repair count is equal to ~p", [ExpectedNumRepairs]),
+%%     Infos = [rpc:call(Node, yz_kv, compute_exchange_info, []) || Node <- Cluster],
+%%     Count = lists:sum([lists:sum([LastCount || {_, _, _, {LastCount, _, _, _}} <- Info])
+%%                        || Info <- Infos]),
+%%     ?assertEqual(ExpectedNumRepairs, Count).
+
+delete_key_in_solr(Cluster, Index, Key) ->
+    [begin
+         lager:info("Deleting solr doc ~s/~s on node ~p", [Index, Key, Node]),
+         ok = rpc:call(Node, yz_solr, delete, [Index, [{key, list_to_binary(Key)}]])
+     end || Node <- Cluster].
+
+read_schema(YZBenchDir) ->
+    Path = filename:join([YZBenchDir, "schemas", "fruit_schema.xml"]),
+    {ok, RawSchema} = file:read_file(Path),
+    RawSchema.
+
+setup_index(Cluster, YZBenchDir) ->
+    Node = yz_rt:select_random(Cluster),
+    RawSchema = read_schema(YZBenchDir),
+    ok = store_schema(Node, ?INDEX_B, RawSchema),
+    ok = yz_rt:create_index(Node, ?INDEX_S, ?INDEX_B),
+    ok = yz_rt:set_index(Node, ?INDEX_B),
+    yz_rt:wait_for_index(Cluster, ?INDEX_S).
+
+store_schema(Node, Name, RawSchema) ->
+    lager:info("Storing schema ~p [~p]", [Name, Node]),
+    ok = rpc:call(Node, yz_schema, store, [Name, RawSchema]).
+
+verify_num_match(Cluster, Num) ->
+    F = fun(Node) ->
+                HP = hd(yz_rt:host_entries(rt:connection_info([Node]))),
+                yz_rt:search_expect(HP, ?INDEX_S, "text", "apricot", Num)
+        end,
+    yz_rt:wait_until(Cluster, F).

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -53,7 +53,7 @@ confirm() ->
     lager:info("Clear trees so AAE will notice missing indexes"),
     [ok = rpc:call(Node, yz_entropy_mgr, clear_trees, []) || Node <- Cluster],
     lager:info("Wait for all trees to re-build"),
-    %% Before exchange of a partition to take place the KV and
+    %% Before exchange of a partition can take place the KV and
     %% Yokozuna hashtree must be built.  Wait for all trees before
     %% checking that Solr indexes are repaired.
     TS2 = erlang:now(),

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -131,7 +131,7 @@ verify_num_match(Cluster, Num) ->
 
 verify_repair_count(Cluster, ExpectedNumRepairs) ->
     RepairCount = get_cluster_repair_count(Cluster),
-    ?assertEqual(ExpectedNumRepairs, ClusterSum).
+    ?assertEqual(ExpectedNumRepairs, RepairCount).
 
 
 %% Eneded up not needing this function but leaving here in casse

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -78,7 +78,7 @@ load_data(Cluster, Index, YZBenchDir, NumKeys) ->
     run_bb(sync, File).
 
 random_keys(MaxKey) ->
-    random_keys(random:uniform(100), MaxKey).
+    random_keys(4 + random:uniform(100), MaxKey).
 
 random_keys(Num, MaxKey) ->
     lists:usort([integer_to_list(random:uniform(MaxKey))

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -47,24 +47,20 @@ doc_id(O, Partition, Sibling) ->
 has_siblings(O) -> riak_object:value_count(O) > 1.
 
 %% @doc Given an object generate the doc to be indexed by Solr.
--spec make_docs(obj(), hash(), binary(), binary(), boolean()) -> [doc()].
-make_docs(O, Hash, FPN, Partition, IndexContent) ->
-    [make_doc(O, Hash, Content, FPN, Partition, IndexContent)
+-spec make_docs(obj(), hash(), binary(), binary()) -> [doc()].
+make_docs(O, Hash, FPN, Partition) ->
+    [make_doc(O, Hash, Content, FPN, Partition)
      || Content <- riak_object:get_contents(O)].
 
--spec make_doc(obj(), hash(), {dict(), dict()}, binary(), binary(), boolean()) -> doc().
-make_doc(O, Hash, {MD, V}, FPN, Partition, IndexContent) ->
+-spec make_doc(obj(), hash(), {dict(), dict()}, binary(), binary()) -> doc().
+make_doc(O, Hash, {MD, V}, FPN, Partition) ->
     Vtag = get_vtag(O, MD),
     DocId = doc_id(O, Partition, Vtag),
     EntropyData = gen_ed(O, Hash, Partition),
     Bkey = {yz_kv:get_obj_bucket(O), yz_kv:get_obj_key(O)},
     Fields = make_fields({DocId, Bkey, FPN,
                           Partition, Vtag, EntropyData}),
-    ExtractedFields =
-        case IndexContent of
-            true -> extract_fields({MD, V});
-            false -> []
-        end,
+    ExtractedFields = extract_fields({MD, V}),
     Tags = extract_tags(MD),
     {doc, lists:append([Tags, ExtractedFields, Fields])}.
 

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -202,7 +202,7 @@ repair(Partition, {remote_missing, KeyBin}) ->
     Index = yz_kv:get_index(BKey, Ring),
     ShortPL = yz_kv:get_short_preflist(BKey, Ring),
     FakeObj = fake_kv_object(BKey),
-    %% Repeat sopme logic in `yz_kv:index/3' to avoid extra work.  Can
+    %% Repeat some logic in `yz_kv:index/3' to avoid extra work.  Can
     %% assume that Yokozuna is enabled and current node is owner.
     case yz_kv:should_index(Index) of
         true ->

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -279,7 +279,6 @@ fold_keys(Partition, Tree) ->
     LI = yz_cover:logical_index(yz_misc:get_ring(transformed)),
     LogicalPartition = yz_cover:logical_partition(LI, Partition),
     Indexes = yz_index:get_indexes_from_ring(yz_misc:get_ring(transformed)),
-    Indexes2 = [{?YZ_DEFAULT_INDEX, ignored}|Indexes],
     F = fun({BKey, Hash}) ->
                 %% TODO: return _yz_fp from iterator and use that for
                 %%       more efficient get_index_N
@@ -287,7 +286,7 @@ fold_keys(Partition, Tree) ->
                 insert(async, IndexN, BKey, Hash, Tree, [if_missing])
         end,
     Filter = [{partition, LogicalPartition}],
-    [yz_entropy:iterate_entropy_data(Name, Filter, F) || {Name,_} <- Indexes2],
+    [yz_entropy:iterate_entropy_data(Name, Filter, F) || {Name,_} <- Indexes],
     ok.
 
 -spec do_new_tree({p(),n()}, state()) -> state().

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -128,7 +128,7 @@ process_stream(_,_,State) ->
 -spec associated_buckets(index_name(), ring()) -> [bucket()].
 associated_buckets(IndexName, Ring) ->
     AllBucketProps = riak_core_bucket:get_buckets(Ring),
-    Indexes = lists:map(fun yz_kv:which_index/1, AllBucketProps),
+    Indexes = lists:map(fun yz_kv:get_index/1, AllBucketProps),
     lists:filter(fun(I) -> I == IndexName end, Indexes).
 
 -spec maybe_create_index(index_name(), schema_name()) -> ok |

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -238,7 +238,7 @@ is_conflict(RD, S) when S#ctx.method =:= 'PUT' ->
 -spec associated_buckets(index_name(), ring()) -> [bucket()].
 associated_buckets(IndexName, Ring) ->
     AllBucketProps = riak_core_bucket:get_buckets(Ring),
-    Indexes = lists:map(fun yz_kv:which_index/1, AllBucketProps),
+    Indexes = lists:map(fun yz_kv:get_index/1, AllBucketProps),
     lists:filter(fun(I) -> I == IndexName end, Indexes).
 
 %% accepts a string and attempt to parse it into json


### PR DESCRIPTION
The default index, `_yz_default`, was added to prevent AAE from doing
unnecessary repairs after tree re-build.  After a Yokozuna hashtree is
cleared it is rebuilt from data in Solr.  If Solr only contains data
for indexed buckets then its hashtree will be missing hashes for
non-indexed buckets.  Since AAE exchanges based on partition the
system will think keys are missing and potentially invoke lots of
repair.  The default index avoids this by indexing the needed data for
AAE for buckets which are not indexed.  AAE works, but at the cost of
affecting write throughput on non-indexed buckets and increasing the
index size.  On my local workstation the default index reduced write
throughput to 56% of baseline.

This tradeoff is unnecessary.  Write throughput on a non-indexed
bucket can remain much closer to baseline without causing trouble for
AAE.
- Determine if the object needs to be indexed.
- If it does then write to Solr and update the hashtree.  If it
  doesn't then just update the hashtree.  This ensures that the
  hashtrees are kept up to date with significantly less cost than
  sending an update to Solr
- After a Yokozuna hashtree is cleared it will be missing keys stored
  in non-indexed buckets.
- During exchange each missing key will cause the repair function to
  be invoked.
- This repair function will now check if the object needs to be
  indexed.  I.e. an actual missing index entry versus an object that
  doesn't need to be indexed.  If the object is not to be indexed then
  the Yokozuna hashtree is simply sent an update.
- So the first exchange of a tree after re-build will invoke the
  repair function potentially many times.  But these invocations will
  consist of a simple check + a hashtree update.  This is far less
  work than minimally indexing all data.
