### PR TITLE
Rename public facing Yokozuna to Riak Search 2.0

### DIFF
--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -13,13 +13,13 @@ resource.
 
 ### HTTP Index Admin
 
-To create a new index, PUT to `/yz/index` path, suffixed with your
+To create a new index, PUT to `/search/index` path, suffixed with your
 index name, with a content type of `application/json`.  The JSON
 content itself is optional and allows specifying a schema to use
 besides the default schema.
 
 ```bash
-curl -i -XPUT http://localhost:8098/yz/index/my_bucket \
+curl -i -XPUT http://localhost:8098/search/index/my_bucket \
   -H 'content-type: application/json' \
   -d '{"schema":"my_schema"}'
 ```
@@ -29,7 +29,7 @@ A `204 No Content` should be returned if successful, or a `409 Conflict` code if
 To get information about the index, issue a GET request to the same URL.
 
 ```bash
-curl http://localhost:8098/yz/index/my_bucket | jsonpp
+curl http://localhost:8098/search/index/my_bucket | jsonpp
 {
   "name":"my_bucket",
   "bucket":"my_bucket",
@@ -44,5 +44,5 @@ Finally, when you are done with the index, you can issue a DELETE
 method with an index name to remove the index.
 
 ```bash
-curl -XDELETE http://localhost:8098/yz/index/my_bucket
+curl -XDELETE http://localhost:8098/search/index/my_bucket
 ```

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,9 +1,9 @@
 Yokozuna Concepts
 ==========
 
-This document goes over important concepts in Yokozuna.  This will not
-cover every detail of every concept.  Instead it is meant as an
-overview of the most important concepts.
+This document goes over important concepts in Yokozuna.
+This will not cover every detail of every concept.
+Instead it is meant as an overview of the most important concepts.
 
 Yokozuna is an Erlang Application
 ---------------------------------

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,9 +1,9 @@
 Install
 =======
 
-There are three methods for obtaining Yokozuna. Which method you
-choose depends on how close to the bleeding edge you want to be. The
-easiest and most convenient method is to use official packages. Binary
+There are three methods for obtaining Yokozuna. Which
+method you choose depends on how close to the bleeding edge you want to be.
+The easiest and most convenient method is to use official packages. Binary
 packages are provided for many different operating systems and
 represent the official way to install Riak in production. The other
 two methods are the source package and cloning from GitHub. The
@@ -41,7 +41,7 @@ Approximately every month a release is cut. Thus, Yokozuna development
 can outpace official Riak releases. The source package provides an
 easy method for building the latest release and thus testing the
 newest features and bug fixes. The source package should always pass
-all Yokozuna integration tests and be stable as possible. It should
+all Searh 2 integration tests and be stable as possible. It should
 not be deployed in production, however. These releases are more like
 previews and compatibility could break between them. Use official
 packages for production.
@@ -92,13 +92,13 @@ To deploy Riak-Yokozuna in a production configuration then you'll want
 to build a normal release.
 
 	make stage
-	sed -e 's/yokozuna = off/yokozuna = on/' -i.back rel/riak/etc/riak.conf
+	sed -e 's/search = off/search = on/' -i.back rel/riak/etc/riak.conf
 
 If you want to develop against multiple nodes on one machine then you
 can build a local development cluster.
 
 	make stagedevrel
-    for d in dev/dev*; do sed -e 's/yokozuna = off/yokozuna = on/' -i.back $d/etc/riak.conf; done
+    for d in dev/dev*; do sed -e 's/search = off/search = on/' -i.back $d/etc/riak.conf; done
 
 At this point creating a cluster is the same as vanilla Riak.  See
 [Basic Cluster Setup][bcs] for more details.  The Riak docs are
@@ -141,6 +141,6 @@ Make `stage` or `stagedevrel`.
 
 	make stagedevrel
 
-Enable Yokozuna.
+Enable Yokozuna.0.
 
-	for d in dev/dev*; do sed -e 's/yokozuna = off/yokozuna = on/' -i.back $d/etc/riak.conf; done
+	for d in dev/dev*; do sed -e 's/search = off/search = on/' -i.back $d/etc/riak.conf; done

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,10 +1,41 @@
 Yokozuna Release Notes
 ==========
 
-0.12.0 (WIP)
+
+0.12.0
 ------
 
 ### Breaking Changes ###
+
+Yokozuna has been publicly renamed to Search 2. Although internally
+the Yokozuna name will still be used (in the code and project name),
+all public facing options will remove the use of "Yokozuna" or "yz"
+in favor of "Yokozuna" or simply "search".
+
+Configuration (riak.conf) changes all yokozuna prefixes to search:
+
+```
+## To enable Search 2, set this 'on'.
+search = on
+
+## The port number which Solr binds to.
+search.solr_port = 10014
+
+## The port number which Solr JMX binds to.
+search.solr_jmx_port = 10013
+
+# and so on...
+```
+
+The index property to associate a bucket will changed from
+`yz_index` to `search_index`.
+
+All HTTP administration request have changed to rename the `yz`
+prefix to `search`. To manage an index or schema, use, respectively:
+
+* http://localhost:10018/search/index/INDEX_NAME
+* http://localhost:10018/search/schema/INDEX_NAME
+
 
 #### Associating Indexes (Bucket Type Support) ####
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Yokozuna Release Notes
 
 ### Breaking Changes ###
 
-Yokozuna has been publicly renamed to Search 2. Although internally
+Yokozuna has been publicly renamed to Search. Although internally
 the Yokozuna name will still be used (in the code and project name),
 all public facing options will remove the use of "Yokozuna" or "yz"
 in favor of "Yokozuna" or simply "search".
@@ -15,7 +15,7 @@ in favor of "Yokozuna" or simply "search".
 Configuration (riak.conf) changes all yokozuna prefixes to search:
 
 ```
