### PR TITLE
Make YZ_BENCH_DIR environment variable optional

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,7 @@ Open `~/.riak_test.config` and add the following to the end.
     {yokozuna, [
                 {rt_project, "yokozuna"},
                 {rt_deps, ["<path-to-testing-dir>/riak_yz/deps"]},
+                {yz_dir, ["<path-to-testing-dir>/riak_yz"]},
                 {rtdev_path, [{root, "/tmp/rt"},
                               {current, "/tmp/rt/riak_yz"}]}
                ]}.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,7 +52,7 @@ Open `~/.riak_test.config` and add the following to the end.
     {yokozuna, [
                 {rt_project, "yokozuna"},
                 {rt_deps, ["<path-to-testing-dir>/riak_yz/deps"]},
-                {yz_dir, ["<path-to-testing-dir>/riak_yz"]},
+                {yz_dir, ["<path-to-testing-dir>/riak_yz/deps/yokozuna"]},
                 {rtdev_path, [{root, "/tmp/rt"},
                               {current, "/tmp/rt/riak_yz"}]}
                ]}.

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -24,7 +24,7 @@
 
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -24,7 +24,7 @@
 
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -38,7 +38,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Nodes = rt:deploy_nodes(4, ?CFG),

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -38,7 +38,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),,
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Nodes = rt:deploy_nodes(4, ?CFG),

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -38,7 +38,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),,
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Nodes = rt:deploy_nodes(4, ?CFG),

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -25,7 +25,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -25,7 +25,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -17,7 +17,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(2, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -17,7 +17,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(2, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -37,7 +37,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -37,7 +37,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -19,7 +19,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(1, ?CFG),

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -19,7 +19,7 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(1, ?CFG),

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -30,7 +30,7 @@
 </schema>">>).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -30,7 +30,7 @@
 </schema>">>).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -58,7 +58,7 @@
 %% TODO: migration by re-index command
 confirm() ->
     lager:info("ticktime: ~p", [net_kernel:get_net_ticktime()]),
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(lists:duplicate(3, {previous, ?CFG})),
 

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -58,7 +58,7 @@
 %% TODO: migration by re-index command
 confirm() ->
     lager:info("ticktime: ~p", [net_kernel:get_net_ticktime()]),
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(lists:duplicate(3, {previous, ?CFG})),
 

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -173,7 +173,7 @@ run_bb(Method, File) ->
               sync -> cmd;
               async -> spawn_cmd
           end,
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     Path = lists:flatten(YZBenchDir ++ "/deps/basho_bench/basho_bench " ++ File),
     rt:Fun(Path).
 

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -173,7 +173,8 @@ run_bb(Method, File) ->
               sync -> cmd;
               async -> spawn_cmd
           end,
-    rt:Fun("$YZ_BENCH_DIR/deps/basho_bench/basho_bench " ++ File).
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),,
+    rt:Fun(YZBenchDir ++ "/deps/basho_bench/basho_bench " ++ File).
 
 search_expect(HP, Index, Name, Term, Expect) ->
     search_expect(yokozuna, HP, Index, Name, Term, Expect).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -173,8 +173,9 @@ run_bb(Method, File) ->
               sync -> cmd;
               async -> spawn_cmd
           end,
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),,
-    rt:Fun(YZBenchDir ++ "/deps/basho_bench/basho_bench " ++ File).
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    Path = lists:flatten(YZBenchDir ++ "/deps/basho_bench/basho_bench " ++ File),
+    rt:Fun(Path).
 
 search_expect(HP, Index, Name, Term, Expect) ->
     search_expect(yokozuna, HP, Index, Name, Term, Expect).

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -14,7 +14,7 @@
 -define(CFG, [{yokozuna, [{enabled, true}]}]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
+    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -14,7 +14,7 @@
 -define(CFG, [{yokozuna, [{enabled, true}]}]).
 
 confirm() ->
-    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR"),
+    YZBenchDir = rt_config:get_os_env("YZ_BENCH_DIR", rt_config:get(rt_bench_path)),
     code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),


### PR DESCRIPTION
Instead you can use `{rt_bench_path, ["/tmp/yz-verify/yokozuna/misc/bench"]},` in your .riak_test.config so Giddyup can actually run the tests.
