### PR TITLE
Translate bucket, or expect index name, in mapred_search

### DIFF
--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -109,17 +109,6 @@ index_for_group(Group) ->
             Index
     end.
 
-join_filters(<<"">>, Filter) ->
-    Filter;
-join_filters("", Filter) ->
-    Filter;
-join_filters(Filter, <<"">>) ->
-    Filter;
-join_filters(Filter, "") ->
-    Filter;
-join_filters(A, B) ->
-    list_to_binary([A, " AND ", B]).
-
 %% @doc Return the ordered set of unique logical partitions stored on
 %%      the local node for the given `Index'.
 -spec partition_list(string()) -> ordset(lp()).


### PR DESCRIPTION
This PR changes mapred_search to lookup the index name associated with a bucket, instead of passing the bucket name to solr. The bucket name is also passed in a filter query, such that only keys from the bucket originally specified are returned from the index.

This PR also allows the specification of an index, instead of a bucket, which will produce all keys matching the query, regardless of bucket. To trigger this behavior, pass `{index, Index}` or `{struct, [{<<"index">>}, Index}]}` (mochijson2 format) instead of `Bucket` as the `Group` parameter to `mapred_search`.
