### PR TITLE
Potential issues with double-writing schema path in core.properties?

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -139,6 +139,7 @@ local_create(Ring, Name) ->
     case yz_schema:get(SchemaName) of
         {ok, RawSchema} ->
             SchemaFile = filename:join([ConfDir, yz_schema:filename(SchemaName)]),
+            LocalSchemaFile = filename:join([".", yz_schema:filename(SchemaName)]),
 
             yz_misc:make_dirs([ConfDir, DataDir]),
             yz_misc:copy_files(ConfFiles, ConfDir, update),
@@ -148,7 +149,7 @@ local_create(Ring, Name) ->
                          {name, Name},
                          {index_dir, IndexDir},
                          {cfg_file, ?YZ_CORE_CFG_FILE},
-                         {schema_file, SchemaFile}
+                         {schema_file, LocalSchemaFile}
                         ],
             case yz_solr:core(create, CoreProps) of
                 {ok, _, _} ->


### PR DESCRIPTION
A user recently sent an email in the backchannel describing an issue where the schema path in `core.properties` is written twice. This produces a very obvious error as the index can't find its schema. I have not seen any of the integration tests fail for this reason and have not been able to reproduce with 0.11.0 release (user is on Riak 2.0.0pre5).

An sanity check of the Yokozuna code for any path building should be done as well as a search against the Solr JIRA list as I've seen plenty of odd core persistence problems the last few releases (they've been moving to a new format).

Here's an excerpt of what the user saw when bringing up the Solr admin interface. He was able to work around by manually setting it to correct relative path.

``` XML
<response>
<lst name="responseHeader">
<int name="status">404</int>
<int name="QTime">0</int>
</lst>
<lst name="error">
<str name="msg">
Can not find: _yz_default.xml [/source/riak-2.0.0pre5/data/yz/test_yoko/conf/source/riak-2.0.0pre5/data/yz/test_yoko/conf/_yz_default.xml]
</str>
<int name="code">404</int>
</lst>
</response>
```
