### PR TITLE
Replace nested separator with dots

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -183,7 +183,7 @@ top-level object can have an object as a value, and this object can
 have another object nested inside, an so on.  Yokozuna's JSON
 extractor must have some method of converting this arbitrary nesting
 into a flat list.  It does this by concatenating nested object fields
-with a separator.  The default separator is `_`.  An example should
+with a separator.  The default separator is `.`.  An example should
 make this more clear.
 
 Below is JSON that represents a person, what city they are from and
@@ -198,17 +198,17 @@ what cities they have traveled to.
 Below is the field list that would be created by the JSON extract.
 
 ```erlang
-[{<<"info_visited">>,<<"San Francisco">>},
- {<<"info_visited">>,<<"New York">>},
- {<<"info_visited">>,<<"Boston">>},
- {<<"info_city">>,<<"Baltimore">>},
+[{<<"info.visited">>,<<"San Francisco">>},
+ {<<"info.visited">>,<<"New York">>},
+ {<<"info.visited">>,<<"Boston">>},
+ {<<"info.city">>,<<"Baltimore">>},
  {<<"name">>,<<"ryan">>}]
 ```
 
 Some key points to notice.
 
 * Nested objects have their field names concatenated to form a field
-  name.  The default field separator is `_`.  This can be modified.
+  name.  The default field separator is `.`.  This can be modified.
 
 * Any array causes field names to repeat.  This will require that your
   schema defines this field as multi-valued.

--- a/src/yz_json_extractor.erl
+++ b/src/yz_json_extractor.erl
@@ -37,12 +37,12 @@
 %% Options:
 %%
 %%   `field_separator' - Use a different field separator than the
-%%                       default of `_'.
+%%                       default of `.'.
 
 -module(yz_json_extractor).
 -compile(export_all).
 -include("yokozuna.hrl").
--define(DEFAULT_FIELD_SEPARATOR, <<"_">>).
+-define(DEFAULT_FIELD_SEPARATOR, <<".">>).
 -record(state, {
           fields = [],
           field_separator = ?DEFAULT_FIELD_SEPARATOR

--- a/src/yz_xml_extractor.erl
+++ b/src/yz_xml_extractor.erl
@@ -35,12 +35,12 @@
 %%
 %% Options:
 %%
-%%   `field_separator' - Use a different field separator than the default of `_'.
+%%   `field_separator' - Use a different field separator than the default of `.'.
 %%
 -module(yz_xml_extractor).
 -compile(export_all).
 -include("yokozuna.hrl").
