### PR TITLE
RS migration via AAE

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ buckets may use the same index.  To create an index via the HTTP
 interface the following.
 
 ```
-curl -XPUT -i 'http://localhost:10018/yz/index/my_index'
+curl -XPUT -i 'http://localhost:10018/search/index/my_index'
 ```
 
 ### Create Bucket Type, and Associate Index ###
@@ -36,11 +36,11 @@ curl -XPUT -i 'http://localhost:10018/yz/index/my_index'
 **N.B.** This is a breaking change in the 0.12.0 version. Previously
 associating an index was done by updating a bucket's properties.
 
-A bucket type must be created and the `yz_index` field must be set
+A bucket type must be created and the `search_index` field must be set
 either at the type-level properties, as shown here, or name-level.
 
 ```
-riak-admin bucket-type create my_type '{"props":{"yz_index":"my_index"}}'
+riak-admin bucket-type create my_type '{"props":{"search_index":"my_index"}}'
 riak-admin bucket-type activate my_type
 ```
 
@@ -61,7 +61,7 @@ API but that is hidden for you.  This means you don't have to worry
 about where your shards are located.
 
 ```
-curl 'http://localhost:10018/yz/search/my_index?q=text:Ryan'
+curl 'http://localhost:10018/search/my_index?q=text:Ryan'
 ```
 
 The canonical Solr URL is also supported allowing the use of an

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -13,13 +13,13 @@ resource.
 
 ### HTTP Index Admin
 
-To create a new index, PUT to `/yz/index` path, suffixed with your
+To create a new index, PUT to `/search/index` path, suffixed with your
 index name, with a content type of `application/json`.  The JSON
 content itself is optional and allows specifying a schema to use
 besides the default schema.
 
 ```bash
-curl -i -XPUT http://localhost:8098/yz/index/my_bucket \
+curl -i -XPUT http://localhost:8098/search/index/my_bucket \
   -H 'content-type: application/json' \
   -d '{"schema":"my_schema"}'
 ```
@@ -29,7 +29,7 @@ A `204 No Content` should be returned if successful, or a `409 Conflict` code if
 To get information about the index, issue a GET request to the same URL.
 
 ```bash
-curl http://localhost:8098/yz/index/my_bucket | jsonpp
+curl http://localhost:8098/search/index/my_bucket | jsonpp
 {
   "name":"my_bucket",
   "bucket":"my_bucket",
@@ -44,5 +44,5 @@ Finally, when you are done with the index, you can issue a DELETE
 method with an index name to remove the index.
 
 ```bash
-curl -XDELETE http://localhost:8098/yz/index/my_bucket
+curl -XDELETE http://localhost:8098/search/index/my_bucket
 ```

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,9 +1,9 @@
 Yokozuna Concepts
 ==========
 
-This document goes over important concepts in Yokozuna.  This will not
-cover every detail of every concept.  Instead it is meant as an
-overview of the most important concepts.
+This document goes over important concepts in Yokozuna.
+This will not cover every detail of every concept.
+Instead it is meant as an overview of the most important concepts.
 
 Yokozuna is an Erlang Application
 ---------------------------------
@@ -221,7 +221,7 @@ extraction and return the document structure as `application/json`.
 
 ```
 curl -XPUT -H 'content-type: application/json' \
-  'http://localhost:8098/yz/extract' --data-binary @object.json
+  'http://localhost:8098/search/extract' --data-binary @object.json
 ```
 
 Schemas

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,9 +1,9 @@
 Install
 =======
 
-There are three methods for obtaining Yokozuna. Which method you
-choose depends on how close to the bleeding edge you want to be. The
-easiest and most convenient method is to use official packages. Binary
+There are three methods for obtaining Yokozuna. Which
+method you choose depends on how close to the bleeding edge you want to be.
+The easiest and most convenient method is to use official packages. Binary
 packages are provided for many different operating systems and
 represent the official way to install Riak in production. The other
 two methods are the source package and cloning from GitHub. The
@@ -41,7 +41,7 @@ Approximately every month a release is cut. Thus, Yokozuna development
 can outpace official Riak releases. The source package provides an
 easy method for building the latest release and thus testing the
 newest features and bug fixes. The source package should always pass
-all Yokozuna integration tests and be stable as possible. It should
+all Searh 2 integration tests and be stable as possible. It should
 not be deployed in production, however. These releases are more like
 previews and compatibility could break between them. Use official
 packages for production.
@@ -92,13 +92,13 @@ To deploy Riak-Yokozuna in a production configuration then you'll want
 to build a normal release.
 
 	make stage
-	sed -e 's/yokozuna = off/yokozuna = on/' -i.back rel/riak/etc/riak.conf
+	sed -e 's/search = off/search = on/' -i.back rel/riak/etc/riak.conf
 
 If you want to develop against multiple nodes on one machine then you
 can build a local development cluster.
 
 	make stagedevrel
-    for d in dev/dev*; do sed -e 's/yokozuna = off/yokozuna = on/' -i.back $d/etc/riak.conf; done
+    for d in dev/dev*; do sed -e 's/search = off/search = on/' -i.back $d/etc/riak.conf; done
 
 At this point creating a cluster is the same as vanilla Riak.  See
 [Basic Cluster Setup][bcs] for more details.  The Riak docs are
@@ -141,6 +141,6 @@ Make `stage` or `stagedevrel`.
 
 	make stagedevrel
 
-Enable Yokozuna.
+Enable Yokozuna.0.
 
-	for d in dev/dev*; do sed -e 's/yokozuna = off/yokozuna = on/' -i.back $d/etc/riak.conf; done
+	for d in dev/dev*; do sed -e 's/search = off/search = on/' -i.back $d/etc/riak.conf; done

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,10 +1,41 @@
 Yokozuna Release Notes
 ==========
 
-0.12.0 (WIP)
+
+0.12.0
 ------
 
 ### Breaking Changes ###
+
+Yokozuna has been publicly renamed to Search. Although internally
+the Yokozuna name will still be used (in the code and project name),
+all public facing options will remove the use of "Yokozuna" or "yz"
+in favor of "Yokozuna" or simply "search".
+
+Configuration (riak.conf) changes all yokozuna prefixes to search:
+
+```
+## To enable Search, set this 'on'.
+search = on
+
+## The port number which Solr binds to.
+search.solr_port = 10014
+
+## The port number which Solr JMX binds to.
+search.solr_jmx_port = 10013
+
+# and so on...
+```
+
+The index property to associate a bucket will changed from
+`yz_index` to `search_index`.
+
+All HTTP administration request have changed to rename the `yz`
+prefix to `search`. To manage an index or schema, use, respectively:
+
+* http://localhost:10018/search/index/INDEX_NAME
+* http://localhost:10018/search/schema/INDEX_NAME
+
 
 #### Associating Indexes (Bucket Type Support) ####
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -41,25 +41,25 @@ currently has two different resources and two different permissions.
 
 | Permission          | Description                               |
 |---------------------|-------------------------------------------|
-| yokozuna.admin      | Ability to admin (CRUD) a resource.       |
-| yokozuna.search     | Ability to search an index.               |
+| search.admin        | Ability to admin (CRUD) a resource.       |
+| search.query        | Ability to query an index.                |
 
 The resources are the objects to control access to and the permissions
 are the actions which may be taken on them. Notice that the
-permissions are name-spaced with `yokozuna.`. This is required because
-other Riak sub-systems may one day have notions of `admin` or `search`
+permissions are name-spaced with `search.`. This is required because
+other Riak sub-systems may one day have notions of `admin` or `query`
 and this prevents collision.
 
 Currently the security system will allow any combination of resource
 and permission but not all combinations make sense. For example,
-giving the search permission on a schema. That makes no sense. Here is
+giving the query permission on a schema. That makes no sense. Here is
 a table covering the legal combinations.
 
-| Permission          | Resource(s)     | Sub-Resource            |
-|---------------------|-----------------|-------------------------|
-| yokozuna.admin      | index           | No                      |
-| yokozuna.admin      | schema          | No                      |
-| yokozuna.search     | index           | Yes                     |
+| Permission        | Resource(s)     | Sub-Resource            |
+|-------------------|-----------------|-------------------------|
+| search.admin      | index           | No                      |
+| search.admin      | schema          | No                      |
+| search.query      | index           | Yes                     |
 
 The sub-resource section denotes whether or not a sub-resource
 identifier can be applies to that combination. Sub-resources are
@@ -78,7 +78,7 @@ Three pieces of information are always required: 1) the permission
 given, 2) the resource the permission applies to, and 3) the user
 receiving the grant. There is an optional piece of information, the
 `<sub-resource>` which allows the grant to apply only to a specific
-instance of a `<resource>`. For example, granting search on a specific
+instance of a `<resource>`. For example, granting query on a specific
 index rather than all indexes.
 
 Examples
@@ -87,11 +87,11 @@ Examples
 In this example there are 3 users. Below is a list of their names
 along with the permissions each should have.
 
-* `ryan` - Is a developer. He needs to write apps that can search any
+* `ryan` - Is a developer. He needs to write apps that can query any
   index.
 
 * `eric` - Is an administrator. He needs to administrate schemas and
-  indexes as well as be able to search one index that he calls his
+  indexes as well as be able to query one index that he calls his
   own.
 
 * `god` - This user can do anything, because why not.
@@ -138,15 +138,15 @@ connections. Mainly because it makes this example easier to write :).
 Note that `all` is syntactic sugar that allows me to apply this source
 rule to all users rather than typing them out.
 
-### Granting Yokozuna Permissions ###
+### Granting Search Permissions ###
 
 With the users created and sources configured Yokozuna specific grants
 can now be applied.
 
-First is `ryan` who can search any index, but that's it.
+First is `ryan` who can query any index, but that's it.
 
 ```
