### PR TITLE
Log JVM stdout/err to INFO level

### DIFF
--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -121,7 +121,7 @@ handle_info({check_solr, WaitTimeSecs}, S=?S_MATCH) ->
             {stop, "solr didn't start in alloted time", S}
     end;
 handle_info({_Port, {data, Data}}, S=?S_MATCH) ->
-    ?DEBUG("~p", Data),
+    ?INFO("solr stdout/err: ~p", Data),
     {noreply, S};
 handle_info({_Port, {exit_status, ExitStatus}}, S) ->
     {stop, {"solr OS process exited", ExitStatus}, S};


### PR DESCRIPTION
Sometimes when the JVM/Jetty/Solr fails to start the only indication
is found in stdout/err. Log at the INFO level. If things are running
properly then there should be no logging.
