### PR TITLE
Small dialyzer fixes

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -69,7 +69,7 @@
 -type p_node() :: {p(), node()}.
 -type lp_node() :: {lp(), node()}.
 -type cover_set() :: [p_node()].
--type logical_cover_set() :: [lp_node()].
+-type logical_cover_set() :: [{lp_node(), filter()}].
 -type filter_cover_set() :: [{p_node(), filter()}].
 
 -type ring_event() :: {ring_event, riak_core_ring:riak_core_ring()}.

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -223,7 +223,7 @@ make_filter_pairs(N, Q, Cover) ->
     [make_filter_pair(N, Q, DP) || DP <- Cover].
 
 %% @doc Convert the `Cover' set to use logical partitions.
--spec make_logical(logical_idx(), cover_set()) -> logical_cover_set().
+-spec make_logical(logical_idx(), cover_set()) -> [lp_node()].
 make_logical(LogicalIndex, Cover) ->
     [{logical_partition(LogicalIndex, P), Node} || {P, Node} <- Cover].
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -165,7 +165,7 @@ name(Info) ->
 
 %% @doc Remove documents in `Index' that are not owned by the local
 %%      node.  Return the list of non-owned partitions found.
--spec remove_non_owned_data(string()) -> [{ordset(p()), ordset(lp())}].
+-spec remove_non_owned_data(index_name()) -> [p()].
 remove_non_owned_data(Index) ->
     Ring = yz_misc:get_ring(raw),
     IndexPartitions = yz_cover:reify_partitions(Ring,
@@ -176,7 +176,7 @@ remove_non_owned_data(Index) ->
     Queries = [{'query', <<?YZ_PN_FIELD_S, ":", (?INT_TO_BIN(LP))/binary>>}
                || LP <- LNonOwned],
     ok = yz_solr:delete(Index, Queries),
-    lists:zip(NonOwned, LNonOwned).
+    NonOwned.
 
 -spec schema_name(index_info()) -> schema_name().
 schema_name(Info) ->

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -131,9 +131,9 @@ associated_buckets(IndexName, Ring) ->
     Indexes = lists:map(fun yz_kv:get_index/1, AllBucketProps),
     lists:filter(fun(I) -> I == IndexName end, Indexes).
 
--spec maybe_create_index(index_name(), schema_name()) -> ok |
-                                                         {error, schema_not_found} |
-                                                         {error, {rpc_fail, node(), term()}}.
+-spec maybe_create_index(binary(), schema_name()) -> ok |
+                                                     {error, schema_not_found} |
+                                                     {error, {rpc_fail, node(), term()}}.
 maybe_create_index(IndexName, _SchemaName = <<>>)->
     maybe_create_index(IndexName, ?YZ_DEFAULT_SCHEMA_NAME);
 maybe_create_index(IndexName, _SchemaName = undefined)->

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -93,7 +93,7 @@ process(#rpbyokozunaindexputreq{
         ok ->
             {reply, #rpbputresp{}, State};
         {error, {rpc_fail, Claimant, _}} ->
-            Msg = "Cannot create index while claimant node "++Claimant++" is down~n",
+            Msg = "Cannot create index while claimant node " ++ atom_to_list(Claimant) ++" is down~n",
             {error, Msg, State};
         {error, schema_not_found} ->
             {error, "Schema not found", State}


### PR DESCRIPTION
NOTE: This requires 16B01 or else dialyzer will fail.

I figured I'd could make some small fixes while incapacitated.  Just some small fixes to make dialyzer happier.

```
yokozuna.erl:37: The call application:set_env('yokozuna',{'component',_},'false') breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
yokozuna.erl:44: The call application:set_env('yokozuna',{'component',_},'true') breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
yokozuna.erl:51: The call app_helper:get_env('yokozuna',{'component',_},'true') will never return since it differs in the 2nd argument from the success typing arguments: (atom(),atom(),any())
yz_kv.erl:71: The call lists:sort(Vclock::vclock:vclock()) contains an opaque term as 1st argument when a structured term of type [any()] is expected
yz_kv.erl:97: Invalid type specification for function yz_kv:get_tree_build_time/1. The success typing is (hashtree:hashtree()) -> any()
yz_pb_admin.erl:32: Callback info about the riak_api_pb_service behaviour is not available
yz_pb_search.erl:30: Callback info about the riak_api_pb_service behaviour is not available
```

Note that these errors still exist but not sure much can be done about them.  I was worried about the first 3.  They are correct according to type specs but I reviewed the application code.  It technically can accept `term()` as key so I'm going to let Yokozuna exploit that for a little while longer.
