### PR TITLE
Convert `index_name()` to binary

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -106,6 +106,7 @@
            true -> ok
         end).
 -define(ATOM_TO_BIN(A), list_to_binary(atom_to_list(A))).
+-define(BIN_TO_ATOM(B), list_to_atom(binary_to_list(B))).
 -define(BIN_TO_INT(B), list_to_integer(binary_to_list(B))).
 -define(INT_TO_BIN(I), list_to_binary(integer_to_list(I))).
 -define(INT_TO_STR(I), integer_to_list(I)).
@@ -249,9 +250,9 @@
 
 -type indexes() :: orddict(index_name(), index_info()).
 -type index_info() :: #index_info{}.
--type index_name() :: string().
+-type index_name() :: binary().
 
--define(YZ_INDEX_TOMBSTONE, "_dont_index_").
+-define(YZ_INDEX_TOMBSTONE, <<"_dont_index_">>).
 -define(YZ_INDEX, yz_index).
 
 %%%===================================================================

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -51,10 +51,11 @@ test_errors(Cluster) ->
     ok.
 
 expect_bad_json(Cluster) ->
+    Index = <<"bad_json">>,
     HP = yz_rt:select_random(host_entries(rt:connection_info(Cluster))),
-    ok = create_index(Cluster, HP, <<"bad_json">>),
+    ok = create_index(Cluster, HP, Index),
     lager:info("Write bad json"),
-    URL = bucket_url(HP, "bad_json", "test"),
+    URL = bucket_url(HP, Index, "test"),
     Opts = [],
     CT = "application/json",
     Headers = [{"content-type", CT}],
@@ -66,14 +67,15 @@ expect_bad_json(Cluster) ->
     {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
     %% Sleep for soft commit
     timer:sleep(1100),
-    ?assert(search_expect(HP, "bad_json", ?YZ_ERR_FIELD_S, "1", 1)),
+    ?assert(search_expect(HP, Index, ?YZ_ERR_FIELD_S, "1", 1)),
     ok.
 
 expect_bad_xml(Cluster) ->
+    Index = <<"bad_xml">>,
     HP = yz_rt:select_random(host_entries(rt:connection_info(Cluster))),
-    ok = create_index(Cluster, HP, <<"bad_xml">>),
+    ok = create_index(Cluster, HP, Index),
     lager:info("Write bad xml"),
-    URL = bucket_url(HP, "bad_xml", "test"),
+    URL = bucket_url(HP, Index, "test"),
     Opts = [],
     CT = "application/xml",
     Headers = [{"content-type", CT}],
@@ -85,14 +87,15 @@ expect_bad_xml(Cluster) ->
     {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
     %% Sleep for soft commit
     timer:sleep(1100),
-    ?assert(search_expect(HP, "bad_xml", ?YZ_ERR_FIELD_S, "1", 1)),
+    ?assert(search_expect(HP, Index, ?YZ_ERR_FIELD_S, "1", 1)),
     ok.
 
 expect_bad_query(Cluster) ->
+    Index = <<"bad_query">>,
     HP = yz_rt:select_random(host_entries(rt:connection_info(Cluster))),
-    ok = create_index(Cluster, HP, <<"bad_query">>),
+    ok = create_index(Cluster, HP, Index),
     lager:info("Write bad query"),
-    URL = bucket_url(HP, "bad_query", "test"),
+    URL = bucket_url(HP, Index, "test"),
     Opts = [],
     CT = "text/plain",
     Headers = [{"content-type", CT}],
@@ -103,7 +106,7 @@ expect_bad_query(Cluster) ->
     %% still store the value in riak
     {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
     %% send a bad query
-    SearchURL = search_url(HP, "bad_query") ++ "?q=*:*&sort=sco+desc",
+    SearchURL = search_url(HP, Index) ++ "?q=*:*&sort=sco+desc",
     {ok, "400", _, _} = ibrowse:send_req(SearchURL, [], get, []),
     ok.
 
@@ -127,5 +130,5 @@ create_index(Cluster, HP, Index) ->
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
     yz_rt:set_index(Node, Index),
-    yz_rt:wait_for_index(Cluster, binary_to_list(Index)),
+    yz_rt:wait_for_index(Cluster, Index),
     ?assertEqual("204", Status).

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -75,7 +75,7 @@ create_index(Cluster, HP, Index) ->
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
     ok = yz_rt:set_index(hd(Cluster), Index),
-    yz_rt:wait_for_index(Cluster, binary_to_list(Index)),
+    yz_rt:wait_for_index(Cluster, Index),
     ?assertEqual("204", Status).
 
 search(HP, Index, Term) ->

--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -33,11 +33,11 @@
 
 -spec confirm() -> pass.
 confirm() ->
-    Index = "mr_index",
+    Index = <<"mr_index">>,
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     yz_rt:create_index(yz_rt:select_random(Cluster), Index),
-    yz_rt:set_index(yz_rt:select_random(Cluster), list_to_binary(Index)),
+    yz_rt:set_index(yz_rt:select_random(Cluster), Index),
     yz_rt:wait_for_index(Cluster, Index),
     write_100_objs(Cluster, Index),
     verify_100_objs_mr(Cluster, Index),
@@ -53,7 +53,7 @@ verify_100_objs_mr(Cluster, Index) ->
                            {name, <<"Riak.reduceSum">>}]}],
     MR = [{inputs, [{module, <<"yokozuna">>},
                     {function, <<"mapred_search">>},
-                    {arg, [list_to_binary(Index), <<"name_s:yokozuna">>]}]},
+                    {arg, [Index, <<"name_s:yokozuna">>]}]},
           {'query', [MakeTick, ReduceSum]}],
     F = fun(Node) ->
                 HP = hd(yz_rt:host_entries(rt:connection_info([Node]))),