-% riak-admin security grant yokozuna.search ON index TO ryan
+% riak-admin security grant search.query ON index TO ryan
 
 % riak-admin security print-user ryan
 
@@ -161,26 +161,26 @@ Applied permissions
 +----------+----------+----------------------------------------+
 |   type   |  bucket  |                 grants                 |
 +----------+----------+----------------------------------------+
-|  index   |    *     |            yokozuna.search             |
+|  index   |    *     |            search.query             |
 +----------+----------+----------------------------------------+
 ```
 
 Note that `ON` and `TO` must be capitalized.
 
-Next is `eric` who can admin everything but only search his personal
+Next is `eric` who can admin everything but only query his personal
 index.
 
 ```
-% riak-admin security grant yokozuna.admin ON schema TO eric
-% riak-admin security grant yokozuna.admin ON index TO eric
-% riak-admin security grant yokozuna.search ON index erics_index TO eric
+% riak-admin security grant search.admin ON schema TO eric
+% riak-admin security grant search.admin ON index TO eric
+% riak-admin security grant search.query ON index erics_index TO eric
 ```
 
 Finally, there is `god` who does whatever she pleases.
 
 ```
-% riak-admin security grant yokozuna.admin ON schema TO god
-% riak-admin security grant yokozuna.admin,yokozuna.search ON index TO god
+% riak-admin security grant search.admin ON schema TO god
+% riak-admin security grant search.admin,search.query ON index TO god
 ```
 
 Note that there must NOT be any white-space between permissions when
@@ -193,13 +193,13 @@ The user Ryan should be prevented from creating or listing indexes
 based on the permissions given.
 
 ```
-% curl -i -k --user ryan:ryan -X PUT 'https://127.0.0.1:10012/yz/index/ryans_index'
+% curl -i -k --user ryan:ryan -X PUT 'https://127.0.0.1:10012/search/index/ryans_index'
 HTTP/1.1 403 Forbidden
 Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
 Date: Thu, 07 Nov 2013 21:22:16 GMT
 Content-Length: 75
 
-Permission denied: User 'ryan' does not have'yokozuna.admin' on <<"index">>
+Permission denied: User 'ryan' does not have'search.admin' on <<"index">>
 ```
 
 As expected Ryan cannot create a new index. You'll have to excuse the
@@ -207,7 +207,7 @@ funny looking string. There is still some polish to be made to the new
 security system. What if Eric tries to create the index?
 
 ```
-% curl -i -k --user eric:eric -X PUT 'https://127.0.0.1:10012/yz/index/ryans_index'
+% curl -i -k --user eric:eric -X PUT 'https://127.0.0.1:10012/search/index/ryans_index'
 HTTP/1.1 204 No Content
 Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
 Date: Thu, 07 Nov 2013 21:27:21 GMT
@@ -220,22 +220,22 @@ mean success but to verify the indexes can be listed. First, Ryan will
 try listing the indexes.
 
 ```
-% curl -k --user ryan:ryan 'https://127.0.0.1:10012/yz/index'
-Permission denied: User 'ryan' does not have'yokozuna.admin' on <<"index">>
+% curl -k --user ryan:ryan 'https://127.0.0.1:10012/search/index'
+Permission denied: User 'ryan' does not have'search.admin' on <<"index">>
 ```
 
 Once again Ryan does not have admin permission for indexes. Only Eric
 or god can list indexes.
 
 ```
-% curl -i -k --user god:iruleudrool 'https://127.0.0.1:10012/yz/index'
+% curl -i -k --user god:iruleudrool 'https://127.0.0.1:10012/search/index'
 [{"name":"ryans_index","schema":"_yz_default"}]
 ```
 
 Finally, Eric will create his own index which he can search.
 
 ```
-% curl -i -k --user eric:eric -X PUT 'https://127.0.0.1:10012/yz/index/erics_index'
+% curl -i -k --user eric:eric -X PUT 'https://127.0.0.1:10012/search/index/erics_index'
 HTTP/1.1 204 No Content
 Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
 Date: Thu, 07 Nov 2013 22:06:55 GMT
@@ -317,7 +317,7 @@ both be searched at the same time but Ryan does have permission to
 search both in separate requests.
 
 ```
-% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/yz/search/ryans_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/ryans_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 1,
@@ -334,7 +334,7 @@ search both in separate requests.
   }
 }
 
-% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/yz/search/erics_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/erics_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 0,
@@ -347,10 +347,10 @@ search both in separate requests.
 
 Ryan found the work structure once in his corpus of Perlis quotes but
 zero times in Eric's collection of Dijkstra. What if Eric wants to
-search for a word in both indexes?
+query for a word in both indexes?
 
 ```
-% curl -s -k --user eric:eric 'https://127.0.0.1:10012/yz/search/erics_index?q=text:program&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/erics_index?q=text:program&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 1,
@@ -367,11 +367,11 @@ search for a word in both indexes?
   }
 }
 
-% curl -s -k --user eric:eric 'https://127.0.0.1:10012/yz/search/ryans_index?q=text:program&wt=json&omitHeader=true'
-Permission denied: User 'eric' does not have'yokozuna.search' on {<<"index">>,
-                                                                  <<"ryans_index">>}
+% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/ryans_index?q=text:program&wt=json&omitHeader=true'
+Permission denied: User 'eric' does not have'search.query' on {<<"index">>,
+                                                               <<"ryans_index">>}
 
-% curl -s -k --user god:iruleudrool 'https://127.0.0.1:10012/yz/search/ryans_index?q=text:program&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user god:iruleudrool 'https://127.0.0.1:10012/search/ryans_index?q=text:program&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 0,
@@ -384,7 +384,7 @@ Permission denied: User 'eric' does not have'yokozuna.search' on {<<"index">>,
 
 Eric found one quote with the word "program" in his index but was
 denied access to Ryan's index as expected. God, however, can do
-anything and was able to search Ryan's index.
+anything and was able to query Ryan's index.
 
 This is the gist of how security may be applied in Yokozuna. Once
 again, for more information refer to [Riak 355][355].

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -124,8 +124,8 @@
 %% and `SubResource' is a specific instance.
 -define(YZ_SECURITY_INDEX, <<"index">>).
 -define(YZ_SECURITY_SCHEMA, <<"schema">>).
--define(YZ_SECURITY_SEARCH_PERM, "yokozuna.search").
--define(YZ_SECURITY_ADMIN_PERM, "yokozuna.admin").
+-define(YZ_SECURITY_SEARCH_PERM, "search.query").
+-define(YZ_SECURITY_ADMIN_PERM, "search.admin").
 
 -define(YZ_COVER_TICK_INTERVAL, app_helper:get_env(?YZ_APP_NAME, cover_tick, 2000)).
 -define(YZ_DEFAULT_SOLR_PORT, 8983).
@@ -135,7 +135,8 @@
 %% TODO: See if using mochiglobal for this makes difference in performance.
 -define(YZ_ENABLED, app_helper:get_env(?YZ_APP_NAME, enabled, false)).
 -define(YZ_EVENTS_TAB, yz_events_tab).
