### PR TITLE
Don't wait for riak_kv service

### DIFF
--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -34,7 +34,6 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
-    riak_core:wait_for_service(riak_kv),
     Enabled = ?YZ_ENABLED,
     case yz_sup:start_link(Enabled) of
         {ok, Pid} ->


### PR DESCRIPTION
Forcing Yokozuna to wait for the riak_kv service causes all
applications which start after Yokozuna to wait.  This can come at the
detriment of those applications.  I've also been told this can crash
the Riak node if an application takes too long to start.

I'm confident I had good reasons for originally waiting for the
riak_kv service.  I believe it had to do with Yokozuna start-up
requiring KV reads around schemas and other such things.  This was
probably related an older implementation of the default index.  The
default index has since been entirely removed.

A race may still exist, but a KV read may fail for many reasons.
Yokozuna should face the harsh reality that a read may fail and deal
with it as best as possible.  Yokozuna shouldn't wait for the riak_kv
service, negatively affecting other applications, just to avoid a
particular race that can be dealt with in a more fundamental way.
