### PR TITLE
Require the `_yz_err` field

### DIFF
--- a/misc/bench/schemas/fruit_schema.xml
+++ b/misc/bench/schemas/fruit_schema.xml
@@ -32,6 +32,10 @@ rue"/>
 
    <!-- Riak Key: The key of the Riak object this doc corresponds to. -->
    <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"/>
+
+   <!-- Node: Stores a flag if this doc is the product of a failed object extration -->
+   <field name="_yz_err" type="_yz_str" indexed="true" stored="false"/>
+
  </fields>
 
  <uniqueKey>_yz_id</uniqueKey>

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -135,6 +135,9 @@
 
    <!-- Riak Bucket: The bucket of the Riak object this doc corresponds to. -->
    <field name="_yz_rb" type="_yz_str" indexed="true" stored="true"/>
+
+   <!-- Node: Stores a flag if this doc is the product of a failed object extration -->
+   <field name="_yz_err" type="_yz_str" indexed="true" stored="false"/>
  </fields>
 
  <uniqueKey>_yz_id</uniqueKey>

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -24,6 +24,7 @@
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
 </fields>
 <uniqueKey>_yz_id</uniqueKey>
 <types>

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -21,6 +21,7 @@
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
 </fields>
 
@@ -90,6 +91,7 @@
    <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
 </fields>
 
@@ -126,6 +128,7 @@
    <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
 </fields>
 
@@ -149,6 +152,7 @@
 </types>
 </schema>">>).
 
+%% Use a bad class name for the `text_general' field type.
 -define(BAD_CLASS_SCHEMA,
         <<"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <schema name=\"test\" version=\"1.5\">
@@ -162,6 +166,7 @@
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
 </fields>
 

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -47,6 +47,7 @@
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
 </fields>
 <uniqueKey>_yz_id</uniqueKey>
 <types>

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -126,7 +126,8 @@ verify_fields({ok, Schema}) ->
               ?YZ_PN_FIELD_XPATH,
               ?YZ_RK_FIELD_XPATH,
               ?YZ_RT_FIELD_XPATH,
-              ?YZ_RB_FIELD_XPATH],
+              ?YZ_RB_FIELD_XPATH,
+              ?YZ_ERR_FIELD_XPATH],
     Checks = [verify_field(F, Schema) || F <- Fields],
     IsError = fun(X) -> X /= ok end,
     case lists:filter(IsError, Checks) of


### PR DESCRIPTION
In order for Yokozuna to function properly this field MUST be part of the schema.
- Add to default schema.
- Add to schema checks.
- Don't store the field.
