### PR TITLE
Move wait_for_solr out of yz_solr_proc:init

### DIFF
--- a/riak_test/yz_solr_start_timeout.erl
+++ b/riak_test/yz_solr_start_timeout.erl
@@ -1,0 +1,78 @@
+%% @doc Ensure that if Solr doesn't start before the startup wait,
+%% yokozuna tears down the Riak node.
+%%
+%% Note: if this test is successful, the node will be left in a state
+%% that will never run solr successfully (because the WAR file will be
+%% missing).
+-module(yz_solr_start_timeout).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CFG, [{yokozuna, [{enabled, true}]}]).
+
+confirm() ->
+    %% start a node, so we can ask it to cripple itself
+    [Node|_] = rt:deploy_nodes(1, [{yokozuna,[{enabled, true}]}]),
+
+    prepare_jetty_for_failure(Node),
+    
+    rt:stop_and_wait(Node),
+
+    %% node should start up successfully, but is missing pieces of
+    %% solr, so...
+    rt:start_and_wait(Node),
+
+    %% ... it should die in a bit
+    ok = rt:wait_until_unpingable(Node),
+
+    %% if it doesn't, we'll never get to this point, because
+    %% the wait asserts failure on timeout
+
+    %% if we did get here, check the log to make sure it was the
+    %% startup wait that triggered
+
+    Logs = rt:get_node_logs(),
+    ?assert(find_startup_wait_log(Logs)),
+    pass.
+
+%% Remove the solr webapp. Jetty will start, so yz_solr_proc will have
+%% a live port to hold onto, but Solr will not start, so the ping will
+%% never return successfully.
+prepare_jetty_for_failure(Node) ->
+    rt:load_modules_on_nodes([?MODULE], [Node]),
+    lager:info("Deleting solr.war"),
+    case rpc:call(Node, ?MODULE, remove_solr_webapp, []) of
+        ok ->
+            ok;
+        {error, enoent} ->
+            lager:warn("solr.war is already missing - are you using --yz-source?"),
+            ok;
+        DeleteResult ->
+            ?assertEqual(ok, DeleteResult)
+    end.
+
+%% This is the part of prepare_jetty_for_failure that is run on the
+%% node via RPC
+remove_solr_webapp() ->
+    Priv = code:priv_dir(yokozuna),
+    SolrWar = filename:join([Priv,"solr","webapps","solr.war"]),
+    file:delete(SolrWar).
+
+%% Find "solr didn't start in alloted time" in console.log
+find_startup_wait_log([]) ->
+    false;
+find_startup_wait_log([{Path, Port}|Rest]) ->
+    case re:run(Path, "console\.log$") of
+        {match, _} ->
+            find_line(Port, file:read_line(Port));
+        nomatch ->
+            find_startup_wait_log(Rest)
+    end.
+
+find_line(Port, {ok, Data}) ->
+    case re:run(Data, "solr didn't start in alloted time") of
+        {match, _} ->
+            true;
+        nomatch ->
+            find_line(Port, file:read_line(Port))
+    end.

--- a/riak_test/yz_solr_start_timeout.erl
+++ b/riak_test/yz_solr_start_timeout.erl
@@ -41,15 +41,7 @@ confirm() ->
 prepare_jetty_for_failure(Node) ->
     rt:load_modules_on_nodes([?MODULE], [Node]),
     lager:info("Deleting solr.war"),
-    case rpc:call(Node, ?MODULE, remove_solr_webapp, []) of
-        ok ->
-            ok;
-        {error, enoent} ->
-            lager:warn("solr.war is already missing - are you using --yz-source?"),
-            ok;
-        DeleteResult ->
-            ?assertEqual(ok, DeleteResult)
-    end.
+    ?assertEqual(ok, rpc:call(Node, ?MODULE, remove_solr_webapp, [])).
 
 %% This is the part of prepare_jetty_for_failure that is run on the
 %% node via RPC

--- a/riak_test/yz_solr_start_timeout.erl
+++ b/riak_test/yz_solr_start_timeout.erl
@@ -1,9 +1,5 @@
 %% @doc Ensure that if Solr doesn't start before the startup wait,
 %% yokozuna tears down the Riak node.
