### PR TITLE
Use POST for search

### DIFF
--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -223,11 +223,11 @@ dist_search(Core, Headers, Params) ->
     end.
 
 search(Core, Headers, Params) ->
-    Encoded = mochiweb_util:urlencode(Params),
-    URL = ?FMT("~s/~s/select?~s", [base_url(), Core, Encoded]),
-    Body = [],
+    Body = mochiweb_util:urlencode(Params),
+    URL = ?FMT("~s/~s/select", [base_url(), Core]),
+    Headers2 = [{content_type, "application/x-www-form-urlencoded"}|Headers],
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, Headers, get, Body, Opts) of
+    case ibrowse:send_req(URL, Headers2, post, Body, Opts) of
         {ok, "200", RHeaders, Resp} -> {RHeaders, Resp};
         {ok, "404", _, _} -> throw(not_found);
         {ok, CodeStr, _, Err} ->

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -115,9 +115,8 @@ search(Req, S) ->
     T1 = os:timestamp(),
     Index = list_to_binary(wrq:path_info(index, Req)),
     Params = wrq:req_qs(Req),
-    ReqHeaders = mochiweb_headers:to_list(wrq:req_headers(Req)),
     try
-        Result = yz_solr:dist_search(Index, ReqHeaders, Params),
+        Result = yz_solr:dist_search(Index, Params),
         case Result of
             {error, insufficient_vnodes_available} ->
                 yz_stat:search_fail(),


### PR DESCRIPTION
- Use the POST method for search to prevent a large `fq` parameter
  from causing error.
- Don't pass request headers to Solr as this can break the POST
  search, e.g. if `content-length: 0` is passed.