--define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir, "data/yz")).
+-define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir,
+                        app_helper:get_env(riak_core, platform_data_dir)++"/yz")).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).
 -define(YZ_CORE_CFG_FILE, "solrconfig.xml").
 -define(YZ_INDEX_CMD, #yz_index_cmd).
@@ -268,7 +269,7 @@
 -type index_name() :: binary().
 
 -define(YZ_INDEX_TOMBSTONE, <<"_dont_index_">>).
--define(YZ_INDEX, yz_index).
+-define(YZ_INDEX, search_index).
 
 %%%===================================================================
 %%% Solr Config

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -1,6 +1,6 @@
-%% @doc The enabled Yokozuna set this 'on'.
+%% @doc To enable Search set this 'on'.
 %% @datatype enum on, off
-{mapping, "yokozuna", "yokozuna.enabled", [
+{mapping, "search", "yokozuna.enabled", [
   {default, off},
   {datatype, {enum, [on, off]}}
 ]}.
@@ -8,7 +8,7 @@
 { translation,
   "yokozuna.enabled",
   fun(Conf) ->
-          Setting = cuttlefish_util:conf_get_value("yokozuna", Conf),
+          Setting = cuttlefish_util:conf_get_value("search", Conf),
           case Setting of
               on -> true;
               off -> false;
@@ -17,13 +17,13 @@
   end}.
 
 %% @doc The port number which Solr binds to.
-{mapping, "yokozuna.solr_port", "yokozuna.solr_port", [
+{mapping, "search.solr_port", "yokozuna.solr_port", [
   {default, {{yz_solr_port}} },
   {datatype, integer}
 ]}.
 
 %% @doc The port number which Solr JMX binds to.
-{mapping, "yokozuna.solr_jmx_port", "yokozuna.solr_jmx_port", [
+{mapping, "search.solr_jmx_port", "yokozuna.solr_jmx_port", [
   {default, {{yz_solr_jmx_port}} },
   {datatype, integer}
 ]}.
@@ -31,17 +31,17 @@
 %% @doc The arguments to pass to the Solr JVM.  Non-standard
 %% arguments, i.e. -XX, may not be portable across JVM
 %% implementations.  E.g. -XX:+UseCompressedStrings.
-{mapping, "yokozuna.solr_jvm_args", "yokozuna.solr_jvm_args", [
+{mapping, "search.solr_jvm_args", "yokozuna.solr_jvm_args", [
   {default, "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
 ]}.
 
-%% @doc The data under which to store all Yokozuna related data.
-%% Including the Solr index data.
-{mapping, "yokozuna.data_dir", "yokozuna.yz_dir", [
-  {default, "{{yz_dir}}" }
+%% @doc The directory where AAE data files are stored
+{mapping, "search.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
+  {default, "{{platform_data_dir}}/yz_anti_entropy" }
 ]}.
 
-%% @doc The directory where aae data files are stored
-{mapping, "yokozuna.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
-  {default, "{{platform_data_dir}}/yz_anti_entropy" }
+%% @doc The root directory for Yokozuna, under which index data and
+%% configuration is stored.
+{mapping, "search.root_dir", "yokozuna.root_dir", [
+  {default, "{{platform_data_dir}}/yz" }
 ]}.

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -42,7 +42,7 @@ confirm() ->
     %% to verify that the exact number of repairs was made given the
     %% number of keys deleted.
     TS1 = erlang:now(),
-    wait_for_full_exchange_round(Cluster, TS1),
+    yz_rt:wait_for_full_exchange_round(Cluster, TS1),
     RepairCountBefore = get_cluster_repair_count(Cluster),
     yz_rt:count_calls(Cluster, ?REPAIR_MFA),
     Keys = yz_rt:random_keys(?NUM_KEYS),
@@ -58,7 +58,7 @@ confirm() ->
     %% Yokozuna hashtree must be built.  Wait for all trees before
     %% checking that Solr indexes are repaired.
     TS2 = erlang:now(),
-    wait_for_full_exchange_round(Cluster, TS2),
+    yz_rt:wait_for_full_exchange_round(Cluster, TS2),
     lager:info("Verify AAE repairs missing Solr documents"),
     verify_num_match(Cluster, ?NUM_KEYS),
     %% Multiply by 3 because of N value
@@ -93,11 +93,6 @@ get_total_repair_count(Node) ->
     Sums = [Sum || {_Key,{index_info,_,{simple_stat,_,_,_,_,Sum},_,_}} <- YZInfo],
     lists:sum(Sums).
 
-greater_than(TimestampA) ->
-    fun(TimestampB) ->
-            TimestampB > TimestampA
-    end.
-
 read_schema(YZBenchDir) ->
     Path = filename:join([YZBenchDir, "schemas", "fruit_schema.xml"]),
     {ok, RawSchema} = file:read_file(Path),
@@ -115,7 +110,7 @@ setup_index(Cluster, PBConn, YZBenchDir) ->
 verify_no_repair(Cluster) ->
     yz_rt:count_calls(Cluster, ?REPAIR_MFA),
     TS = erlang:now(),
-    wait_for_full_exchange_round(Cluster, TS),
+    yz_rt:wait_for_full_exchange_round(Cluster, TS),
     yz_rt:stop_tracing(),
     Count = yz_rt:get_call_count(Cluster, ?REPAIR_MFA),
     ?assertEqual(0, Count).
@@ -130,29 +125,3 @@ verify_num_match(Cluster, Num) ->
 verify_repair_count(Cluster, ExpectedNumRepairs) ->
     RepairCount = get_cluster_repair_count(Cluster),
     ?assertEqual(ExpectedNumRepairs, RepairCount).
-
-
-%% Eneded up not needing this function but leaving here in casse
-%% useful later.
-
-%% wait_for_all_trees(Cluster) ->
-%%     F = fun(Node) ->
-%%                 lager:info("Check if all trees built for node ~p", [Node]),
-%%                 Info = rpc:call(Node, yz_kv, compute_tree_info, []),
-%%                 NotBuilt = [X || {_,undefined}=X <- Info],
-%%                 NotBuilt == []
-%%         end,
-%%     yz_rt:wait_until(Cluster, F).
-
-
-%% @doc Wait for a full exchange round since `Timestamp'.  This means
-%% that all `{Idx,N}' for all partitions must have exchanged after
-%% `Timestamp'.
-wait_for_full_exchange_round(Cluster, Timestamp) ->
-    F = fun(Node) ->
-                lager:info("Check if all partitions have had full exchange for ~p", [Node]),
-                EIs = rpc:call(Node, yz_kv, compute_exchange_info, []),
-                AllTimes = [AllTime || {_,_,AllTime,_} <- EIs],
-                lists:all(greater_than(Timestamp), AllTimes)
-        end,
-    yz_rt:wait_until(Cluster, F).

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -101,7 +101,7 @@ expect_bad_query(Cluster) ->
     ok.
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s", [Host, Port, BType, BName, Key]).

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -78,7 +78,7 @@ confirm_delete(Cluster, Index) ->
     lager:info("confirm_delete ~s [~p]", [Index, HP]),
     URL = index_url(HP, Index),
 
-    Suffix = "yz/index/" ++ Index,
+    Suffix = "search/index/" ++ Index,
     Is200 = is_status("200", get, Suffix, ?NO_HEADERS, ?NO_BODY),
     [ ?assertEqual(ok, rt:wait_until(Node, Is200)) || Node <- Cluster],
 
@@ -90,7 +90,7 @@ confirm_delete(Cluster, Index) ->
     [ ?assertEqual(ok, rt:wait_until(Node, Is404)) || Node <- Cluster],
 
     %% Verify the index dir was removed from disk as well
-    [ ?assertEqual(ok, rt:wait_until(Node, is_deleted("data/yz/" ++ binary_to_list(Index))))
+    [ ?assertEqual(ok, rt:wait_until(Node, is_deleted("data/search/" ++ binary_to_list(Index))))
       || Node <- Cluster].
 
 is_status(ExpectedStatus, Method, URLSuffix, Headers, Body) ->
@@ -132,7 +132,7 @@ confirm_delete_409(Cluster, Index) ->
     URL = index_url(HP, Index),
     {ok, "204", _, _} = http(put, URL, ?NO_HEADERS, ?NO_BODY),
     H = [{"content-type", "application/json"}],
-    B = <<"{\"props\":{\"yz_index\":\"delete_409\"}}">>,
+    B = <<"{\"props\":{\"search_index\":\"delete_409\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B),
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B),
 
@@ -150,13 +150,13 @@ confirm_delete_409(Cluster, Index) ->
     %% Can't be deleted because of associated buckets
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"yz_index\":\"_yz_default\"}}">>,
+    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B2),
 
     %% Still can't delete because of associated bucket
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"yz_index\":\"_yz_default\"}}">>,
+    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B2),
 
     %% TODO: wait_for_index_delete?
@@ -189,10 +189,10 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 index_list_url({Host, Port}) ->
-    ?FMT("http://~s:~B/yz/index", [Host, Port]).
+    ?FMT("http://~s:~B/search/index", [Host, Port]).
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 url({Host,Port}, Suffix) ->
     ?FMT("http://~s:~B/~s", [Host, Port, Suffix]).

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -36,7 +36,7 @@ host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -53,10 +53,10 @@ host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
 schema_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/schema/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -12,7 +12,7 @@
 %% index in Yokozuna.
 %%
 %% 3. For every bucket which is indexed by Riak Search the user must
-%% add the `yz_index' bucket property to point to the Yokozuna index
+%% add the `search_index' bucket property to point to the Yokozuna index
 %% which is going to eventually be migrated to.
 %%
 %% 4. As objects are written or modified they will be indexed by both

--- a/riak_test/yz_rs_migration.erl
+++ b/riak_test/yz_rs_migration.erl
@@ -19,11 +19,14 @@
 %% Riak Search and Yokozuna.  But the HTTP and PB query interfaces
 %% will continue to use Riak Search.
 %%
-%% 5a. In the background AAE will start building trees for Yokozuna and
+%% 5a. The YZ AAE trees must be manually cleared so that AAE will notice
+%% the missing indexes.
+%%
+%% 5b. In the background AAE will start building trees for Yokozuna and
 %% exchange them with KV.  These exchanges will notice objects are
 %% missing and index them in Yokozuna.
 %%
-%% 5b. The user wants Yokozuna to index the missing objects as fast as
+%% 5c. The user wants Yokozuna to index the missing objects as fast as
 %% possible.  A command may be used (repair? bucket map-reduce? custom
 %% fold function?) to immediately re-index data.
 %%
@@ -77,16 +80,12 @@ confirm() ->
     check_for_errors(Cluster),
 
     create_index(Cluster, yokozuna),
-    yz_rt:set_index(hd(Cluster), ?FRUIT_BUCKET),
-    %% TODO: actually this would require clearing trees (which
-    %% yokozuna normally handles in yz_events but in this case if AAE
-    %% didn't already index at least some stuff in the default index
-    %% then adding the property won't trip the clear trees call, and
-    %% besides once the default index is removed I imagine that code
-    %% path will be as well.
-    %%
-    %% For now just going to verify that this fails, although it might not
-    wait_for_aae(yokozuna, Cluster),
+    yz_rt:set_index(hd(Cluster), ?FRUIT_BUCKET, ?FRUIT_BUCKET),
+
+    clear_aae_trees(Cluster),
+    timer:sleep(2000),
+
+    wait_for_aae(Cluster),
     %% Sleep for auto-commit
     timer:sleep(1100),
 
@@ -100,7 +99,6 @@ confirm() ->
     ?assertEqual(5000, Found),
     close_pb_conn(PB),
 
-    %% TODO: This won't work until fix to `riak_core_bucket:set_bucket' is made
     set_search_false(Cluster, ?FRUIT_BUCKET),
     disable_riak_search(),
     stop_riak_search(Cluster),
@@ -121,6 +119,10 @@ confirm() ->
     check_for_errors(Cluster),
 
     pass.
+
+clear_aae_trees(Cluster) ->
+    lager:info("Clearing AAE trees across cluster"),
+    [ok = rpc:call(Node, yz_entropy_mgr, clear_trees, []) || Node <- Cluster].
 
 restart(Cluster) ->
     [rt:stop_and_wait(Node) || Node <- Cluster],
@@ -151,23 +153,12 @@ switch_to_yokozuna(Cluster) ->
 
 %% Use AAE status to verify that exchange has occurred for all
 %% partitions since the time this function was invoked.
-wait_for_aae(yokozuna, Cluster) ->
+-spec wait_for_aae([node()]) -> ok.
+wait_for_aae(Cluster) ->
     lager:info("Wait for AAE to migrate/repair indexes"),
-    Now = os:timestamp(),
-    MoreRecent =  fun({_Idx, _, undefined, _RepairStats}) ->
-                          false;
-                     ({_Idx, _, AllExchanged, _RepairStats}) ->
-                          AllExchanged > Now
-                  end,
-    AllExchanged =
-        fun(Node) ->
-                Exchanges = rpc:call(Node, yz_kv, compute_exchange_info, []),
-                {Recent, WaitingFor1} = lists:partition(MoreRecent, Exchanges),
-                WaitingFor2 = [element(1,X) || X <- WaitingFor1],
-                lager:info("Still waiting for AAE of ~p ~p", [Node, WaitingFor2]),
-                length(Recent) == length(Exchanges)
-        end,
-    yz_rt:wait_until(Cluster, AllExchanged).
+    yz_rt:wait_for_all_trees(Cluster),
+    yz_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
+    ok.
 
 is_error_or_crash_log({FileName,_}) ->
     Base = filename:basename(FileName, ".log"),
@@ -253,7 +244,6 @@ http_get_bucket_prop({Host, Port}, Bucket, Prop, Default) ->
     {struct, Props} = element(2,hd(element(2, Struct))),
     proplists:get_value(Prop, Props, Default).
 
-%% TODO: enable Yokozuna
 rolling_upgrade(Cluster, Vsn) ->
     lager:info("Perform rolling upgrade on cluster ~p", [Cluster]),
     SolrPorts = lists:seq(11000, 11000 + length(Cluster) - 1),
@@ -268,7 +258,7 @@ rolling_upgrade(Cluster, Vsn) ->
                             {anti_entropy_concurrency, 6},
                             {anti_entropy_build_limit, {6,500}},
                             {enabled, true},
-			    {solr_port, integer_to_list(SolrPort)}]}],
+			    {solr_port, SolrPort}]}],
 	 rt:upgrade(Node, Vsn, Cfg),
 	 rt:wait_for_service(Node, riak_kv),
 	 rt:wait_for_service(Node, riak_search),

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -354,7 +354,7 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 index_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Name]).
 
 schema_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/yz/schema/~s", [Host, Port, Name]).
+    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -137,7 +137,7 @@ confirm_index_pb(Node) ->
     riakc_pb_socket:stop(Pid0),
 
     lager:info("Grant index permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","index","TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","index","TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can create an index"),
@@ -181,7 +181,7 @@ confirm_schema_permission_pb(Node) ->
     riakc_pb_socket:stop(Pid0),
 
     lager:info("Grant schema permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","schema","TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","schema","TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can create schema"),
@@ -201,7 +201,7 @@ confirm_search_pb(Node) ->
 
     lager:info("Grant search permission to user on ~s", [?INDEX]),
     IndexS = binary_to_list(?INDEX),
-    ok = ?GRANT(Node, [["yokozuna.search","ON","index",IndexS,"TO",?USER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_SEARCH_PERM,"ON","index",IndexS,"TO",?USER]]),
 
     Pid1 = get_secure_pid(Host, Port),
     lager:info("verifying user can search granted on ~s", [?INDEX]),
@@ -238,12 +238,12 @@ confirm_index_https(Node) ->
               [{"content-type", "application/json"}]
                ++ get_auth_header(?HUSER, ?PASSWORD),
     Body = <<"{\"schema\":\"_yz_default\"}">>,
-    URL = lists:flatten(io_lib:format("https://~s:~s/yz/index/~s",
+    URL = lists:flatten(io_lib:format("https://~s:~s/search/index/~s",
                                       [Host, integer_to_list(Port), ?HINDEX])),
     {ok, "403", _, _} = ibrowse:send_req(URL, Headers, put, Body, Opts),
 
     lager:info("Grant index permission to user"),
-    ok = ?GRANT(Node, [["yokozuna.admin","ON","index","TO",?HUSER]]),
+    ok = ?GRANT(Node, [[?YZ_SECURITY_ADMIN_PERM,"ON","index","TO",?HUSER]]),
 
     %% this should work now that this user has permission
     {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body, Opts),

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -96,7 +96,7 @@ allow_mult(Cluster, BType) ->
     ok.
 
 index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/yz/index/~s", [Host, Port, Index]).
+    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s", [Host, Port, BType, BName, Key]).

--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -54,4 +54,4 @@ http(Method, URL, Headers, Body) ->
     ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 extract_url({Host,Port}) ->
-    ?FMT("http://~s:~B/yz/extract", [Host, Port]).
+    ?FMT("http://~s:~B/search/extract", [Host, Port]).

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -51,11 +51,13 @@ stop(_State) ->
 maybe_setup(false) ->
     ok;
 maybe_setup(true) ->
+    Ring = yz_misc:get_ring(raw),
+    RSEnabled = yz_misc:is_riak_search_enabled(),
+    strip_rs_hooks(RSEnabled, Ring),
     Routes = yz_wm_search:routes() ++ yz_wm_extract:routes() ++
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
-    maybe_register_pb(?QUERY_SERVICES),
-    maybe_register_pb(?ADMIN_SERVICES),
+    maybe_register_pb(RSEnabled),
     setup_stats(),
     ok = riak_core:register(yokozuna, [{permissions, [search,admin]}]),
     ok = yz_schema:setup_schema_bucket(),
@@ -63,14 +65,14 @@ maybe_setup(true) ->
 
 %% @doc Conditionally register PB service IFF Riak Search is not
 %%      enabled.
--spec maybe_register_pb(list()) -> ok.
-maybe_register_pb(Services) ->
-    case yz_misc:is_riak_search_enabled() of
-        false ->
-            ok = riak_api_pb_service:register(Services);
-        true ->
-            ok
-    end.
+-spec maybe_register_pb(boolean()) -> ok.
+maybe_register_pb(true) ->
+    lager:info("Not registering Yokozuna protocol buffer services"
+               " because Riak Search is enabled as well"),
+    ok;
+maybe_register_pb(false) ->
+    ok = riak_api_pb_service:register(?QUERY_SERVICES),
+    ok = riak_api_pb_service:register(?ADMIN_SERVICES).
 
 %% @private
 %%
@@ -83,3 +85,84 @@ setup_stats() ->
         false -> sidejob:new_resource(yz_stat_sj, yz_stat_worker, 10000)
     end,
     ok = riak_core:register(yokozuna, [{stat_mod, yz_stat}]).
+
+%%%===================================================================
+%%% EVERYTHING BELOW IS FOR BUG CAUSED BY LEAKED BUCKET FIXUPS.
+%%%
+%%% Much of this code was copied from `riak_search_kv_hook'.
+%%%===================================================================
+
+%% @private
+%%
+%% @doc Given current pre-commit hook generate a new one with all
+%% instances of the Riak Search hook removed.
+%%
+%% `Changed' - A boolean indicating if the `Precommit' value changed.
+%%
+%% `NewPrecommit' - The new pre-commit hook.
+-spec gen_new_precommit([term()]) -> {Changed :: boolean(),
+                                      NewPrecommit :: [term()]}.
+gen_new_precommit(Precommit) ->
+    %% Strip ALL Riak Search hooks.
+    NewPrecommit = lists:filter(fun ?MODULE:not_rs_hook/1, Precommit),
+    Changed = not (Precommit =:= NewPrecommit),
+    {Changed, NewPrecommit}.
+
+%% @private
+%%
+%% @doc Retrieve the pre-commit hook from bucket properties.  If it
+%% doesn not exist then default to the empty list.
+-spec get_precommit([term()]) -> [term()].
+get_precommit(BProps) ->
+    case proplists:get_value(precommit, BProps, []) of
+        X when is_list(X) -> X;
+        {struct, _}=X -> [X]
+    end.
+
+%% @private
+%%
+%% @doc Predicate function which returns `true' if the `Hook' is NOT a
+%% Riak Search hook.  For use with `lists:filter/2'.
+-spec not_rs_hook(term()) -> boolean().
+not_rs_hook(Hook) ->
+    not (Hook == rs_precommit_def()).
+
+%% @private
+%%
+%% @doc The definition of the Riak Search pre-commit hook.
+-spec rs_precommit_def() -> term().
+rs_precommit_def() ->
+    {struct, [{<<"mod">>,<<"riak_search_kv_hook">>},
+              {<<"fun">>,<<"precommit">>}]}.
+
+%% @private
+%%
+%% @doc Remove Riak Search pre-commit hook from all buckets when Riak
+%% Search is disabled.
+%%
+%% Previous versions of Riak had a bug in `set_bucket' which caused
+%% bucket fixups to leak into the raw ring.  If a user is upgrading
+%% from one of these versions, and enabled search on a bucket, then
+%% the Riak Searc hook will be in the raw ring.  After migrating to
+%% Yokozuna these hooks must be removed to avoid errors.
+-spec strip_rs_hooks(boolean(), ring()) -> ok.
+strip_rs_hooks(true, _) ->
+    ok;
+strip_rs_hooks(false, Ring) ->
+    Buckets = riak_core_ring:get_buckets(Ring),
+    strip_rs_hooks_2(Ring, Buckets).
+
+strip_rs_hooks_2(_Ring, []) ->
+    ok;
+strip_rs_hooks_2(Ring, [Bucket|Rest]) ->
+    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
+    Precommit = get_precommit(BProps),
+    {Changed, NewPreHook} = gen_new_precommit(Precommit),
+    case Changed of
+        true ->
+            riak_core_bucket:set_bucket(Bucket, [{precommit, NewPreHook}]),
+            ok;
+        false ->
+            ok
+    end,
+    strip_rs_hooks_2(Ring, Rest).

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -52,8 +52,8 @@ maybe_setup(false) ->
     ok;
 maybe_setup(true) ->
     Ring = yz_misc:get_ring(raw),
-    RSEnabled = yz_misc:is_riak_search_enabled(),
-    strip_rs_hooks(RSEnabled, Ring),
+    RSEnabled = yz_rs_migration:is_riak_search_enabled(),
+    yz_rs_migration:strip_rs_hooks(RSEnabled, Ring),
     Routes = yz_wm_search:routes() ++ yz_wm_extract:routes() ++
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
@@ -85,84 +85,3 @@ setup_stats() ->
         false -> sidejob:new_resource(yz_stat_sj, yz_stat_worker, 10000)
     end,
     ok = riak_core:register(yokozuna, [{stat_mod, yz_stat}]).
-
-%%%===================================================================
-%%% EVERYTHING BELOW IS FOR BUG CAUSED BY LEAKED BUCKET FIXUPS.
-%%%
-%%% Much of this code was copied from `riak_search_kv_hook'.
-%%%===================================================================
-
-%% @private
-%%
-%% @doc Given current pre-commit hook generate a new one with all
-%% instances of the Riak Search hook removed.
-%%
-%% `Changed' - A boolean indicating if the `Precommit' value changed.
-%%
-%% `NewPrecommit' - The new pre-commit hook.
--spec gen_new_precommit([term()]) -> {Changed :: boolean(),
-                                      NewPrecommit :: [term()]}.
-gen_new_precommit(Precommit) ->
-    %% Strip ALL Riak Search hooks.
-    NewPrecommit = lists:filter(fun ?MODULE:not_rs_hook/1, Precommit),
-    Changed = not (Precommit =:= NewPrecommit),
-    {Changed, NewPrecommit}.
-
-%% @private
-%%
-%% @doc Retrieve the pre-commit hook from bucket properties.  If it
-%% doesn not exist then default to the empty list.
--spec get_precommit([term()]) -> [term()].
-get_precommit(BProps) ->
-    case proplists:get_value(precommit, BProps, []) of
-        X when is_list(X) -> X;
-        {struct, _}=X -> [X]
-    end.
-
-%% @private
-%%
-%% @doc Predicate function which returns `true' if the `Hook' is NOT a
-%% Riak Search hook.  For use with `lists:filter/2'.
--spec not_rs_hook(term()) -> boolean().
-not_rs_hook(Hook) ->
-    not (Hook == rs_precommit_def()).
-
-%% @private
-%%
-%% @doc The definition of the Riak Search pre-commit hook.
--spec rs_precommit_def() -> term().
-rs_precommit_def() ->
-    {struct, [{<<"mod">>,<<"riak_search_kv_hook">>},
-              {<<"fun">>,<<"precommit">>}]}.
-
-%% @private
-%%
-%% @doc Remove Riak Search pre-commit hook from all buckets when Riak
-%% Search is disabled.
-%%
-%% Previous versions of Riak had a bug in `set_bucket' which caused
-%% bucket fixups to leak into the raw ring.  If a user is upgrading
-%% from one of these versions, and enabled search on a bucket, then
-%% the Riak Searc hook will be in the raw ring.  After migrating to
-%% Yokozuna these hooks must be removed to avoid errors.
--spec strip_rs_hooks(boolean(), ring()) -> ok.
-strip_rs_hooks(true, _) ->
-    ok;
-strip_rs_hooks(false, Ring) ->
-    Buckets = riak_core_ring:get_buckets(Ring),
-    strip_rs_hooks_2(Ring, Buckets).
-
-strip_rs_hooks_2(_Ring, []) ->
-    ok;
-strip_rs_hooks_2(Ring, [Bucket|Rest]) ->
-    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    Precommit = get_precommit(BProps),
-    {Changed, NewPreHook} = gen_new_precommit(Precommit),
-    case Changed of
-        true ->
-            riak_core_bucket:set_bucket(Bucket, [{precommit, NewPreHook}]),
-            ok;
-        false ->
-            ok
-    end,
-    strip_rs_hooks_2(Ring, Rest).

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -59,7 +59,7 @@ maybe_setup(true) ->
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
     setup_stats(),
-    ok = riak_core:register(yokozuna, [{permissions, [search,admin]}]),
+    ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),
     ok.
 

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -197,11 +197,6 @@ split_tag_names(TagNames) ->
 %%% Private
 %%%===================================================================
 
-%% TODO: I don't like having X-Riak-Last-Modified in here.  Add
-%%       function to riak_object.
-doc_ts(MD) ->
-    dict:fetch(<<"X-Riak-Last-Modified">>, MD).
-
 %% NOTE: All of this data needs to be in one field to efficiently
 %%       iterate.  Otherwise the doc would have to be fetched for each
 %%       entry.

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -22,8 +22,6 @@
 -include("yokozuna.hrl").
 -compile(export_all).
 
--define(YZ_DEFAULT_DIR, filename:join(["data", "yz"])).
-
 %% @doc This module contains functionaity for using and administrating
 %%      indexes.  In this case an index is an instance of a Solr Core.
 
@@ -234,8 +232,7 @@ remove_from_ring(Name) ->
     end.
 
 index_dir(Name) ->
-    YZDir = app_helper:get_env(?YZ_APP_NAME, yz_dir, ?YZ_DEFAULT_DIR),
-    filename:absname(filename:join([YZDir, Name])).
+    filename:absname(filename:join([?YZ_ROOT_DIR, Name])).
 
 %% @private
 %%

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -136,17 +136,7 @@ get_md_entry(MD, Key) ->
 -spec get_index(bkey(), ring()) -> index_name().
 get_index({Bucket, _}, Ring) ->
     BProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    case is_default_type(Bucket) of
-        false ->
-            proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE);
-        true ->
-            case proplists:get_value(search, BProps, false) of
-                false ->
-                    ?YZ_INDEX_TOMBSTONE;
-                true ->
-                    bucket_name(Bucket)
-            end
-    end.
+    proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE).
 
 %% @doc Determine the "short" preference list given the `BKey' and
 %% `Ring'.  A short preflist is one that defines the preflist by

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -159,7 +159,7 @@ get_short_preflist({Bucket, _} = BKey, Ring) ->
 %% types to transfer.  Once types have transfered some global flag
 %% which is cheap to check would be set and this call would simply
 %% check that.
--spec should_handoff({p(), node()}) -> boolean().
+-spec should_handoff({term(), {p(), node()}}) -> boolean().
 should_handoff({_Reason, {_Partition, TargetNode}}) ->
     BucketTypesPrefix = {core, bucket_types},
     Server = {riak_core_metadata_hashtree, TargetNode},

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -360,19 +360,6 @@ put(Client, Bucket, Key, Value, ContentType) ->
 
 %% @private
 %%
-%% @docs remove a hook from the bucket
-%%
-%% NOTE: Move this into riak_kv
-remove_obj_modified_hook(Bucket, Mod, Fun) ->
-    BProps = riak_core_bucket:get_bucket(Bucket),
-    Existing = proplists:get_value(obj_modified_hooks, BProps, []),
-    HookProp = {Mod, Fun},
-    Hooks = lists:delete(HookProp, Existing),
-    ok = riak_core_bucket:set_bucket(Bucket, [{obj_modified_hooks, Hooks}]).
-
-
-%% @private
-%%
 %% @doc Determine whether process `Flag' is set.
 -spec check_flag(term()) -> boolean().
 check_flag(Flag) ->

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -45,11 +45,6 @@ hostname(Node) ->
 is_claimant(Ring, Node) ->
     Node == get_claimant(Ring).
 
-%% @doc Determine if Riak Search is enabled.
--spec is_riak_search_enabled() -> boolean().
-is_riak_search_enabled() ->
-    app_helper:get_env(?RS_SVC, enabled, false).
-
 %% @doc Add list of webmachine routes to the router.
 add_routes(Routes) ->
     [webmachine_router:add_route(R) || R <- Routes].

--- a/src/yz_rs_migration.erl
+++ b/src/yz_rs_migration.erl
@@ -1,0 +1,109 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(yz_rs_migration).
+-compile(export_all).
+-include("yokozuna.hrl").
+
+%%% @doc This code is only needed for riak search migration and can be
+%%% pulled once riak search is removed from riak.
+
+%% @doc Determine if Riak Search is enabled.
+-spec is_riak_search_enabled() -> boolean().
+is_riak_search_enabled() ->
+    app_helper:get_env(?RS_SVC, enabled, false).
+
+%% @doc Remove Riak Search pre-commit hook from all buckets when Riak
+%% Search is disabled.
+%%
+%% Previous versions of Riak had a bug in `set_bucket' which caused
+%% bucket fixups to leak into the raw ring.  If a user is upgrading
+%% from one of these versions, and enabled search on a bucket, then
+%% the Riak Searc hook will be in the raw ring.  After migrating to
+%% Yokozuna these hooks must be removed to avoid errors.
+-spec strip_rs_hooks(IsRSEnabled :: boolean(), ring()) -> ok.
+strip_rs_hooks(true, _) ->
+    ok;
+strip_rs_hooks(false, Ring) ->
+    Buckets = riak_core_ring:get_buckets(Ring),
+    strip_rs_hooks_2(Ring, Buckets).
+
+%%%===================================================================
+%%% EVERYTHING BELOW IS FOR BUG CAUSED BY LEAKED BUCKET FIXUPS.
+%%%
+%%% Much of this code was copied from `riak_search_kv_hook'.
+%%%===================================================================
+
+%% @private
+%%
+%% @doc Given current pre-commit hook generate a new one with all
+%% instances of the Riak Search hook removed.
+%%
+%% `Changed' - A boolean indicating if the `Precommit' value changed.
+%%
+%% `NewPrecommit' - The new pre-commit hook.
+-spec gen_new_precommit([term()]) -> {Changed :: boolean(),
+                                      NewPrecommit :: [term()]}.
+gen_new_precommit(Precommit) ->
+    %% Strip ALL Riak Search hooks.
+    NewPrecommit = lists:filter(fun ?MODULE:not_rs_hook/1, Precommit),
+    Changed = not (Precommit =:= NewPrecommit),
+    {Changed, NewPrecommit}.
+
+%% @private
+%%
+%% @doc Retrieve the pre-commit hook from bucket properties.  If it
+%% doesn not exist then default to the empty list.
+-spec get_precommit([term()]) -> [term()].
+get_precommit(BProps) ->
+    case proplists:get_value(precommit, BProps, []) of
+        X when is_list(X) -> X;
+        {struct, _}=X -> [X]
+    end.
+
+%% @private
+%%
+%% @doc Predicate function which returns `true' if the `Hook' is NOT a
+%% Riak Search hook.  For use with `lists:filter/2'.
+-spec not_rs_hook(term()) -> boolean().
+not_rs_hook(Hook) ->
+    not (Hook == rs_precommit_def()).
+
+%% @private
+%%
+%% @doc The definition of the Riak Search pre-commit hook.
+-spec rs_precommit_def() -> term().
+rs_precommit_def() ->
+    {struct, [{<<"mod">>,<<"riak_search_kv_hook">>},
+              {<<"fun">>,<<"precommit">>}]}.
+
+strip_rs_hooks_2(_Ring, []) ->
+    ok;
+strip_rs_hooks_2(Ring, [Bucket|Rest]) ->
+    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
+    Precommit = get_precommit(BProps),
+    {Changed, NewPreHook} = gen_new_precommit(Precommit),
+    case Changed of
+        true ->
+            riak_core_bucket:set_bucket(Bucket, [{precommit, NewPreHook}]),
+            ok;
+        false ->
+            ok
+    end,
+    strip_rs_hooks_2(Ring, Rest).

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -179,7 +179,7 @@ build_cmd(SolrPort, SolrJMXPort, Dir) ->
     YZPrivSolr = filename:join([?YZ_PRIV, "solr"]),
     {ok, Etc} = application:get_env(riak_core, platform_etc_dir),
     Headless = "-Djava.awt.headless=true",
-    SolrHome = "-Dsolr.solr.home=" ++ Dir,
+    SolrHome = "-Dsolr.solr.home=" ++ filename:absname(Dir),
     JettyHome = "-Djetty.home=" ++ YZPrivSolr,
     Port = "-Djetty.port=" ++ integer_to_list(SolrPort),
     CP = "-cp",

--- a/src/yz_wm_extract.erl
+++ b/src/yz_wm_extract.erl
@@ -29,7 +29,7 @@
          }).
 
 routes() ->
-    [{["yz", "extract"], yz_wm_extract, []}].
+    [{["search", "extract"], yz_wm_extract, []}].
 
 init(_) ->
     {ok, #state{}}.

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -23,13 +23,13 @@
 %%
 %% Available operations:
 %%
-%% GET /yz/index
+%% GET /search/index
 %%
 %%   Get information about every index in JSON format.
-%%   Currently the same information as /yz/index/Index,
+%%   Currently the same information as /search/index/Index,
 %%   but as an array of JSON objects.
 %%
-%% GET /yz/index/Index
+%% GET /search/index/Index
 %%
 %%   Gets information about a specific index in JSON format.
 %%   Returns the following information:
@@ -45,7 +45,7 @@
 %%   index. That schema file must already be installed on the server.
 %%   Defaults to "_yz_default".
 %%
-%% PUT /yz/index/Index
+%% PUT /search/index/Index
 %%
 %%   Creates a new index with the given name.
 %%
@@ -60,7 +60,7 @@
 %%
 %%   Returns a '409 Conflict' code if the index already exists.
 %%
-%% DELETE /yz/index/Index
+%% DELETE /search/index/Index
 %%
 %%   Deletes the index with the given index name.
 %%
@@ -83,8 +83,8 @@
 
 %% @doc Return the list of routes provided by this resource.
 routes() ->
-    [{["yz", "index", index], yz_wm_index, []},
-     {["yz", "index"], yz_wm_index, []}].
+    [{["search", "index", index], yz_wm_index, []},
+     {["search", "index"], yz_wm_index, []}].
 
 %%%===================================================================
 %%% Callbacks

--- a/src/yz_wm_schema.erl
+++ b/src/yz_wm_schema.erl
@@ -23,10 +23,10 @@
 %%
 %% Available operations:
 %% 
-%% GET /yz/schema/Schema
+%% GET /search/schema/Schema
 %%   Retrieves the schema with the given name
 %%
-%% PUT /yz/schema/Schema
+%% PUT /search/schema/Schema
 %%   Uploads a schema with the given name
 %%   A PUT request requires this header:
 %%     Content-Type: application/xml
@@ -50,7 +50,7 @@
 
 %% @doc Return the list of routes provided by this resource.
 routes() ->
-    [{["yz", "schema", schema], yz_wm_schema, []}].
+    [{["search", "schema", schema], yz_wm_schema, []}].
 
 
 %%%===================================================================

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -35,7 +35,7 @@
 -spec routes() -> [tuple()].
 routes() ->
     Routes1 = [{["search", index], ?MODULE, []}],
-    case yz_misc:is_riak_search_enabled() of
+    case yz_rs_migration:is_riak_search_enabled() of
         false ->
             [{["solr", index, "select"], ?MODULE, []}|Routes1];
         true ->

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -34,8 +34,7 @@
 %% @doc Return the list of routes provided by this resource.
 -spec routes() -> [tuple()].
 routes() ->
-    Routes1 = [{["yz", "search", index], ?MODULE, []},
-               {["search", index], ?MODULE, []}],
+    Routes1 = [{["search", index], ?MODULE, []}],
     case yz_misc:is_riak_search_enabled() of
         false ->
             [{["solr", index, "select"], ?MODULE, []}|Routes1];


### PR DESCRIPTION
Another installment of Riak Search migration code. This pull request does the following.
- Brings the migration test up to speed with the latest code.
- Factors out some common test logic related to AAE.
- Revert the default vs. non-default bucket type change. I.e. all buckets, once again, can have indexes associated with them.
- Remove some dead code and fix type spec.

Most importantly. As of this PR it is possible to migrate a Riak Search deployment to a Yokozuna one.

There is still more to do for Riak Search migration. The biggest task being a command to iterate + index all data in a bucket or list of buckets. This is useful because migration will not require waiting for AAE and it will be useful in future for schema migrations. However, that change will require some more fundamental changes in the Yokozuna indexing code path. Rather than make an even bigger PR I thought it makes sense to push this one out so that it has a chance to make it in the 0.12.0 release.

This is related to issue #20.
