### PR TITLE
Correspondence to Apache Lucene 4.5.x, and detailed change of java_scr 

### DIFF
--- a/java_src/com/basho/yokozuna/monitor/Monitor.java
+++ b/java_src/com/basho/yokozuna/monitor/Monitor.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * down or yz_solr_proc exits.
  */
 public class Monitor extends Thread {
-    protected static Logger log = LoggerFactory.getLogger(Monitor.class);
+    protected static final Logger log = LoggerFactory.getLogger(Monitor.class);
 
     public Monitor() {
         // nothing to init
@@ -33,15 +33,23 @@ public class Monitor extends Thread {
 
     public void run() {
             try {
-                log.debug("Monitor attempting read on stdin");
+                if (log.isDebugEnabled()) {
+                    log.debug("Monitor attempting read on stdin");
+                }
                 if (System.in.read() < 0) {
-                    log.info("Yokozuna has exited - shutting down Solr");
+                    if (log.isInfoEnabled()) {
+                        log.info("Yokozuna has exited - shutting down Solr");
+                    }
                     System.exit(0);
                 }
-                log.debug("Monitoring succeeded reading stdin");
+                if (log.isDebugEnabled()) {
+                    log.debug("Monitoring succeeded reading stdin");
+                }
             }
-            catch (IOException ioe) {
-                log.info("Yokozuna has exited - shutting down Solr");
+            catch (final IOException ioe) {
+                if (log.isInfoEnabled()) {
+                    log.info("Yokozuna has exited - shutting down Solr");
+                }
                 System.exit(0);
             }
     }
@@ -50,7 +58,7 @@ public class Monitor extends Thread {
      * Start monitoring stdin in a background thread
      */
     public static Monitor monitor() {
-        Monitor m = new Monitor();
+        final Monitor m = new Monitor();
         m.start();
         return m;
     }
@@ -67,7 +75,7 @@ public class Monitor extends Thread {
                 Thread.sleep(1000);
             }
         }
-        catch (InterruptedException ie) {
+        catch (final InterruptedException ie) {
             // nothing to do but shutdown
         }
     }

--- a/java_src/com/basho/yokozuna/query/SimpleQueryExample.java
+++ b/java_src/com/basho/yokozuna/query/SimpleQueryExample.java
@@ -19,24 +19,23 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.request.QueryRequest;
-import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 
 public class SimpleQueryExample {
 
     public static void main(String[] args) throws SolrServerException {
-        String baseURL = args[0];
-        String index = args[1];
-        String field = args[2];
-        String term = args[3];
+        final String baseURL = args[0];
+        final String index = args[1];
+        final String field = args[2];
+        final String term = args[3];
 
-        SolrServer solr = new HttpSolrServer(baseURL + "/" + index);
-        ModifiableSolrParams params = new ModifiableSolrParams();
+        final SolrServer solr = new HttpSolrServer(baseURL + "/" + index);
+        final ModifiableSolrParams params = new ModifiableSolrParams();
         params.set("qt", "/");
         params.set("q", field + ":" + term);
-        SolrRequest req = new QueryRequest(params);
+        final SolrRequest req = new QueryRequest(params);
 
-        QueryResponse resp = solr.query(params);
+        final QueryResponse resp = solr.query(params);
         System.out.println("resp: " + resp);
     }
 }


### PR DESCRIPTION
- It corresponds to Lucene-5114 [remove boolean useCache param from TermsEnum.seekCeil/Exact].
  https://issues.apache.org/jira/browse/LUCENE-5114
  
  TermsEnum.SeekStatus seekCeil(BytesRef text, boolean useCache) is removed@Lucene 4.5.x
- "final" is added to the variable which is not changed.
- The processing which judges whether it is effective in logger is added.