--define(DEFAULT_FIELD_SEPARATOR, <<"_">>).
+-define(DEFAULT_FIELD_SEPARATOR, <<".">>).
 -record(state, {
           name_stack = [],
           fields = [],

--- a/test/yz_json_extractor_tests.erl
+++ b/test/yz_json_extractor_tests.erl
@@ -10,13 +10,13 @@ json_extract_test() ->
          {<<"age">>,<<"29">>},
          {<<"pets">>,<<"smokey">>},
          {<<"pets">>,<<"bandit">>},
-         {<<"books_title">>,<<"Introduction to Information Retrieval">>},
-         {<<"books_title">>,<<"Principles of Distributed Database Systems">>},
-         {<<"books_authors">>,<<"Christopher D. Manning">>},
-         {<<"books_authors">>,<<"Prabhakar Raghavan">>},
-         {<<"books_authors">>,<<"Hinrich Schütze">>},
-         {<<"books_authors">>,<<"M. Tamer Özsu">>},
-         {<<"books_authors">>,<<"Patrick Valduriez">>},
+         {<<"books.title">>,<<"Introduction to Information Retrieval">>},
+         {<<"books.title">>,<<"Principles of Distributed Database Systems">>},
+         {<<"books.authors">>,<<"Christopher D. Manning">>},
+         {<<"books.authors">>,<<"Prabhakar Raghavan">>},
+         {<<"books.authors">>,<<"Hinrich Schütze">>},
+         {<<"books.authors">>,<<"M. Tamer Özsu">>},
+         {<<"books.authors">>,<<"Patrick Valduriez">>},
          {<<"alive">>,true},
          {<<"married">>,false},
          {<<"a_number">>,<<"1100000.0">>},
@@ -42,45 +42,45 @@ utf8_test() ->
             ok
     end,
     Expect =
-        [{<<"langs_english">>, <<"The quick brown fox jumps over the lazy dog.">>},
-         {<<"langs_jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
-         {<<"langs_irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
-         {<<"langs_dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
-         {<<"langs_german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
-         {<<"langs_german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
-         {<<"langs_norwegian">>, <<"Blåbærsyltetøy.">>},
-         {<<"langs_danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
-         {<<"langs_swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
-         {<<"langs_icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
-         {<<"langs_finnish">>, <<"Törkylempijävongahdus.">>},
-         {<<"langs_polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
-         {<<"langs_czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
-         {<<"langs_slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
-         {<<"langs_greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
-         {<<"langs_greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
-         {<<"langs_russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
-         {<<"langs_bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
-         {<<"langs_sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
-         {<<"langs_hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
-         {<<"langs_spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
-         {<<"langs_portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
-         {<<"langs_french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
-         {<<"langs_esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
-         {<<"langs_hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
-         {<<"langs_japanese_hiragana">>, <<"
+        [{<<"langs.english">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs.jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
+         {<<"langs.irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
+         {<<"langs.dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
+         {<<"langs.german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
+         {<<"langs.german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
+         {<<"langs.norwegian">>, <<"Blåbærsyltetøy.">>},
+         {<<"langs.danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
+         {<<"langs.swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
+         {<<"langs.icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
+         {<<"langs.finnish">>, <<"Törkylempijävongahdus.">>},
+         {<<"langs.polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
+         {<<"langs.czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
+         {<<"langs.slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
+         {<<"langs.greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
+         {<<"langs.greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
+         {<<"langs.russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
+         {<<"langs.bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
+         {<<"langs.sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
+         {<<"langs.hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
+         {<<"langs.spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
+         {<<"langs.portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
+         {<<"langs.french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
+         {<<"langs.esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
+         {<<"langs.hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
+         {<<"langs.japanese_hiragana">>, <<"
     いろはにほへど　ちりぬるを
     わがよたれぞ　つねならむ
     うゐのおくやま　けふこえて
     あさきゆめみじ　ゑひもせず
   ">>},
-        {<<"langs_japanese_kanji">>, <<"
+        {<<"langs.japanese_kanji">>, <<"
     色は匂へど 散りぬるを
     我が世誰ぞ 常ならむ
     有為の奥山 今日越えて
     浅き夢見じ 酔ひもせず
   ">>},
-         {<<"langs_английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
-         {<<"langs_chinese">>, <<"
+         {<<"langs.английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs.chinese">>, <<"
     花非花
     雾非雾
     夜半来

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -3,9 +3,9 @@
 -include_lib("yz_test.hrl").
 
 make_name_test() ->
-    Expect = <<"one_two_three_four">>,
+    Expect = <<"one.two.three.four">>,
     Stack = ["four", "three", "two", "one"],
-    Result = yz_xml_extractor:make_name(<<"_">>, Stack),
+    Result = yz_xml_extractor:make_name(<<".">>, Stack),
     ?assertEqual(Expect, Result),
 
     Expect2 = <<"one_two_three_four_five">>,
@@ -25,47 +25,47 @@ utf8_test() ->
             ok
     end,
     Expect =
-        [{<<"langs_english">>, <<"The quick brown fox jumps over the lazy dog.">>},
-         {<<"langs_english@attr">>, <<"The quick">>},
-         {<<"langs_jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
-         {<<"langs_irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
-         {<<"langs_dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
-         {<<"langs_german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
-         {<<"langs_german_1@attr">>, <<"Falsches Üben">>},
-         {<<"langs_german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
-         {<<"langs_norwegian">>, <<"Blåbærsyltetøy.">>},
-         {<<"langs_danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
-         {<<"langs_swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
-         {<<"langs_icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
-         {<<"langs_finnish">>, <<"Törkylempijävongahdus.">>},
-         {<<"langs_polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
-         {<<"langs_czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
-         {<<"langs_slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
-         {<<"langs_greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
-         {<<"langs_greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
-         {<<"langs_russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
-         {<<"langs_bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
-         {<<"langs_sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
-         {<<"langs_hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
-         {<<"langs_spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
-         {<<"langs_portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
-         {<<"langs_french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
-         {<<"langs_esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
-         {<<"langs_hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
-         {<<"langs_japanese_hiragana">>, <<"
+        [{<<"langs.english">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs.english@attr">>, <<"The quick">>},
+         {<<"langs.jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
+         {<<"langs.irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
+         {<<"langs.dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
+         {<<"langs.german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
+         {<<"langs.german_1@attr">>, <<"Falsches Üben">>},
+         {<<"langs.german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
+         {<<"langs.norwegian">>, <<"Blåbærsyltetøy.">>},
+         {<<"langs.danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
+         {<<"langs.swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
+         {<<"langs.icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
+         {<<"langs.finnish">>, <<"Törkylempijävongahdus.">>},
+         {<<"langs.polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
+         {<<"langs.czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
+         {<<"langs.slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
+         {<<"langs.greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
+         {<<"langs.greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
+         {<<"langs.russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
+         {<<"langs.bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
+         {<<"langs.sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
+         {<<"langs.hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
+         {<<"langs.spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
+         {<<"langs.portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
+         {<<"langs.french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
+         {<<"langs.esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
+         {<<"langs.hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
+         {<<"langs.japanese_hiragana">>, <<"
     いろはにほへど　ちりぬるを
     わがよたれぞ　つねならむ
     うゐのおくやま　けふこえて
     あさきゆめみじ　ゑひもせず
   ">>},
-        {<<"langs_japanese_kanji">>, <<"
+        {<<"langs.japanese_kanji">>, <<"
     色は匂へど 散りぬるを
     我が世誰ぞ 常ならむ
     有為の奥山 今日越えて
     浅き夢見じ 酔ひもせず
   ">>},
-         {<<"langs_английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
-         {<<"langs_chinese">>, <<"
+         {<<"langs.английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
+         {<<"langs.chinese">>, <<"
     花非花
     雾非雾
     夜半来
@@ -73,8 +73,8 @@ utf8_test() ->
     来如春梦几多时
     去似朝云无觅处
   ">>},
-        {<<"langs_chinese@作者">>, <<"Bai Juyi">>},
-        {<<"langs_chinese@title">>, <<"The Bloom is not a Bloom">>}],
+        {<<"langs.chinese@作者">>, <<"Bai Juyi">>},
+        {<<"langs.chinese@title">>, <<"The Bloom is not a Bloom">>}],
     ?assertEqual(length(Expect), length(Result)),
     Pairs = lists:zip(lists:keysort(1, Expect), lists:keysort(1, Result)),
     [?assertPairsEq(E,R) || {E,R} <- Pairs],


### PR DESCRIPTION
Currently, the extractors separate nested XML or JSON objects with underscore (`_`). Let's replace this with dots (`.`). This should clarify that values are nested, since dot is a common separator (KVC, mongo nested queries).
