### PR TITLE
Require a JDK during build process.

### DIFF
--- a/tools/build-jar.sh
+++ b/tools/build-jar.sh
@@ -3,6 +3,11 @@
 # Temporary script to build JAR file containing customer Solr request
 # handlers.
 
+if [ ! -x "`which javac`" ] || [ ! -x "`which jar`" ]; then
+  echo "Couldn't find javac and/or jar, which is needed to compile Yokozuna."
+  exit 1
+fi
+
 if [ $(basename $PWD) != "tools" ]
 then
     cd tools

--- a/tools/build-solr.sh
+++ b/tools/build-solr.sh
@@ -68,6 +68,11 @@ WORK_DIR=$1; shift
 NAME=$1; shift
 URL=$1; shift
 
+if [ ! -x "`which ant`"]; then
+  echo "Couldn't find ant, which is needed to compile Solr."
+  exit 1
+fi
+
 mkdir $WORK_DIR
 if test ! -e $WORK_DIR; then
     error "failed to created work dir: $WORK_DIR"


### PR DESCRIPTION
These changes add a couple checks to `tools/build-solr.sh` and `tools/build-jar.sh`, checking for the presence of `javac`, `jar`, and `ant` and failing out when they're not present.