-## To enable Search 2, set this 'on'.
+## To enable Search, set this 'on'.
 search = on
 
 ## The port number which Solr binds to.

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -124,8 +124,8 @@
 %% and `SubResource' is a specific instance.
 -define(YZ_SECURITY_INDEX, <<"index">>).
 -define(YZ_SECURITY_SCHEMA, <<"schema">>).
--define(YZ_SECURITY_SEARCH_PERM, "yokozuna.search").
--define(YZ_SECURITY_ADMIN_PERM, "yokozuna.admin").
+-define(YZ_SECURITY_SEARCH_PERM, "search.query").
+-define(YZ_SECURITY_ADMIN_PERM, "search.admin").
 
 -define(YZ_COVER_TICK_INTERVAL, app_helper:get_env(?YZ_APP_NAME, cover_tick, 2000)).
 -define(YZ_DEFAULT_SOLR_PORT, 8983).
@@ -269,7 +269,7 @@
 -type index_name() :: binary().
 
 -define(YZ_INDEX_TOMBSTONE, <<"_dont_index_">>).
--define(YZ_INDEX, yz_index).
+-define(YZ_INDEX, search_index).
 
 %%%===================================================================
 %%% Solr Config

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -35,12 +35,6 @@
   {default, "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
 ]}.
 
-%% @doc The data under which to store all Search related data.
-%% Including the Solr index data.
-{mapping, "search.data_dir", "yokozuna.yz_dir", [
-  {default, "{{yz_dir}}" }
-]}.
-
 %% @doc The directory where AAE data files are stored
 {mapping, "search.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
   {default, "{{platform_data_dir}}/yz_anti_entropy" }

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -1,12 +1,12 @@
-%% @doc The enabled Yokozuna set this 'on'.
+%% @doc To enable Search set this 'on'.
 %% @datatype enum on, off
-{mapping, "yokozuna", "yokozuna.enabled", [
+{mapping, "search", "yokozuna.enabled", [
   {default, off},
   {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
-  "yokozuna.enabled",
+  "search.enabled",
   fun(Conf) ->
           Setting = cuttlefish_util:conf_get_value("yokozuna", Conf),
           case Setting of
@@ -17,13 +17,13 @@
   end}.
 
 %% @doc The port number which Solr binds to.
-{mapping, "yokozuna.solr_port", "yokozuna.solr_port", [
+{mapping, "search.solr_port", "yokozuna.solr_port", [
   {default, {{yz_solr_port}} },
   {datatype, integer}
 ]}.
 
 %% @doc The port number which Solr JMX binds to.
-{mapping, "yokozuna.solr_jmx_port", "yokozuna.solr_jmx_port", [
+{mapping, "search.solr_jmx_port", "yokozuna.solr_jmx_port", [
   {default, {{yz_solr_jmx_port}} },
   {datatype, integer}
 ]}.
@@ -31,17 +31,23 @@
 %% @doc The arguments to pass to the Solr JVM.  Non-standard
 %% arguments, i.e. -XX, may not be portable across JVM
 %% implementations.  E.g. -XX:+UseCompressedStrings.
-{mapping, "yokozuna.solr_jvm_args", "yokozuna.solr_jvm_args", [
+{mapping, "search.solr_jvm_args", "yokozuna.solr_jvm_args", [
   {default, "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
 ]}.
 
+%% @doc The data under which to store all Search related data.
+%% Including the Solr index data.
+{mapping, "search.data_dir", "yokozuna.yz_dir", [
+  {default, "{{yz_dir}}" }
+]}.
+
 %% @doc The directory where AAE data files are stored
-{mapping, "yokozuna.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
+{mapping, "search.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
   {default, "{{platform_data_dir}}/yz_anti_entropy" }
 ]}.
 
 %% @doc The root directory for Yokozuna, under which index data and
 %% configuration is stored.
-{mapping, "yokozuna.root_dir", "yokozuna.root_dir", [
+{mapping, "search.root_dir", "yokozuna.root_dir", [
   {default, "{{platform_data_dir}}/yz" }
 ]}.

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -6,9 +6,9 @@
 ]}.
 
 { translation,
-  "search.enabled",
+  "yokozuna.enabled",
   fun(Conf) ->
-          Setting = cuttlefish_util:conf_get_value("yokozuna", Conf),
+          Setting = cuttlefish_util:conf_get_value("search", Conf),
           case Setting of
               on -> true;
               off -> false;

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -101,7 +101,7 @@ expect_bad_query(Cluster) ->
     ok.
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s", [Host, Port, BType, BName, Key]).

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -78,7 +78,7 @@ confirm_delete(Cluster, Index) ->
     lager:info("confirm_delete ~s [~p]", [Index, HP]),
     URL = index_url(HP, Index),
 
-    Suffix = "yz/index/" ++ Index,
+    Suffix = "search/index/" ++ Index,
     Is200 = is_status("200", get, Suffix, ?NO_HEADERS, ?NO_BODY),
     [ ?assertEqual(ok, rt:wait_until(Node, Is200)) || Node <- Cluster],
 
@@ -90,7 +90,7 @@ confirm_delete(Cluster, Index) ->
     [ ?assertEqual(ok, rt:wait_until(Node, Is404)) || Node <- Cluster],
 
     %% Verify the index dir was removed from disk as well
-    [ ?assertEqual(ok, rt:wait_until(Node, is_deleted("data/yz/" ++ binary_to_list(Index))))
+    [ ?assertEqual(ok, rt:wait_until(Node, is_deleted("data/search/" ++ binary_to_list(Index))))
       || Node <- Cluster].
 
 is_status(ExpectedStatus, Method, URLSuffix, Headers, Body) ->
@@ -132,7 +132,7 @@ confirm_delete_409(Cluster, Index) ->
     URL = index_url(HP, Index),
     {ok, "204", _, _} = http(put, URL, ?NO_HEADERS, ?NO_BODY),
     H = [{"content-type", "application/json"}],
-    B = <<"{\"props\":{\"yz_index\":\"delete_409\"}}">>,
+    B = <<"{\"props\":{\"search_index\":\"delete_409\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B),
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B),
 
@@ -150,13 +150,13 @@ confirm_delete_409(Cluster, Index) ->
     %% Can't be deleted because of associated buckets
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"yz_index\":\"_yz_default\"}}">>,
+    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B2),
 
     %% Still can't delete because of associated bucket
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"yz_index\":\"_yz_default\"}}">>,
+    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B2),
 
     %% TODO: wait_for_index_delete?
@@ -189,10 +189,10 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 index_list_url({Host, Port}) ->
-    ?FMT("http://~s:~B/yz/index", [Host, Port]).
+    ?FMT("http://~s:~B/search/index", [Host, Port]).
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 url({Host,Port}, Suffix) ->
     ?FMT("http://~s:~B/~s", [Host, Port, Suffix]).

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -36,7 +36,7 @@ host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -53,10 +53,10 @@ host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
 schema_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/schema/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -12,7 +12,7 @@
 %% index in Yokozuna.
 %%
 %% 3. For every bucket which is indexed by Riak Search the user must
-%% add the `yz_index' bucket property to point to the Yokozuna index
+%% add the `search_index' bucket property to point to the Yokozuna index
 %% which is going to eventually be migrated to.
 %%
 %% 4. As objects are written or modified they will be indexed by both

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -354,7 +354,7 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 index_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Name]).
 
 schema_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/schema/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -137,7 +137,7 @@ confirm_index_pb(Node) ->
     riakc_pb_socket:stop(Pid0),
 
     lager:info("Grant index permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","index","TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","index","TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can create an index"),
@@ -181,7 +181,7 @@ confirm_schema_permission_pb(Node) ->
     riakc_pb_socket:stop(Pid0),
 
     lager:info("Grant schema permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","schema","TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","schema","TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can create schema"),
@@ -201,7 +201,7 @@ confirm_search_pb(Node) ->
 
     lager:info("Grant search permission to user on ~s", [?INDEX]),
     IndexS = binary_to_list(?INDEX),
-    ok = ?GRANT(Node, [["yokozuna.search","ON","index",IndexS,"TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_SEARCH_PERM,"ON","index",IndexS,"TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can search granted on ~s", [?INDEX]),
@@ -238,12 +238,12 @@ confirm_index_https(Node) ->
               [{"content-type", "application/json"}]
                ++ get_auth_header(?HUSER, ?PASSWORD),
     Body = <<"{\"schema\":\"_yz_default\"}">>,
-    URL = lists:flatten(io_lib:format("https://~s:~s/yz/index/~s",
+    URL = lists:flatten(io_lib:format("https://~s:~s/search/index/~s",
                                       [Host, integer_to_list(Port), ?HINDEX])),
     {ok, "403", _, _} = ibrowse:send_req(URL, Headers, put, Body, Opts),
 
     lager:info("Grant index permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","index","TO",?HUSER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","index","TO",?HUSER]]),
 
     %% this should work now that this user has permission
     {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body, Opts),

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -96,7 +96,7 @@ allow_mult(Cluster, BType) ->
     ok.
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s", [Host, Port, BType, BName, Key]).

--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -54,4 +54,4 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 extract_url({Host,Port}) ->
-    ?FMT("http://~s:~B/yz/extract", [Host, Port]).
+    ?FMT("http://~s:~B/search/extract", [Host, Port]).

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -57,7 +57,7 @@ maybe_setup(true) ->
     maybe_register_pb(?QUERY_SERVICES),
     maybe_register_pb(?ADMIN_SERVICES),
     setup_stats(),
-    ok = riak_core:register(yokozuna, [{permissions, [search,admin]}]),
+    ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),
     ok.
 

--- a/src/yz_wm_extract.erl
+++ b/src/yz_wm_extract.erl
@@ -29,7 +29,7 @@
          }).
 
 routes() ->
-    [{["yz", "extract"], yz_wm_extract, []}].
+    [{["search", "extract"], yz_wm_extract, []}].
 
 init(_) ->
     {ok, #state{}}.

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -23,13 +23,13 @@
 %%
 %% Available operations:
 %%
-%% GET /yz/index
+%% GET /search/index
 %%
 %%   Get information about every index in JSON format.
-%%   Currently the same information as /yz/index/Index,
+%%   Currently the same information as /search/index/Index,
 %%   but as an array of JSON objects.
 %%
-%% GET /yz/index/Index
+%% GET /search/index/Index
 %%
 %%   Gets information about a specific index in JSON format.
 %%   Returns the following information:
@@ -45,7 +45,7 @@
 %%   index. That schema file must already be installed on the server.
 %%   Defaults to "_yz_default".
 %%
-%% PUT /yz/index/Index
+%% PUT /search/index/Index
 %%
 %%   Creates a new index with the given name.
 %%
@@ -60,7 +60,7 @@
 %%
 %%   Returns a '409 Conflict' code if the index already exists.
 %%
-%% DELETE /yz/index/Index
+%% DELETE /search/index/Index
 %%
 %%   Deletes the index with the given index name.
 %%
@@ -83,8 +83,8 @@
 
 %% @doc Return the list of routes provided by this resource.
 routes() ->
-    [{["yz", "index", index], yz_wm_index, []},
-     {["yz", "index"], yz_wm_index, []}].
+    [{["search", "index", index], yz_wm_index, []},
+     {["search", "index"], yz_wm_index, []}].
 
 %%%===================================================================
 %%% Callbacks

--- a/src/yz_wm_schema.erl
+++ b/src/yz_wm_schema.erl
@@ -23,10 +23,10 @@
 %%
 %% Available operations:
 %% 
-%% GET /yz/schema/Schema
+%% GET /search/schema/Schema
 %%   Retrieves the schema with the given name
 %%
-%% PUT /yz/schema/Schema
+%% PUT /search/schema/Schema
 %%   Uploads a schema with the given name
 %%   A PUT request requires this header:
 %%     Content-Type: application/xml
@@ -50,7 +50,7 @@
 
 %% @doc Return the list of routes provided by this resource.
 routes() ->
-    [{["yz", "schema", schema], yz_wm_schema, []}].
+    [{["search", "schema", schema], yz_wm_schema, []}].
 
 
 %%%===================================================================

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -34,8 +34,7 @@
 %% @doc Return the list of routes provided by this resource.
 -spec routes() -> [tuple()].
 routes() ->
-    Routes1 = [{["yz", "search", index], ?MODULE, []},
-               {["search", index], ?MODULE, []}],
+    Routes1 = [{["search", index], ?MODULE, []}],
     case yz_misc:is_riak_search_enabled() of
         false ->
             [{["solr", index, "select"], ?MODULE, []}|Routes1];


### PR DESCRIPTION
We need to rename all of the cases where the term yokozuna is public facing, with some variety of `search`, or `rs`, so as to clarify that this is a Riak Search 2.0 project.
- [x] Update HTTP admin resource names from `yz` prefix to `rs`
- [x] Update all yokozuna.schema cuttlefish mappings from `yokozuna` prefix to `search`
- [x] Rename `yz_index` bucket label to `search_index`
- [x] Update docs with use new resource paths and settings
- [x] Rename `yokozuna.*` security to `search.*` (also change `yokozuna.search` to `search.query`)

Testing this relies on basho/riak-erlang-client#134.

After this is merged:
- the mapred test needs updated basho/riak_test#454
- the remaining drivers need the renamed bucket prop `search_index`
