### PR TITLE
Still need to support Erlang 15B

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -108,8 +108,10 @@
 -define(ATOM_TO_BIN(A), list_to_binary(atom_to_list(A))).
 -define(BIN_TO_ATOM(B), list_to_atom(binary_to_list(B))).
 -define(BIN_TO_INT(B), list_to_integer(binary_to_list(B))).
+-define(BIN_TO_FLOAT(B), list_to_float(binary_to_list(B))).
 -define(INT_TO_BIN(I), list_to_binary(integer_to_list(I))).
 -define(INT_TO_STR(I), integer_to_list(I)).
+-define(FLOAT_TO_BIN(F), list_to_binary(float_to_list(F))).
 -define(PARTITION_BINARY(S), S#state.partition_binary).
 -define(HEAD_CTYPE, "content-type").
 -define(YZ_HEAD_EXTRACTOR, "yz-extractor").

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -195,6 +195,6 @@ confirm_stored_fields(Cluster) ->
         riakc_pb_socket:search(Pid, Bucket, Search, Params),
     ?assertEqual(<<"true">>, proplists:get_value(<<"bool_b">>, Fields)),
     ?assertEqual(3.14,
-                 binary_to_float(proplists:get_value(<<"float_tf">>, Fields))),
+                 ?BIN_TO_FLOAT(proplists:get_value(<<"float_tf">>, Fields))),
     ?assertEqual(Bucket, proplists:get_value(<<"_yz_rb">>, Fields)),
     riakc_pb_socket:stop(Pid).

--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -164,9 +164,11 @@ encode_field({Field, Val}, EncodedDoc) ->
 %% numbers.
 -spec encode_val(number() | atom() | binary()) -> atom() | binary().
 encode_val(Val) when is_integer(Val) ->
-    integer_to_binary(Val);
+    %% TODO Use 16B `integer_to_binary' BIF once we ditch 15B support
+    ?INT_TO_BIN(Val);
 encode_val(Val) when is_float(Val) ->
-    float_to_binary(Val);
+    %% TODO Use 16B `float_to_binary' BIF once we ditch 15B support
+    ?FLOAT_TO_BIN(Val);
 encode_val(Val) ->
     Val.
 


### PR DESCRIPTION
For the time being Yokozuna still needs to compile on 15B and cannot
use the new BIFs.

Pinging @jaredmorrow and @coderoshi 
