### PR TITLE
Add anti-entropy dir to cuttlefish schema

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -42,6 +42,6 @@
 ]}.
 
 %% @doc The directory where aae data files are stored
-{mapping, "yokozuna.anti_entropy_data_dir", "yokozuna.anti_entropy_data_dir", [
-  {default, "./data/yz_anti_entropy" }
+{mapping, "yokozuna.anti_entropy_data_dir", "yokozuna.anti_entropy.data_dir", [
+  {default, "{{platform_data_dir}}/yz_anti_entropy" }
 ]}.

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -40,3 +40,8 @@
 {mapping, "yokozuna.data_dir", "yokozuna.yz_dir", [
   {default, "{{yz_dir}}" }
 ]}.
+
+%% @doc The directory where aae data files are stored
+{mapping, "yokozuna.anti_entropy_data_dir", "yokozuna.anti_entropy_data_dir", [
+  {default, "./data/yz_anti_entropy" }
+]}.

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -42,6 +42,6 @@
 ]}.
 
 %% @doc The directory where aae data files are stored
-{mapping, "yokozuna.anti_entropy_data_dir", "yokozuna.anti_entropy.data_dir", [
+{mapping, "yokozuna.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
   {default, "{{platform_data_dir}}/yz_anti_entropy" }
 ]}.


### PR DESCRIPTION
Got this warning when I started Riak w/ YZ enabled:

```
[warning] Config yokozuna/anti_entropy_data_dir is missing. Defaulting to: "./data/yz_anti_entropy"
```

But there is no setting (or default) in https://github.com/basho/yokozuna/blob/develop/priv/yokozuna.schema

cc/ @joedevivo 
