### PR TITLE
Remove entropy data timestamp

### DIFF
--- a/java_src/com/basho/yokozuna/handler/EntropyData.java
+++ b/java_src/com/basho/yokozuna/handler/EntropyData.java
@@ -69,11 +69,6 @@ public class EntropyData
         BytesRef cont = contParam != null ?
             decodeCont(contParam) : DEFAULT_CONT;
 
-        // TODO: Make before required in handler config
-        String before = req.getParams().get("before");
-        if (before == null) {
-            throw new Exception("Parameter 'before' is required");
-        }
         int n = req.getParams().getInt("n", DEFAULT_N);
 
         String partition = req.getParams().get("partition");
@@ -124,7 +119,6 @@ public class EntropyData
 
             String text = null;
             String[] vals = null;
-            String ts = null;
             String docPartition = null;
             String riakBucket = null;
             String riakKey = null;
@@ -140,19 +134,11 @@ public class EntropyData
                     text = tmp.utf8ToString();
                     log.debug("text: " + text);
                     vals = text.split(" ");
-                    ts = vals[0];
 
-                    // TODO: what if null?
-                    if (! (ts.compareTo(before) < 0)) {
-                        rsp.add("more", false);
-                        docs.setNumFound(count);
-                        return;
-                    }
-
-                    docPartition = vals[1];
-                    riakBucket = vals[2];
-                    riakKey = vals[3];
-                    hash = vals[4];
+                    docPartition = vals[0];
+                    riakBucket = vals[1];
+                    riakKey = vals[2];
+                    hash = vals[3];
                     if (partition.equals(docPartition)) {
                         SolrDocument tmpDoc = new SolrDocument();
                         tmpDoc.addField("riak_bucket", riakBucket);

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -190,18 +190,11 @@ split_tag_names(TagNames) ->
 doc_ts(MD) ->
     dict:fetch(<<"X-Riak-Last-Modified">>, MD).
 
-gen_ts() ->
-    {{Year, Month, Day},
-     {Hour, Min, Sec}} = calendar:now_to_universal_time(erlang:now()),
-    list_to_binary(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0B",
-                                 [Year,Month,Day,Hour,Min,Sec])).
-
 %% NOTE: All of this data needs to be in one field to efficiently
 %%       iterate.  Otherwise the doc would have to be fetched for each
 %%       entry.
 gen_ed(O, Hash, Partition) ->
-    TS = gen_ts(),
     RiakBucket = yz_kv:get_obj_bucket(O),
     RiakKey = yz_kv:get_obj_key(O),
     Hash64 = base64:encode(Hash),
-    <<TS/binary," ",Partition/binary," ",RiakBucket/binary," ",RiakKey/binary," ",Hash64/binary>>.
+    <<Partition/binary," ",RiakBucket/binary," ",RiakKey/binary," ",Hash64/binary>>.


### PR DESCRIPTION
The entropy data timestamp is a holdover left from the very early days
of Yokozuna.  The 3rd commit to be exact.  The idea was to allow only
building a tree from data up to a certain time.  This was to prevent
spurious repair in a non-quiescent cluster.

However, the AAE system in KV doesn't have this feature and thus it is
never used.  It is simply dead code taking up time and space.  Time to
say goodbye.
