### PR TITLE
Disable certificate checking when using wget to fetch solr

### DIFF
--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -25,7 +25,7 @@ check_for_solr()
 
 get_solr()
 {
-        wget --progress=dot:mega https://s3.amazonaws.com/yzami/pkgs/$VSN.tgz
+        wget --no-check-certificate --progress=dot:mega https://s3.amazonaws.com/yzami/pkgs/$VSN.tgz
         tar zxf $VSN.tgz
 }
 


### PR DESCRIPTION
Solaris, SmartOS, and FreeBSD are having trouble checking
the certificates of AWS when downloading the solr tgz.  This
commit simply passes `--no-check-certificate` to wget.

Fixes the following error as seen on SmartOS

```
ERROR: cannot verify s3.amazonaws.com's certificate, issued by `/C=US/O=VeriSign, Inc./OU=VeriSign Trust Network/OU=Terms of use at https://www.verisign.com/rpa (c)09/CN=VeriSign Class 3 Secure Server CA - G2':
  Unable to locally verify the issuer's authority.
```