@@ -76,7 +76,7 @@ write_obj(Cluster, Index) ->
             HP = yz_rt:select_random(yz_rt:host_entries(rt:connection_info(Cluster))),
             CT = "application/json",
             lager:info("Writing object with bkey ~p [~p]", [{Index,Key}, HP]),
-            yz_rt:http_put(HP, list_to_binary(Index), Key, CT, Body)
+            yz_rt:http_put(HP, Index, Key, CT, Body)
     end.
 
 -spec http_mr({host(), portnum()}, term()) -> binary().

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -84,7 +84,7 @@ create_index(Cluster, Index, Bucket) ->
     ?assertEqual(ok, riakc_pb_socket:create_search_index(Pid, Index)),
     % Add the index to the bucket props
     yz_rt:set_index(Node, Index, Bucket),
-    yz_rt:wait_for_index(Cluster, binary_to_list(Index)),
+    yz_rt:wait_for_index(Cluster, Index),
     %% Check that the index exists
     {ok, IndexData} = riakc_pb_socket:get_search_index(Pid, Index),
     ?assertEqual([{index,Index},{schema,?YZ_DEFAULT_SCHEMA_NAME}], IndexData),

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -203,7 +203,7 @@ create_index([Node1|_]=Cluster, riak_search) ->
         end,
     yz_rt:wait_until(Cluster, F);
 create_index(Cluster, yokozuna) ->
-    Idx = binary_to_list(?FRUIT_BUCKET),
+    Idx = ?FRUIT_BUCKET,
     yz_rt:create_index(hd(Cluster), Idx),
     yz_rt:wait_for_index(Cluster, Idx).
 

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -35,7 +35,7 @@ join(Nodes) ->
 
 test_siblings(Cluster) ->
     HP = hd(host_entries(rt:connection_info(Cluster))),
-    ok = create_index(Cluster, HP, <<"siblings">>),
+    create_index(Cluster, HP, <<"siblings">>),
     ok = allow_mult(Cluster, <<"siblings">>),
     ok = write_sibs(HP),
     %% Verify 10 times because of non-determinism in coverage
@@ -61,9 +61,9 @@ write_sibs({Host, Port}) ->
 
 verify_sibs(HP) ->
     lager:info("Verify siblings are indexed"),
