### PR TITLE
Use common URL prefix

### DIFF
--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -54,4 +54,4 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 extract_url({Host,Port}) ->
-    ?FMT("http://~s:~B/extract", [Host, Port]).
+    ?FMT("http://~s:~B/yz/extract", [Host, Port]).

--- a/src/yz_wm_extract.erl
+++ b/src/yz_wm_extract.erl
@@ -29,7 +29,7 @@
          }).
 
 routes() ->
-    [{["extract"], yz_wm_extract, []}].
+    [{["yz", "extract"], yz_wm_extract, []}].
 
 init(_) ->
     {ok, #state{}}.

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -31,7 +31,8 @@
 %% @doc Return the list of routes provided by this resource.
 -spec routes() -> [tuple()].
 routes() ->
-    Routes1 = [{["search", index], ?MODULE, []}],
+    Routes1 = [{["yz", "search", index], ?MODULE, []},
+               {["search", index], ?MODULE, []}],
     case yz_misc:is_riak_search_enabled() of
         false ->
             [{["solr", index, "select"], ?MODULE, []}|Routes1];


### PR DESCRIPTION
For consistency, use the yz prefix for all HTTP resources.