-%%
-%% Note: if this test is successful, the node will be left in a state
-%% that will never run solr successfully (because the WAR file will be
-%% missing).
 -module(yz_solr_start_timeout).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -38,7 +38,7 @@ start(_StartType, _StartArgs) ->
     Enabled = ?YZ_ENABLED,
     case yz_sup:start_link(Enabled) of
         {ok, Pid} ->
-            maybe_setup(Enabled, Pid),
+            maybe_setup(Enabled),
             {ok, Pid};
         Error ->
             Error
@@ -49,15 +49,14 @@ stop(_State) ->
     ok = riak_api_pb_service:deregister(?ADMIN_SERVICES),
     ok.
 
-maybe_setup(false, _) ->
+maybe_setup(false) ->
     ok;
-maybe_setup(true, SupPid) ->
+maybe_setup(true) ->
     Routes = yz_wm_search:routes() ++ yz_wm_extract:routes() ++
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
     maybe_register_pb(?QUERY_SERVICES),
     maybe_register_pb(?ADMIN_SERVICES),
-    riak_core_node_watcher:service_up(yokozuna, SupPid),
     ok.
 
 %% @doc Conditionally register PB service IFF Riak Search is not

--- a/src/yz_general_sup.erl
+++ b/src/yz_general_sup.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervisor for long-lived processes *other* than yz_solr_proc,
+%% because they don't want to live under yz_solr_sup's specific
+%% restart strategy.
+
+-module(yz_general_sup).
+-behaviour(supervisor).
+-include("yokozuna.hrl").
+-export([start_link/0]).
+-export([init/1]).
+
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+
+%%%===================================================================
+%%% Callbacks
+%%%===================================================================
+
+init([]) ->
+    Events = {yz_events,
+              {yz_events, start_link, []},
+              permanent, 5000, worker, [yz_events]},
+
+    HashtreeSup = {yz_index_hashtree_sup,
+                   {yz_index_hashtree_sup, start_link, []},
+                   permanent, infinity, supervisor, [yz_index_hashtree_sup]},
+
+    EntropyMgr = {yz_entropy_mgr,
+                  {yz_entropy_mgr, start_link, []},
+                  permanent, 5000, worker, [yz_entropy_mgr]},
+
+    Cover = {yz_cover,
+             {yz_cover, start_link, []},
+             permanent, 5000, worker, [yz_cover]},
+
+    Children = [Events, HashtreeSup, EntropyMgr, Cover],
+
+    {ok, {{one_for_one, 5, 10}, Children}}.

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -143,7 +143,7 @@ terminate(_, S) ->
             ok;
         Pid ->
             os:cmd("kill -TERM " ++ integer_to_list(Pid)),
-            port_close(Port),
+            catch port_close(Port),
             ok
     end.
 
@@ -170,6 +170,11 @@ ensure_data_dir(Dir) ->
     end.
 
 -spec build_cmd(non_neg_integer(), non_neg_integer(), string()) -> {string(), [string()]}.
+build_cmd(_SolrPort, _SolrJXMPort, "data/::yz_solr_start_timeout::") ->
+    %% this will start an executable to keep yz_solr_proc's port
+    %% happy, but will never respond to pings, so we can test the
+    %% timeout capability
+    {os:find_executable("grep"), ["foo"]};
 build_cmd(SolrPort, SolrJMXPort, Dir) ->
     YZPrivSolr = filename:join([?YZ_PRIV, "solr"]),
     {ok, Etc} = application:get_env(riak_core, platform_etc_dir),

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -109,6 +109,7 @@ handle_info({check_solr, WaitTimeSecs}, S=?S_MATCH) ->
         true ->
             %% solr finished its startup, be merry
             ?INFO("solr is up", []),
+            riak_core_node_watcher:service_up(yokozuna, self()),
             {noreply, S};
         false when WaitTimeSecs > 0 ->
             %% solr hasn't finished yet, keep waiting

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -67,27 +67,32 @@ getpid() ->
 %%% Callbacks
 %%%===================================================================
 
