### PR TITLE
Integrate the Exometer metrics package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {riak_kv, ".*",
-   {git, "git://github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}}
+   {git, "git@github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {riak_kv, ".*",
-   {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}}
+   {git, "git://github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {riak_kv, ".*",
-   {git, "git@github.com:Feuerlabs/riak_kv.git", {branch, "uw-exometer-dev"}}}
+   {git, "git@github.com:basho/riak_kv.git", {branch, "feuerlabs-exometer"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -29,8 +29,8 @@
 -include("yokozuna.hrl").
 %% -type microseconds() :: integer().
 -define(SERVER, ?MODULE).
--define(NOTIFY(A, B, Type, Arg),
-        folsom_metrics:notify_existing_metric({?YZ_APP_NAME, A, B}, Arg, Type)).
+-define(APP, ?YZ_APP_NAME).
+-define(PFX, riak_core_stat:prefix()).
 
 %% -------------------------------------------------------------------
 %% API
@@ -42,13 +42,7 @@ start_link() ->
 %% @doc Register Yokozuna stats.
 -spec register_stats() -> ok.
 register_stats() ->
-    [begin
-         Name = stat_name(Path),
-         (catch folsom_metrics:delete_metric(Name)),
-         register_stat(Name, Type)
-     end || {Path, Type} <- stats()],
-    riak_core_stat_cache:register_app(?YZ_APP_NAME, {?MODULE, produce_stats, []}),
-    ok.
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Transform the yz stats to a format consistent
 %% with "legacy" stats and rename them
@@ -63,21 +57,7 @@ search_stats() ->
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist() | {error, term()}.
 get_stats() ->
-    get_stats(?YZ_ENABLED).
-
-%% @doc Return current aggregation of all stats.
--spec get_stats(false | true) -> proplists:proplist().
-get_stats(false) -> [];
-get_stats(true) ->
-    case riak_core_stat_cache:get_stats(?YZ_APP_NAME) of
-        {ok, Stats, _TS} -> Stats;
-        Error -> Error
-    end.
-
-%% TODO: export stats() type from riak_core_stat_q.
--spec produce_stats() -> {atom(), list()}.
-produce_stats() ->
-    {?YZ_APP_NAME, riak_core_stat_q:get_stats([yokozuna])}.
+    riak_core_stat:get_stats(?APP).
 
 %% @doc Send stat updates for an index failure.
 -spec index_fail() -> ok.
@@ -171,33 +151,22 @@ code_change(_OldVsn, State, _Extra) ->
 %%
 %% @doc Notify specific metrics in folsom based on the `StatUpdate' term
 %% passed in.
--spec notify(StatUpdate::term()) -> ok.
-notify({index_end, Time}) ->
-    ?NOTIFY(index, latency, histogram, Time),
-    ?NOTIFY(index, throughput, spiral, 1);
-notify(index_fail) ->
-    ?NOTIFY(index, fail, spiral, 1);
-notify({search_end, Time}) ->
-    ?NOTIFY('query', latency, histogram, Time),
-    ?NOTIFY('query', throughput, spiral, 1);
-notify(search_fail) ->
-    ?NOTIFY('query', fail, spiral, 1).
+-spec update(StatUpdate::term()) -> ok.
+update({index_end, Time}) ->
+    exometer:update([?PFX, ?APP, index, latency], Time),
+    exometer:update([?PFX, ?APP, index, throughput], 1);
+update(index_fail) ->
+    exometer:update([?PFX, ?APP, fail], 1);
+update({search_end, Time}) ->
+    exometer:update([?PFX, ?APP, search, latency], Time),
+    exometer:update([?PFX, ?APP, search, throughput], 1);
+update(search_fail) ->
+    exometer:update([?PFX, ?APP, search, fail], 1).
 
-%% @private
-get_sample_type(Name) ->
-    SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),
-    app_helper:get_env(?YZ_APP_NAME, Name, SampleType0).
-
-%% @private
--spec register_stat(riak_core_stat_q:stat_name(), atom()) -> ok |
-                                                             {error, Subject :: term(), Reason :: term()}.
-register_stat(Name, histogram) ->
-    {SampleType, SampleArgs} = get_sample_type(Name),
-    folsom_metrics:new_histogram(Name, SampleType, SampleArgs);
-register_stat(Name, spiral) ->
-    folsom_metrics:new_spiral(Name);
-register_stat(Name, counter) ->
-    folsom_metrics:new_counter(Name).
+%% %% @private
+%% get_sample_type(Name) ->
+%%     SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),
+%%     app_helper:get_env(?APP, Name, SampleType0).
 
 %% @private
 -spec stats() -> [{riak_core_stat_q:path(), atom()}].
@@ -210,20 +179,3 @@ stats() ->
      {['query', latency], histogram},
      {['query', throughput], spiral}
     ].
-
-%% @private
--spec stat_name(riak_core_stat_q:path()) -> riak_core_stat_q:stat_name().
-stat_name(Name) ->
-    list_to_tuple([?YZ_APP_NAME|Name]).
-
-%% @private
-%%
-%% @doc Determine the correct channel through which to send the
-%% `StatUpdate'.
--spec update(term()) -> ok.
-update(StatUpdate) ->
-    case erlang:module_loaded(yz_stat_sj) of
-        true -> yz_stat_worker:update(StatUpdate);
-        false -> notify(StatUpdate)
-    end,
-    ok.

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -44,16 +44,6 @@ start_link() ->
 register_stats() ->
     riak_core_stat:register_stats(?APP, stats()).
 
-%% @doc Transform the yz stats to a format consistent
-%% with "legacy" stats and rename them
--spec search_stats() -> proplists:proplist().
-search_stats() ->
-    {Legacy, _Calculated} = lists:foldl(fun({Old, New, Type}, {Acc, Cache}) ->
-                                                riak_kv_stat_bc:bc_stat({Old, New, Type}, Acc, Cache) end,
-                                        {[], []},
-                                        stats_map()),
-    lists:reverse(Legacy).
-
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist() | {error, term()}.
 get_stats() ->


### PR DESCRIPTION
This PR is part of a set of PRs aimed at integrating the [Exometer](https://github.com/Feuerlabs/exometer) metrics package into Riak.

(From basho/riak_core#465)

From our measurements so far, Exometer offers both better throughput and lower footprint than the previous metrics management, and at the same time offers more flexible and uniform handling and better extensibility.

In addition to maintaining the console command `riak-admin status` and the HTTP JSON report (which aim to be backwards-compatible), a new console command, `riak-admin stat <cmd>` has been added, for selective reporting of statistics as well as some management (ability to enable/disable metrics on the fly).

Other noteworthy changes:
- Exometer entry names are always lists. In riak, only atoms and numbers should be used as list elements.
- A top-level 'prefix' (default: `riak`) has been added, in order to differentiate between stats from different riak-style products (e.g. when reporting stats to collectd). The function `riak_core_stat:prefix()` is generated as a constant expression through the parse transform `riak_core_stat_xform`, which in its turn checks the OS env variable `RIAK_CORE_STAT_PREFIX`. A typical entry would thus be e.g. `[riak,riak_kv,node,gets,siblings]`.
- Internally in riak, stats are referred to symbolically using the same (tuple-based) names as before. These often refer to more than one low-level metric, so it seemed reasonable to keep this naming scheme.
- Exometer provides similar functionality as 'sidejob' and the riak_core stat cache, so these are no longer used for stats management (although sidejob still maintains some stats on its own, which are accessible via Exometer). Other apps still register with `riak_core_stat`, but need not provide callbacks in other to query the stats. The query style of exometer is the same as that of riak_core_stat.