-    true = yz_rt:search_expect(HP, "siblings", "_yz_rk", "test", 4),
+    true = yz_rt:search_expect(HP, <<"siblings">>, "_yz_rk", "test", 4),
     Values = ["alpha", "beta", "charlie", "delta"],
-    [true = yz_rt:search_expect(HP, "siblings", "text", S, 1) || S <- Values],
+    [true = yz_rt:search_expect(HP, <<"siblings">>, "text", S, 1) || S <- Values],
     ok.
 
 reconcile_sibs(HP) ->
@@ -76,7 +76,7 @@ reconcile_sibs(HP) ->
 
 verify_reconcile(HP) ->
     lager:info("Verify sibling indexes were deleted after reconcile"),
-    true = yz_rt:search_expect(HP, "siblings", "_yz_rk", "test", 1),
+    true = yz_rt:search_expect(HP, <<"siblings">>, "_yz_rk", "test", 1),
     ok.
 
 http_put({Host, Port}, Bucket, Key, VClock, Value) ->
@@ -122,7 +122,6 @@ create_index(Cluster, HP, Index) ->
     lager:info("create_index ~s [~p]", [Index, HP]),
     URL = index_url(HP, Index),
     Headers = [{"content-type", "application/json"}],
-    {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
+    {ok, "204", _, _} = http(put, URL, Headers, ?NO_BODY),
     ok = set_index(hd(Cluster), Index),
-    yz_rt:wait_for_index(Cluster, binary_to_list(Index)),
-    ?assertEqual("204", Status).
+    yz_rt:wait_for_index(Cluster, Index).

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -45,7 +45,7 @@ logical_partitions(Ring, Partitions) ->
 -spec plan(index_name()) -> {[node()], term(), [{node(),{string(),string()}}]} |
                             {error, term()}.
 plan(Index) ->
-    case mochiglobal:get(list_to_atom(Index), undefined) of
+    case mochiglobal:get(?BIN_TO_ATOM(Index), undefined) of
         undefined -> calc_plan(Index);
         Plan -> Plan
     end.
@@ -111,9 +111,9 @@ add_filtering(N, Q, LPI, CS) ->
 cache_plan(Index) ->
     case calc_plan(Index) of
         {error, _} ->
-            mochiglobal:put(list_to_atom(Index), undefined);
+            mochiglobal:put(?BIN_TO_ATOM(Index), undefined);
         Plan ->
-            mochiglobal:put(list_to_atom(Index), Plan)
+            mochiglobal:put(?BIN_TO_ATOM(Index), Plan)
     end,
     ok.
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -38,7 +38,7 @@ associated_buckets(Index, Ring) ->
     Assoc = lists:filter(fun(BProps) ->  yz_kv:get_index(BProps) == Index end, AllBucketProps),
     lists:map(fun riak_core_bucket:name/1, Assoc).
 
--spec create(string()) -> ok.
+-spec create(index_name()) -> ok.
 create(Name) ->
     create(Name, ?YZ_DEFAULT_SCHEMA_NAME).
 
@@ -55,9 +55,9 @@ create(Name) ->
 %% NOTE: All create requests are serialized through the claimant node
 %%       to avoid races between disjoint nodes.  If the claimant is
 %%       down no indexes may be created.
--spec create(string(), schema_name()) -> ok |
-                                         {error, schema_not_found} |
-                                         {error, {rpc_fail, node(), term()}}.
+-spec create(index_name(), schema_name()) -> ok |
+                                             {error, schema_not_found} |
+                                             {error, {rpc_fail, node(), term()}}.
 create(Name, SchemaName) ->
     case yz_schema:exists(SchemaName) of
         false ->
@@ -122,7 +122,7 @@ get_info_from_ring(Ring, Name) ->
 %% NOTE: This should typically be called by a the ring handler in
 %%       `yz_event'.  The `create/1' API should be used to create a
 %%       cluster-wide index.
--spec local_create(ring(), string()) -> ok.
+-spec local_create(ring(), index_name()) -> ok.
 local_create(Ring, Name) ->
     %% TODO: Allow data dir to be changed
     IndexDir = index_dir(Name),
@@ -158,7 +158,7 @@ local_create(Ring, Name) ->
     end.
 
 %% @doc Remove the index `Name' locally.
--spec local_remove(string()) -> ok.
+-spec local_remove(index_name()) -> ok.
 local_remove(Name) ->
     CoreProps = [
                     {core, Name},

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -111,16 +111,9 @@ get_md_entry(MD, Key) ->
 
 %% @doc Extract the index name from `BProps' or return the tombstone
 %% name if there is no associated index.
-%%
-%% TODO: Convert `index_name()' to be binary everywhere.
 -spec get_index(term()) -> index_name().
 get_index(BProps) ->
-    case proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE) of
-        B when is_binary(B) ->
-            binary_to_list(B);
-        S ->
-            S
-    end.
+    proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE).
 
 %% @doc Extract the index name.
 %% @see get_index/1

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -68,9 +68,8 @@ process(#rpbyokozunaschemagetreq{name = SchemaName}, State) ->
     Schema = #rpbyokozunaschema{name = SchemaName, content = Content},
     {reply, #rpbyokozunaschemagetresp{schema = Schema}, State};
 
-process(#rpbyokozunaindexdeletereq{name = IndexNameBin}, State) ->
+process(#rpbyokozunaindexdeletereq{name = IndexName}, State) ->
     Ring = yz_misc:get_ring(transformed),
-    IndexName = binary_to_list(IndexNameBin),
     case yz_index:exists(IndexName) of
         true  ->
             case yz_index:associated_buckets(IndexName, Ring) of
@@ -106,9 +105,8 @@ process(rpbyokozunaindexgetreq, State) ->
       || IndexName <- orddict:fetch_keys(Indexes)],
     {reply, #rpbyokozunaindexgetresp{index=Details}, State};
 
-process(#rpbyokozunaindexgetreq{name = IndexNameBin}, State) ->
+process(#rpbyokozunaindexgetreq{name = IndexName}, State) ->
     Ring = yz_misc:get_ring(transformed),
-    IndexName = binary_to_list(IndexNameBin),
     case yz_index:exists(IndexName) of
         true ->
             Details = [index_details(Ring, IndexName)],
@@ -133,15 +131,15 @@ maybe_create_index(IndexName, _SchemaName = <<>>)->
 maybe_create_index(IndexName, _SchemaName = undefined)->
     maybe_create_index(IndexName, ?YZ_DEFAULT_SCHEMA_NAME);
 maybe_create_index(IndexName, SchemaName)->
-    case yz_index:exists(binary_to_list(IndexName)) of
+    case yz_index:exists(IndexName) of
         true  -> ok;
         false ->
-            yz_index:create(binary_to_list(IndexName), SchemaName)
+            yz_index:create(IndexName, SchemaName)
     end.
 
 index_details(Ring, IndexName) ->
     Info = yz_index:get_info_from_ring(Ring, IndexName),
     #rpbyokozunaindex{
-        name = list_to_binary(IndexName),
+        name = IndexName,
         schema = yz_index:schema_name(Info)
     }.

--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -55,10 +55,9 @@ encode(Message) ->
 process(Msg, State) ->
     maybe_process(yokozuna:is_enabled(search), Msg, State).
 
-maybe_process(true, #rpbsearchqueryreq{index=IndexBin}=Msg, State) ->
+maybe_process(true, #rpbsearchqueryreq{index=Index}=Msg, State) ->
     case extract_params(Msg) of
         {ok, Params} ->
-            Index = binary_to_list(IndexBin),
             try
                 Result = yz_solr:dist_search(Index, Params),
                 case Result of

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -73,7 +73,7 @@ process_post(Req, S) ->
 search(Req, S) ->
     {FProf, FProfFile} = check_for_fprof(Req),
     ?IF(FProf, fprof:trace(start, FProfFile)),
-    Index = wrq:path_info(index, Req),
+    Index = list_to_binary(wrq:path_info(index, Req)),
     Params = wrq:req_qs(Req),
     ReqHeaders = mochiweb_headers:to_list(wrq:req_headers(Req)),
     try


### PR DESCRIPTION
Use a binary index name to stay consistent with binary bucket name,
key name, etc.
