### PR TITLE
Don't store all _yz fields

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -294,14 +294,14 @@
 -define(YZ_ED_FIELD, '_yz_ed').
 -define(YZ_ED_FIELD_S, "_yz_ed").
 -define(YZ_ED_FIELD_XML, ?YZ_FIELD_XML(?YZ_ED_FIELD_S)).
--define(YZ_ED_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_ed\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
+-define(YZ_ED_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_ed\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
 %% First Partition Number
 -define(YZ_FPN_FIELD, '_yz_fpn').
 -define(YZ_FPN_FIELD_S, "_yz_fpn").
 -define(YZ_FPN_FIELD_B, <<"_yz_fpn">>).
 -define(YZ_FPN_FIELD_XML, ?YZ_FIELD_XML(?YZ_FPN_FIELD_S)).
--define(YZ_FPN_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_fpn\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
+-define(YZ_FPN_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_fpn\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
 %% Sibling VTags
 -define(YZ_VTAG_FIELD, '_yz_vtag').
@@ -314,14 +314,14 @@
 -define(YZ_NODE_FIELD, '_yz_node').
 -define(YZ_NODE_FIELD_S, "_yz_node").
 -define(YZ_NODE_FIELD_XML, ?YZ_FIELD_XML(?YZ_NODE_FIELD_S)).
--define(YZ_NODE_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_node\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
+-define(YZ_NODE_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_node\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
 %% Partition Number
 -define(YZ_PN_FIELD, '_yz_pn').
 -define(YZ_PN_FIELD_S, "_yz_pn").
 -define(YZ_PN_FIELD_B, <<"_yz_pn">>).
 -define(YZ_PN_FIELD_XML, ?YZ_FIELD_XML(?YZ_PN_FIELD_S)).
--define(YZ_PN_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_pn\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
+-define(YZ_PN_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_pn\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
 %% Riak key
 -define(YZ_RK_FIELD, '_yz_rk').

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -308,7 +308,7 @@
 -define(YZ_VTAG_FIELD_S, "_yz_vtag").
 -define(YZ_VTAG_FIELD_B, <<"_yz_vtag">>).
 -define(YZ_VTAG_FIELD_XML, ?YZ_FIELD_XML(?YZ_VTAG_FIELD_S)).
--define(YZ_VTAG_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_vtag\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
+-define(YZ_VTAG_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_vtag\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
 %% Node
 -define(YZ_NODE_FIELD, '_yz_node').

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -112,20 +112,20 @@
    <field name="_yz_id" type="_yz_str" indexed="true" stored="true" required="true"/>
 
    <!-- Entropy Data: Data related to anti-entropy -->
-   <field name="_yz_ed" type="_yz_str" indexed="true" stored="true"/>
+   <field name="_yz_ed" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- Partition Number: Used as a filter query param -->
-   <field name="_yz_pn" type="_yz_str" indexed="true" stored="true"/>
+   <field name="_yz_pn" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- First Partition Number: The first partition in this doc's
         preflist, used for further filtering on overlapping partitions. -->
-   <field name="_yz_fpn" type="_yz_str" indexed="true" stored="true"/>
+   <field name="_yz_fpn" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- If there is a sibling, use vtag to differentiate them -->
    <field name="_yz_vtag" type="_yz_str" indexed="true" stored="true"/>
 
    <!-- Node: The name of the node that this doc was created on. -->
-   <field name="_yz_node" type="_yz_str" indexed="true" stored="true"/>
+   <field name="_yz_node" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- Riak Key: The key of the Riak object this doc corresponds to. -->
    <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"/>

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -122,7 +122,7 @@
    <field name="_yz_fpn" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- If there is a sibling, use vtag to differentiate them -->
-   <field name="_yz_vtag" type="_yz_str" indexed="true" stored="true"/>
+   <field name="_yz_vtag" type="_yz_str" indexed="true" stored="false"/>
 
    <!-- Node: The name of the node that this doc was created on. -->
    <field name="_yz_node" type="_yz_str" indexed="true" stored="false"/>


### PR DESCRIPTION
The entropy data, node, partition and first partition fields do not
need to be stored.  They are only used for filtering by Yokozuna and
are of no immediate use to the user.  The `_yz_id` field is also of no
use but Solr's distributed search requires the id field to be stored.

By not storing these fields a lot of space is saved in the index.  In
one benchmark disk usage was reduced by 25%.