-%% NOTE: Doing the work here will slow down startup but I think that's
-%%       desirable given that Solr must be up for Yokozuna to work
-%%       properly.
+%% NOTE: JVM startup is broken into two pieces:
+%%       1. ensuring the data dir exists, and spawning the JVM process
+%%       2. checking whether solr finished initialization
+%%
+%%       The first bit is done here, because if it take more than the
+%%       five second supervisor limit, something is *really* wrong.
+%%
+%%       The second bit is done once per second until solr is found to
+%%       be up, or until the startup timeout expires. The idea behind
+%%       the once-per second check is to get something in the log soon
+%%       after Solr is confirmed up, instead of waiting until the
+%%       timeout expires.
 init([Dir, SolrPort, SolrJMXPort]) ->
     ensure_data_dir(Dir),
     process_flag(trap_exit, true),
     {Cmd, Args} = build_cmd(SolrPort, SolrJMXPort, Dir),
     ?INFO("Starting solr: ~p ~p", [Cmd, Args]),
     Port = run_cmd(Cmd, Args),
-    case wait_for_solr(solr_startup_wait()) of
-        ok ->
-            S = #state{
-              dir=Dir,
-              port=Port,
-              solr_port=SolrPort,
-              solr_jmx_port=SolrJMXPort
-             },
-            {ok, S};
-        Reason ->
-            Reason
-    end.
+    schedule_solr_check(solr_startup_wait()),
+    S = #state{
+      dir=Dir,
+      port=Port,
+      solr_port=SolrPort,
+      solr_jmx_port=SolrJMXPort
+     },
+    {ok, S}.
 
 handle_call(getpid, _, S) ->
     {reply, get_pid(?S_PORT(S)), S};
@@ -99,6 +104,21 @@ handle_cast(Req, S) ->
     ?WARN("unexpected request ~p", [Req]),
     {noreply, S}.
 
+handle_info({check_solr, WaitTimeSecs}, S=?S_MATCH) ->
+    case is_up() of
+        true ->
+            %% solr finished its startup, be merry
+            ?INFO("solr is up", []),
+            {noreply, S};
+        false when WaitTimeSecs > 0 ->
+            %% solr hasn't finished yet, keep waiting
+            schedule_solr_check(WaitTimeSecs),
+            {noreply, S};
+        false ->
+            %% solr did not finish startup quickly enough, or has just
+            %% crashed and the exit message is on its way, shutdown
+            {stop, "solr didn't start in alloted time", S}
+    end;
 handle_info({_Port, {data, Data}}, S=?S_MATCH) ->
     ?DEBUG("~p", Data),
     {noreply, S};
@@ -193,6 +213,13 @@ get_pid(Port) ->
 
 %% @private
 %%
+%% @doc send a message to this server to remind it to check if solr
+%% finished starting
+schedule_solr_check(WaitTimeSecs) ->
+    erlang:send_after(1000, self(), {check_solr, WaitTimeSecs-1}).
+
+%% @private
+%%
 %% @doc Determine if Solr is running.
 -spec is_up() -> boolean().
 is_up() ->
@@ -213,14 +240,3 @@ solr_jvm_args() ->
     app_helper:get_env(?YZ_APP_NAME,
                        solr_jvm_args,
                        ?YZ_DEFAULT_SOLR_JVM_ARGS).
-
-wait_for_solr(0) ->
-    {stop, "Solr didn't start in alloted time"};
-wait_for_solr(N) ->
-    case is_up() of
-        true ->
-            ok;
-        false ->
-            timer:sleep(1000),
-            wait_for_solr(N-1)
-    end.

--- a/src/yz_sup.erl
+++ b/src/yz_sup.erl
@@ -59,7 +59,7 @@ init([_Enabled]) ->
 
     GeneralSup = {yz_general_sup,
                   {yz_general_sup, start_link, []},
-                  permanent, 5000, supervisor, [yz_general_sup]},
+                  permanent, infinity, supervisor, [yz_general_sup]},
 
     Children = [SolrSup, GeneralSup],
 

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -169,9 +169,9 @@ function build_riak_yokozuna()
     fi
 
     if [ ! -e dev/dev1 ]; then
