### PR TITLE
Use `basho_bench` riak test config

### DIFF
--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -25,7 +25,6 @@
 
 confirm() ->
     YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     PBConns = yz_rt:open_pb_conns(Cluster),

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -25,8 +25,6 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -17,8 +17,6 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(2, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),
     create_index(Cluster, ?INDEX),

--- a/riak_test/yz_flag_transitions.erl
+++ b/riak_test/yz_flag_transitions.erl
@@ -38,7 +38,6 @@
 
 confirm() ->
     YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -19,8 +19,6 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(1, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -30,8 +30,6 @@
 </schema>">>).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -59,7 +59,6 @@
 confirm() ->
     lager:info("ticktime: ~p", [net_kernel:get_net_ticktime()]),
     YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     Cluster = rt:build_cluster(lists:duplicate(3, {previous, ?CFG})),
 
     create_index(Cluster, riak_search),

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -173,8 +173,8 @@ run_bb(Method, File) ->
               sync -> cmd;
               async -> spawn_cmd
           end,
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    Path = lists:flatten(YZBenchDir ++ "/deps/basho_bench/basho_bench " ++ File),
+    BB = filename:join([rt_config:get(basho_bench), "basho_bench"]),
+    Path = lists:flatten([BB, " ", File]),
     rt:Fun(Path).
 
 search_expect(HP, Index, Name, Term, Expect) ->

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -14,8 +14,6 @@
 -define(CFG, [{yokozuna, [{enabled, true}]}]).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
     random:seed(now()),
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -217,7 +217,6 @@ function run_riak_test_tests()
     fi
 
     info "run yokozuna riak_test tests"
-    export YZ_BENCH_DIR=$(pwd)/misc/bench
     if ! $WORK_DIR/riak_test/riak_test -c yz_verify -d riak_test/ebin; then
         error "yokozuna riak_test tests failed"
     fi


### PR DESCRIPTION
Use the `basho_bench` riak test config to play nice with the automated testers.

/cc @jaredmorrow 

Related to #132.
