### PR TITLE
Cache Solr archive

### DIFF
--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -4,6 +4,7 @@
 #
 # Usage:
 #     ./grab-solr.sh
+#
 #     specify SOLR_PKG_DIR to skip the solr download and use a local copy
 set -e
 
@@ -15,6 +16,9 @@ fi
 SOLR_DIR=../priv/solr
 BUILD_DIR=../build
 VSN=solr-4.3.0-yz
+FILENAME=$VSN.tgz
+TMP_DIR=/tmp/yokozuna
+TMP_FILE=$TMP_DIR/$FILENAME
 SRC_DIR=$BUILD_DIR/$VSN
 EXAMPLE_DIR=$SRC_DIR/example
 
@@ -28,12 +32,22 @@ get_solr()
 {
         if [[ -z ${SOLR_PKG_DIR+x} ]]
         then
-          wget --no-check-certificate --progress=dot:mega https://s3.amazonaws.com/yzami/pkgs/$VSN.tgz
+            if [ -e /tmp/yokozuna/$VSN.tgz ]; then
+                echo "Using cached copy of Solr $TMP_FILE"
+                ln -s $TMP_FILE $FILENAME
+            else
+                echo "Pulling Solr from S3"
+                wget --no-check-certificate --progress=dot:mega https://s3.amazonaws.com/yzami/pkgs/$FILENAME
+                mkdir $TMP_DIR
+                cp $FILENAME $TMP_DIR
+            fi
         else
-          echo "Using local copy of $VSN.tgz"
-          cp $SOLR_PKG_DIR/$VSN.tgz ./
+            # This is now obsolete thanks to implicit caching above
+            # but will leave in for now as to not break anyone.
+            echo "Using local copy of Solr $SOLR_PKG_DIR/$FILENAME"
+            cp $SOLR_PKG_DIR/$FILENAME ./
         fi
-        tar zxf $VSN.tgz
+        tar zxf $FILENAME
 }
 
 if check_for_solr


### PR DESCRIPTION
Cache the Solr archive in /tmp/yokozuna to avoid superfluous network
activity.

The very first time you build Yokozuna (or if the Solr version changes) it will pull Solr archive from S3.  All subsequent builds will check `/tmp/yokozuna` for a local cache and use a symlink.  Thus reducing network usage, disk usage, and build time.

Example of build output when cached copy is used.

```
Using cached copy of Solr /tmp/yokozuna/solr-4.3.0-yz.tgz
```
