### PR TITLE
Update yokozuna.schema to include solr_startup_wait cuttlefish support

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -16,6 +16,12 @@
           end
   end}.
 
+%% Critical once Solr is loaded with data it can takes a minute to startup. milliseconds for Riak to wait for solr to startup before terminating
+{mapping, "yokozuna.solr_startup_wait", "yokozuna.solr_startup_wait", [
+  {default, {{15000}} },
+  {datatype, integer}
+]}.
+
 %% @doc The port number which Solr binds to.
 {mapping, "search.solr_port", "yokozuna.solr_port", [
   {default, {{yz_solr_port}} },

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -17,9 +17,12 @@
   end}.
 
 
-%% @doc The startup wait time, in milliseconds, Riak will wait for Solr to startup before exiting and shutting down the node (after the preset attempt limit). This may need to be increased as more data is indexed and Solr takes longer to start.
+%% @doc The startup wait time, in milliseconds, Riak will wait for Solr
+%% to startup before exiting and shutting down the node (after the preset
+%% attempt limit). This may need to be increased as more data is indexed
+%% and Solr takes longer to start.
 {mapping, "search.solr_startup_wait", "yokozuna.solr_startup_wait", [
-  {default, {{15000}} },
+  {default, {15000} },
   {datatype, integer}
 ]}.
 

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -22,7 +22,7 @@
 %% attempt limit). This may need to be increased as more data is indexed
 %% and Solr takes longer to start.
 {mapping, "search.solr_startup_wait", "yokozuna.solr_startup_wait", [
-  {default, {15000} },
+  {default, 15000},
   {datatype, integer}
 ]}.
 

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -16,8 +16,9 @@
           end
   end}.
 
-%% Critical once Solr is loaded with data it can takes a minute to startup. milliseconds for Riak to wait for solr to startup before terminating
-{mapping, "yokozuna.solr_startup_wait", "yokozuna.solr_startup_wait", [
+
+%% @doc The startup wait time, in milliseconds, Riak will wait for Solr to startup before exiting and shutting down the node (after the preset attempt limit). This may need to be increased as more data is indexed and Solr takes longer to start.
+{mapping, "search.solr_startup_wait", "yokozuna.solr_startup_wait", [
   {default, {{15000}} },
   {datatype, integer}
 ]}.


### PR DESCRIPTION
Riak would not startup when Solr is loaded with millions of docs