-        info "build stagedevrel"
-        if ! make stagedevrel; then
-            error "failed to make stagedevrel"
+        info "build devrel"
+        if ! make devrel; then
+            error "failed to make devrel"
         fi
     fi
 

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -169,9 +169,9 @@ function build_riak_yokozuna()
     fi
 
     if [ ! -e dev/dev1 ]; then
-        info "build devrel"
-        if ! make devrel; then
-            error "failed to make devrel"
+        info "build stagedevrel"
+        if ! make stagedevrel; then
+            error "failed to make stagedevrel"
         fi
     fi
 


### PR DESCRIPTION
Solr startup may take several seconds. All `gen_server:init` functions must finish within five seconds, though. So, waiting for Solr to become available in `yz_solr_proc:init` is not practical.

This PR splits the startup into two stages.
1. In `init`, we still make sure the data directory is setup correctly, and also spawn the JVM process.
2. After returning from init, `yz_solr_proc` checks once per second whether Solr has finished starting. If it hasn't finished by the set timeout, `yz_solr_proc` exits with a message about the timeout.

In order to support this new startup timeout, the application supervisors have also been rearranged. The `yz_solr_proc` process now lives under its own `yz_solr_sup` supervisor, while all other servers now live under a `yz_general_sup` supervisor. This is to allow for different restart policies for the children of each. Both of these new supervisors now live under the top-level `yz_sup`, where the restart strategy sets max restarts to zero. The idea is that if any child of the `solr` or `general` supervisor misbehaves enough that one of those supervisors exits, the whole app should tear down.

The restart strategy of `yz_solr_sup` attempts to match Solr's startup time. This PR sets things so that `yz_solr_sup` is not allowed to restart more than once within a span three times the length of the configured startup timeout. The idea is that if Solr falls over, the supervisor will attempt to restart it once, but if it fails to restart fast enough, the restart is not tried again.

A too-slow initial startup looks a little odd: `yz_solr_sup` exits with a message about the startup timeout, and then the supervisor tries to restart it. Typically this restart happens too quickly for the JVM to die and release network resources, though, so the restart will fail immediately when Jetty gets an error about ports already being in use. The biggest problem I foresee with this is that users are likely to send us log excerpts of the wrong error message. I'm not sure I see a clean fix yet, though.

The final commit of this PR also moves the registration with the `riak_core_node_watcher` service to `yz_solr_proc` so that it doesn't happen until Solr has become available. This also ties the service's status to the `yz_solr_proc` process instead of the yz supervisor. Since Erlang application startup no longer waits for Solr, this seemed the right thing to do.

~~The test for this change is `yz_solr_start_timeout`. It's a little bit of a tricky test. What it needs to do is prevent Solr from starting, but allow the JVM to start. This will keep `yz_solr_proc` in its wait state until it reaches its timeout. The best way I've found to make this happen so far is to delete `solr.war` from the node under test. An error is printed in the Solr log, but Jetty still hangs around anyway. This makes testing a little sticky for two reasons:~~
1. ~~If yz_solr_start_timeout fails, the dev node will be left in a state that will never correctly start solr, because solr.war is missing.~~
2. ~~I had to change `verify.sh` to use `devrel` instead of `stagedevrel`. With `stagedevrel`, the `solr.war` is contained in a symlinked yokozuna directory. The git-reset done by riak_test between tests does not reach into symlinked directories, so `solr.war` would never be restored.~~

~~A possible better test would be to use intercepts to override `yz_solr_proc:build_cmd/3` to make it return any command other than Solr that would stick around but not respond to Solr pings. Using the "manual" test-specific method of installing intercepts is not fast enough to get one installed before the process starts, though. The global config version may be, but I didn't try because the correct location of the intercept module was also uncertain.~~

The test has been changed to pass a well-known string for the data directory. This well-known string causes `yz_solr_proc` to start `grep` instead of jetty/solr. Since grep will never respond to a solr ping, `yz_solr_proc` eventually reaches its timeout. Hopefully our test machines have grep installed. This change means that `verify.sh` goes back to using `stagedevrel` safely.
