### PR TITLE
Schema bucket should disallow siblings

### DIFF
--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -57,6 +57,7 @@ maybe_setup(true) ->
     maybe_register_pb(?QUERY_SERVICES),
     maybe_register_pb(?ADMIN_SERVICES),
     setup_stats(),
+    ok = yz_schema:setup_schema_bucket(),
     ok.
 
 %% @doc Conditionally register PB service IFF Riak Search is not

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -71,6 +71,12 @@ exists(SchemaName) ->
 %%% Private
 %%%===================================================================
 
+%% @doc Set ?YZ_SCHEMA_BUCKET with the property {allow_mult, false}
+%%      We never want schema value siblings.
+-spec setup_schema_bucket() -> ok.
+setup_schema_bucket() ->
+    ok = riak_core_bucket:set_bucket(?YZ_SCHEMA_BUCKET, [{allow_mult, false}]).
+
 %% @private
 %%
 %% @doc Parse the schema and verify it contains necessary elements.


### PR DESCRIPTION
The new `default_bucket_props` have `allow_mult=true`, which is hell on the `_yz_schema` bucket, which shouldn't have sibling schema values.
