### PR TITLE
Increase Solr startup timeout

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -129,7 +129,7 @@
 
 -define(YZ_COVER_TICK_INTERVAL, app_helper:get_env(?YZ_APP_NAME, cover_tick, 2000)).
 -define(YZ_DEFAULT_SOLR_PORT, 8983).
--define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 15).
+-define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 30).
 -define(YZ_DEFAULT_TICK_INTERVAL, 60000).
 -define(YZ_DEFAULT_SOLR_JVM_ARGS, "").
 %% TODO: See if using mochiglobal for this makes difference in performance.


### PR DESCRIPTION
The default timeout of 15 seconds seems to be too low for some users
and also some of our CI machines. Double the timeout for slower
machines.
