### PR TITLE
Fix associated_buckets

### DIFF
--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -140,6 +140,13 @@ confirm_delete_409(Cluster, Index) ->
     %% Sleeping for bprops (TODO: convert to `wait_for_bprops')
     timer:sleep(4000),
 
+    %% Verify associated_buckets is correct
+    Node = select_random(Cluster),
+    lager:info("Verify associated buckets for index ~s [~p]", [Node]),
+    Ring = rpc:call(Node, yz_misc, get_ring, [transformed]),
+    Assoc = rpc:call(Node, yz_index, associated_buckets, [Index, Ring]),
+    ?assertEqual([<<"b1">>, <<"b2">>], Assoc),
+
     %% Can't be deleted because of associated buckets
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -31,6 +31,13 @@
 %%% API
 %%%===================================================================
 
+%% @doc Get the list of buckets associated with `Index'.
+-spec associated_buckets(index_name(), ring()) -> [bucket()].
+associated_buckets(Index, Ring) ->
+    AllBucketProps = riak_core_bucket:get_buckets(Ring),
+    Assoc = lists:filter(fun(BProps) ->  yz_kv:get_index(BProps) == Index end, AllBucketProps),
+    lists:map(fun riak_core_bucket:name/1, Assoc).
+
 -spec create(string()) -> ok.
 create(Name) ->
     create(Name, ?YZ_DEFAULT_SCHEMA_NAME).

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -73,7 +73,7 @@ process(#rpbyokozunaindexdeletereq{name = IndexNameBin}, State) ->
     IndexName = binary_to_list(IndexNameBin),
     case yz_index:exists(IndexName) of
         true  ->
-            case associated_buckets(IndexName, Ring) of
+            case yz_index:associated_buckets(IndexName, Ring) of
                 [] ->
                     ok = yz_index:remove(IndexName),
                     {reply, rpbdelresp, State};
@@ -124,12 +124,6 @@ process_stream(_,_,State) ->
 %% ---------------------------------
 %% Internal functions
 %% ---------------------------------
-
--spec associated_buckets(index_name(), ring()) -> [bucket()].
-associated_buckets(IndexName, Ring) ->
-    AllBucketProps = riak_core_bucket:get_buckets(Ring),
-    Indexes = lists:map(fun yz_kv:get_index/1, AllBucketProps),
-    lists:filter(fun(I) -> I == IndexName end, Indexes).
 
 -spec maybe_create_index(binary(), schema_name()) -> ok |
                                                      {error, schema_not_found} |

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -126,7 +126,7 @@ delete_resource(RD, S) ->
     IndexName = S#ctx.index_name,
     case yz_index:exists(IndexName) of
         true  ->
-            case associated_buckets(IndexName, S#ctx.ring) of
+            case yz_index:associated_buckets(IndexName, S#ctx.ring) of
                 [] ->
                     ok = yz_index:remove(IndexName),
                     {true, RD, S};
@@ -234,12 +234,6 @@ is_conflict(RD, S) when S#ctx.method =:= 'PUT' ->
 %%%===================================================================
 %%% Private
 %%%===================================================================
-
--spec associated_buckets(index_name(), ring()) -> [bucket()].
-associated_buckets(IndexName, Ring) ->
-    AllBucketProps = riak_core_bucket:get_buckets(Ring),
-    Indexes = lists:map(fun yz_kv:get_index/1, AllBucketProps),
-    lists:filter(fun(I) -> I == IndexName end, Indexes).
 
 %% accepts a string and attempt to parse it into json
 decode_json(RDBody) ->


### PR DESCRIPTION
Fix the associated_buckets function to actually return bucket names.
Reduce the copy & paste, move to common location.  Add check to index
admin test.
