### PR TITLE
Setting meta via PB fails

### DIFF
--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -133,10 +133,11 @@ get_user_meta(MD) ->
         none ->
             dict:new();
         MetaMeta ->
+
             %% NOTE: Need to call `to_lower' because
             %%       `erlang:decode_packet' which is used by mochiweb
             %%       will modify the case of certain header names
-            MM2 = [{list_to_binary(string:to_lower(K)), list_to_binary(V)}
+            MM2 = [{format_meta(key, K), format_meta(value, V)}
                    || {K,V} <- MetaMeta],
             dict:from_list(MM2)
     end.
@@ -200,3 +201,13 @@ gen_ed(O, Hash, Partition) ->
     RiakKey = yz_kv:get_obj_key(O),
     Hash64 = base64:encode(Hash),
     <<Partition/binary," ",RiakBucket/binary," ",RiakKey/binary," ",Hash64/binary>>.
+
+%% Meta keys and values can be strings or binaries
+format_meta(key, Value) when is_binary(Value) ->
+    format_meta(key, binary_to_list(Value));
+format_meta(key, Value) ->
+    list_to_binary(string:to_lower(Value));
+format_meta(value, Value) when is_binary(Value) ->
+    Value;
+format_meta(value, Value) ->
+    list_to_binary(Value).


### PR DESCRIPTION
We can't control whether user meta keys are given to us as lists or binaries. This is a failed test when populating meta via a PB interface.

[error] <0.762.0>@yz_kv:index:161 failed to index object {<<"test">>,<<"tygra">>} with error function_clause because [{string,to_lower,[<<"x-riak-meta-yz-tags">>],[{file,"string.erl"},{line,493}]},{yz_doc,'-get_user_meta/1-lc$^0/1-0-',1,[{file,"src/yz_doc.erl"},{line,139}]},{yz_doc,get_user_meta,1,[{file,"src/yz_doc.erl"},{line,139}]},{yz_doc,extract_tags,1,[{file,"src/yz_doc.erl"},{line,118}]},{yz_doc,make_doc,5,[{file,"src/yz_doc.erl"},{line,64}]},{yz_doc,'-make_docs/4-lc$^0/1-0-',5,[{file,"src/yz_doc.erl"},{line,52}]},{yz_kv,index,7,[{file,"src/yz_kv.erl"},{line,207}]},{yz_kv,index,3,[{file,"src/yz_kv.erl"},{line,148}]}]

I swear I fixed this once before :-/
