### PR TITLE
Add support for KV datatypes (counters, sets, maps)

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -106,6 +106,16 @@
    <dynamicField name="*_ig" type="ignored" multiValued="true"/>
    <dynamicField name="random_*" type="random" />
 
+   <!-- Riak datatypes default fields-->
+   <field name="counter" type="int"    indexed="true" stored="true" />
+   <field name="set"     type="string" indexed="true" stored="false" multiValued="true" />
+
+   <!-- Riak datatypes embedded fields -->
+   <dynamicField name="*_flag"     type="boolean" indexed="true" stored="true" />
+   <dynamicField name="*_counter"  type="int"     indexed="true" stored="true" />
+   <dynamicField name="*_register" type="string"  indexed="true" stored="false" />
+   <dynamicField name="*_set"      type="string"  indexed="true" stored="false" multiValued="true" />
+
    <!-- catch-all field -->
    <dynamicField name="*" type="text_general" indexed="true" stored="false" multiValued="true" />
 

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -113,7 +113,7 @@
    <!-- Riak datatypes embedded fields -->
    <dynamicField name="*_flag"     type="boolean" indexed="true" stored="true" />
    <dynamicField name="*_counter"  type="int"     indexed="true" stored="true" />
-   <dynamicField name="*_register" type="string"  indexed="true" stored="false" />
+   <dynamicField name="*_register" type="string"  indexed="true" stored="true" />
    <dynamicField name="*_set"      type="string"  indexed="true" stored="false" multiValued="true" />
 
    <!-- catch-all field -->

--- a/riak_test/yz_dt_test.erl
+++ b/riak_test/yz_dt_test.erl
@@ -1,0 +1,141 @@
+-module(yz_dt_test).
+-compile(export_all).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CFG, [{riak_core, [{ring_creation_size, 16}]},
+              {yokozuna, [{enabled, true}]}]).
+-define(COUNTER, <<"counters">>).
+-define(SET, <<"sets">>).
+-define(MAP, <<"maps">>).
+-define(TYPES,
+        [{?COUNTER, counter, riakc_counter},
+         {?SET, set, riakc_set},
+         {?MAP, map, riakc_map}]).
+
+-import(yz_rt, [
+                connection_info/1,
+                create_index/2, 
+                search_expect/5,
+                solr_http/1,
+                wait_for_index/2
+               ]).
+
+confirm() ->
+    application:start(ibrowse),
+    %% Build a cluster
+    [Node|_] = Nodes = rt:build_cluster(4, ?CFG),
+    [CI|_] = connection_info(Nodes),
+    PB = rt:pbc(Node),
+    Solr = solr_http(CI),
+    [ begin
+          %% Create an index for each type (default schema)
+          create_index(Node, BType),
+          wait_for_index(Nodes, BType),
+          %% Create bucket types for datatypes with given indexes
+          rt:create_and_activate_bucket_type(Node, BType, [{datatype, Type},
+                                                           {allow_mult, true},
+                                                           {search_index, BType}])
+      end || {BType, Type, _} <- ?TYPES ],
+    %% Update some datatypes
+    counter_update(PB),
+    set_update(PB),
+    map_update(PB),
+    %% Search the index for the types
+    counter_search(Solr),
+    set_search(Solr),
+    map_search(Solr),
+    pass.
+
+counter_update(PB) ->
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?COUNTER, <<"1">>}, <<"10">>, {counter, {increment, 10}, undefined})),
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?COUNTER, <<"2">>}, <<"100">>, {counter, {increment, 100}, undefined})),
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?COUNTER, <<"1">>}, <<"1000">>, {counter, {decrement, 1000}, undefined})).
+
+counter_search(Solr) ->
+    ?assert(search_expect(Solr, ?COUNTER, "counter", "10", 1)),
+    ?assert(search_expect(Solr, ?COUNTER, "counter", "[0 TO 999]", 2)),
+    ?assert(search_expect(Solr, ?COUNTER, "counter", "[99 TO 999]", 1)).
+
+set_update(PB) ->
+    Dynamos = lists:foldl(fun riakc_set:add_element/2, riakc_set:new(),
+                          [<<"Riak">>, <<"Cassandra">>, <<"Voldemort">>, <<"Couchbase">>]),
+    Erlangs = lists:foldl(fun riakc_set:add_element/2, riakc_set:new(),
+                          [<<"Riak">>, <<"Couchbase">>, <<"CouchDB">>]),
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?SET, <<"databass">>}, <<"dynamo">>, riakc_set:to_op(Dynamos))),
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?SET, <<"databass">>}, <<"erlang">>, riakc_set:to_op(Erlangs))).
+
+set_search(Solr) ->
+    ?assert(search_expect(Solr, ?SET, "set", "Riak", 2)),
+    ?assert(search_expect(Solr, ?SET, "set", "CouchDB", 1)),
+    ?assert(search_expect(Solr, ?SET, "set", "Voldemort", 1)),
+    ?assert(search_expect(Solr, ?SET, "set", "C*", 2)).
+
+map_update(PB) ->
+    Sam = lists:foldl(fun({Key, Fun}, Map) ->
+                              riakc_map:update(Key, Fun, Map)
+                      end, riakc_map:new(),
+                      [{{<<"friends">>, set},
+                        fun(Set) ->
+                                riakc_set:add_element(<<"Sean">>,
+                                                      riakc_set:add_element(<<"Russell">>, Set))
+                        end},
+                       {{<<"name">>, register},
+                        fun(Reg) ->
+                                riakc_register:set(<<"Sam Elliott">>, Reg)
+                        end},
+                       {{<<"student">>, flag}, fun riakc_flag:enable/1},
+                       {{<<"burgers">>, counter}, fun(C) -> riakc_counter:increment(10, C) end}]),
+
+    Russell = lists:foldl(fun({Key, Fun}, Map) ->
+                                  riakc_map:update(Key, Fun, Map)
+                          end, riakc_map:new(),
+                          [{{<<"friends">>, set},
+                            fun(Set) ->
+                                    riakc_set:add_element(<<"Sean">>,
+                                                          riakc_set:add_element(<<"Sam">>, Set))
+                            end},
+                           {{<<"name">>, register},
+                            fun(Reg) ->
+                                    riakc_register:set(<<"Russell Brown">>, Reg)
+                            end},
+                           {{<<"student">>, flag}, fun riakc_flag:disable/1},
+                           {{<<"burgers">>, counter}, fun(C) -> riakc_counter:increment(100, C) end}]),
+
+    Sean = lists:foldl(fun({Key, Fun}, Map) ->
+                               riakc_map:update(Key, Fun, Map)
+                       end, riakc_map:new(),
+                       [{{<<"friends">>, set},
+                         fun(Set) ->
+                                 riakc_set:add_element(<<"Russell">>,
+                                                       riakc_set:add_element(<<"Joe">>, Set))
+                         end},
+                        {{<<"name">>, register},
+                         fun(Reg) ->
+                                 riakc_register:set(<<"Sean Cribbs">>, Reg)
+                         end},
+                        {{<<"office">>, map}, 
+                         fun(M) -> 
+                                 riakc_map:update(
+                                   {<<"cats">>, counter}, 
+                                   fun(C) -> riakc_counter:increment(2, C) end, 
+                                   riakc_map:update(
+                                     {<<"location">>, register}, 
+                                     fun(R) -> riakc_register:set(<<"The Cornfields, IL USA">>, R) end, M))
+                         end}]),
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?MAP, <<"people">>},<<"lenary">> ,riakc_map:to_op(Sam))), 
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?MAP, <<"people">>},<<"rdb">> ,riakc_map:to_op(Russell))), 
+    ?assertEqual(ok, riakc_pb_socket:update_type(PB, {?MAP, <<"people">>},<<"scribbs">> ,riakc_map:to_op(Sean))).    
+
+map_search(Solr) ->
+    ?assert(search_expect(Solr, ?MAP, "burgers_counter", "*", 2)),
+    ?assert(search_expect(Solr, ?MAP, "burgers_counter", "[11 TO 1000]", 1)),
+    ?assert(search_expect(Solr, ?MAP, "student_flag", "*", 2)),
+    ?assert(search_expect(Solr, ?MAP, "student_flag", "true", 1)),
+    ?assert(search_expect(Solr, ?MAP, "name_register", "S*", 2)),
+    ?assert(search_expect(Solr, ?MAP, "office_map.cats_counter", "1", 0)),
+    ?assert(search_expect(Solr, ?MAP, "office_map.cats_counter", "2", 1)),
+    ?assert(search_expect(Solr, ?MAP, "office_map.location_register", "*", 1)),
+    ?assert(search_expect(Solr, ?MAP, "friends_set", "Sam", 1)),
+    ?assert(search_expect(Solr, ?MAP, "friends_set", "Joe", 1)),
+    ?assert(search_expect(Solr, ?MAP, "friends_set", "Russell", 2)).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -190,7 +190,9 @@ search(HP, Index, Name, Term) ->
 search(Type, {Host, Port}, Index, Name, Term) when is_integer(Port) ->
     search(Type, {Host, integer_to_list(Port)}, Index, Name, Term);
 
-search(Type, {Host, Port}, Index, Name, Term) ->
+search(Type, {Host, Port}, Index, Name0, Term0) ->
+    Name = mochiweb_util:quote_plus(Name0),
+    Term = mochiweb_util:quote_plus(Term0),
     FmtStr = case Type of
                  solr ->
                      "http://~s:~s/solr/~s/select?q=~s:~s&wt=json";

--- a/src/yz_dt_extractor.erl
+++ b/src/yz_dt_extractor.erl
@@ -1,0 +1,136 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc An extractor for Riak KV's datatypes. Maps have their fields
+%% concatenated with `field_separator'. Sets are converted into
+%% multi-valued fields. Counters are treated as integer fields.
+%% Embedded flags are treated as boolean fields. Embedded registers
+%% are treated as regular fields.
+%%
+%% Counter example:
+%%
+%%    [{<<"counter">>, <<"5">>}]
+%%
+%% Set example:
+%%
+%%    [<<"Cassandra">>, <<"Riak">>, <<"Voldemort">>]
+%%
+%%    [{<<"set">>, <<"Cassandra">>},
+%%     {<<"set">>, <<"Riak">>},
+%%     {<<"set">>, <<"Voldemort">>}]
+%%
+%% Map example (note the output of embedded types and conversion of
+%% module to symbolic type):
+%%
+%%    [{{<<"activated">>, riak_dt_od_flag}, true},
+%%     {{<<"name">>, riak_dt_lwwreg}, <<"Ryan Zezeski">>},
+%%     {{<<"phones">>, riak_dt_orswot}, [<<"555-5555">>, <<"867-5309">>]},
+%%     {{<<"page_views">>, riak_dt_pncounter}, 1502},
+%%     {{<<"events">>, riak_dt_map},
+%%      [{{<<"RICON">>, riak_dt_lwwreg}, <<"spoke">>},
+%%       {{<<"Surge">>, riak_dt_lwwreg}, <<"attended">>}]}]
+%%
+%%    [{<<"activated_flag">>, true},
+%%     {<<"name_register">>, <<"Ryan Zezeski">>},
+%%     {<<"phones_set">>, <<"555-5555">>},
+%%     {<<"phones_set">>, <<"867-5309">>},
+%%     {<<"page_views_counter">>, <<"1502">>},
+%%     {<<"events_map.RICON_register">>, <<"spoke">>},
+%%     {<<"events_map.Surge_register">>, <<"attended">>}]
+%%
+%% Options:
+%%
+%%   `field_separator' - Use a different field separator than the
+%%                       default of `.'.
+
+-module(yz_dt_extractor).
+-compile(export_all).
+-include("yokozuna.hrl").
+-include_lib("riak_kv/include/riak_kv_types.hrl").
+-define(DEFAULT_FIELD_SEPARATOR, <<".">>).
+
+-record(state, {
+          fields = [],
+          field_separator = ?DEFAULT_FIELD_SEPARATOR
+         }).
+-type state() :: #state{}.
+-type field_path_name() :: undefined | {binary() | undefined, binary()}.
+-type datatype() :: map | set | counter | register | flag.
+-spec extract(binary()) -> fields() | {error, any()}.
+extract(Value) ->
+    extract(Value, ?NO_OPTIONS).
+
+-spec extract(binary(), proplist()) -> fields() | {error, any()}.
+extract(Value0, Opts) ->
+    Sep = proplists:get_value(field_separator, Opts, ?DEFAULT_FIELD_SEPARATOR),
+    case riak_kv_crdt:from_binary(Value0) of
+        {ok, Value} ->
+            extract_fields(Value, #state{field_separator = Sep});
+        Err -> Err
+    end.
+
+-spec extract_fields(#crdt{}, state()) -> fields().
+extract_fields(#crdt{mod=Mod, value=Data}, S) ->
+    case extract_fields(undefined, riak_kv_crdt:from_mod(Mod), Mod:value(Data), S) of
+        #state{fields=F} -> F;
+        Err -> Err
+    end.
+
+-spec extract_fields(field_path_name(), datatype(), term(), state()) -> state().
+extract_fields(Name0, map, Pairs, #state{field_separator=Sep}=State) ->
+    Name = field_name(Name0, map, Sep),
+    lists:foldl(extract_map(Name), State, Pairs);
+extract_fields(Name0, set, Entries, #state{field_separator=Sep}=State) ->
+    Name = field_name(Name0, set, Sep),
+    lists:foldl(extract_set(Name), State, Entries);
+extract_fields(Name, counter, Value, #state{fields=Fields, field_separator=Sep}=State) ->
+    FieldName = field_name(Name, counter, Sep),
+    State#state{fields=[{FieldName, ?INT_TO_BIN(Value)}|Fields]};
+extract_fields(Name, register, Value, #state{fields=Fields, field_separator=Sep}=State) ->
+    FieldName = field_name(Name, register, Sep),
+    State#state{fields=[{FieldName, Value}|Fields]};
+extract_fields(Name, flag, Value, #state{fields=Fields, field_separator=Sep}=State) ->
+    FieldName = field_name(Name, flag, Sep),
+    State#state{fields=[{FieldName, Value}|Fields]}.
+
+-spec field_name(field_path_name(), datatype(), binary()) -> binary().
+field_name(undefined, map, _Sep) ->
+    %% (timeforthat)
+    undefined;
+field_name(undefined, Type, _Sep) ->
+    ?ATOM_TO_BIN(Type);
+field_name({undefined, Name}, Type, _Sep) ->
+    %% First-level in map
+    <<Name/binary,$_,(?ATOM_TO_BIN(Type))/binary>>;
+field_name({Prefix, Name}, Type, Sep) ->
+    <<Prefix/binary, Sep/binary, Name/binary,$_,(?ATOM_TO_BIN(Type))/binary>>.
+
+-spec extract_set(binary()) -> fun((binary(), state()) -> state()).
+extract_set(Name) ->
+    fun(Elem, #state{fields=Fields}=Acc) ->
+            Acc#state{fields=[{Name, Elem}|Fields]}
+    end.
+
+-spec extract_map(field_path_name()) -> fun(({{binary(), module()}, term()}, state()) -> state()).
+extract_map(Prefix) ->
+    fun({{FieldName, Mod}, Value}, Acc) ->
+            Type = riak_kv_crdt:from_mod(Mod),
+            extract_fields({Prefix, FieldName}, Type, Value, Acc)
+    end.

--- a/src/yz_dt_extractor.erl
+++ b/src/yz_dt_extractor.erl
@@ -112,7 +112,6 @@ extract_fields(Name, flag, Value, #state{fields=Fields, field_separator=Sep}=Sta
 
 -spec field_name(field_path_name(), datatype(), binary()) -> binary().
 field_name(undefined, map, _Sep) ->
-    %% (timeforthat)
     undefined;
 field_name(undefined, Type, _Sep) ->
     ?ATOM_TO_BIN(Type);

--- a/src/yz_extractor.erl
+++ b/src/yz_extractor.erl
@@ -30,12 +30,12 @@
 %%       registered when there is one.
 -define(DEFAULT_MAP, [{default, yz_noop_extractor},
                       {"application/json",yz_json_extractor},
+                      {"application/riak_counter", yz_dt_extractor},
+                      {"application/riak_map", yz_dt_extractor},
+                      {"application/riak_set", yz_dt_extractor},
                       {"application/xml",yz_xml_extractor},
                       {"text/plain",yz_text_extractor},
-                      {"text/xml",yz_xml_extractor},
-                      {"application/riak_counter", yz_dt_extractor},
-                      {"application/riak_set", yz_dt_extractor},
-                      {"application/riak_map", yz_dt_extractor}
+                      {"text/xml",yz_xml_extractor}
                      ]).
 -define(META_EXTRACTOR_MAP, yokozuna_extractor_map).
 

--- a/src/yz_extractor.erl
+++ b/src/yz_extractor.erl
@@ -32,7 +32,11 @@
                       {"application/json",yz_json_extractor},
                       {"application/xml",yz_xml_extractor},
                       {"text/plain",yz_text_extractor},
-                      {"text/xml",yz_xml_extractor}]).
+                      {"text/xml",yz_xml_extractor},
+                      {"application/riak_counter", yz_dt_extractor},
+                      {"application/riak_set", yz_dt_extractor},
+                      {"application/riak_map", yz_dt_extractor}
+                     ]).
 -define(META_EXTRACTOR_MAP, yokozuna_extractor_map).
 
 

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -121,7 +121,7 @@ handle_info({check_solr, WaitTimeSecs}, S=?S_MATCH) ->
             {stop, "solr didn't start in alloted time", S}
     end;
 handle_info({_Port, {data, Data}}, S=?S_MATCH) ->
-    ?INFO("solr stdout/err: ~p", Data),
+    ?INFO("solr stdout/err: ~s", [Data]),
     {noreply, S};
 handle_info({_Port, {exit_status, ExitStatus}}, S) ->
     {stop, {"solr OS process exited", ExitStatus}, S};

--- a/test/yz_dt_extractor_tests.erl
+++ b/test/yz_dt_extractor_tests.erl
@@ -1,0 +1,85 @@
+-module(yz_dt_extractor_tests).
+-compile(export_all).
+-include_lib("yz_test.hrl").
+-include_lib("riak_kv/include/riak_kv_types.hrl").
+
+
+%% Test counter extract
+counter_test() ->
+    CounterBin = binary_crdt(counter),
+    Result = yz_dt_extractor:extract(CounterBin),
+    Expect = [{<<"counter">>, <<"10">>}],
+
+    valid_extraction(Result, Expect).
+
+%% Test set extract
+set_test() ->
+    SetBin = binary_crdt(set),
+    Result = yz_dt_extractor:extract(SetBin),
+    Expect = [{<<"set">>, <<"Riak">>},
+              {<<"set">>, <<"Cassandra">>},
+              {<<"set">>, <<"Voldemort">>}],
+
+    valid_extraction(Result, Expect).
+
+%% Test map extract
+map_test() ->
+    MapBin = binary_crdt(map),
+    Result = yz_dt_extractor:extract(MapBin),
+    Expect = [{<<"activated_flag">>, true},
+              {<<"name_register">>, <<"Ryan Zezeski">>},
+              {<<"phones_set">>, <<"555-5555">>},
+              {<<"phones_set">>, <<"867-5309">>},
+              {<<"page_views_counter">>, <<"1502">>},
+              {<<"events_map.RICON_register">>, <<"spoke">>},
+              {<<"events_map.Surge_register">>, <<"attended">>}],
+
+    valid_extraction(Result, Expect).
+
+field_separator_test() ->
+    MapBin = binary_crdt(map),
+    Result = yz_dt_extractor:extract(MapBin, [{field_separator, <<"--">>}]),
+    Expect = [{<<"activated_flag">>, true},
+              {<<"name_register">>, <<"Ryan Zezeski">>},
+              {<<"phones_set">>, <<"555-5555">>},
+              {<<"phones_set">>, <<"867-5309">>},
+              {<<"page_views_counter">>, <<"1502">>},
+              {<<"events_map--RICON_register">>, <<"spoke">>},
+              {<<"events_map--Surge_register">>, <<"attended">>}],
+
+    valid_extraction(Result, Expect).
+
+
+valid_extraction(Result, Expect) ->
+    ?assertEqual((length(Expect)), (length(Result))),
+    Pairs = lists:zip(lists:sort(Expect), lists:sort(Result)),
+    [ ?assertEqual(E,R) || {E,R} <- Pairs],
+    ?STACK_IF_FAIL(yz_solr:prepare_json([{doc, Result}])).
+
+binary_crdt(Type) ->
+    riak_kv_crdt:to_binary(raw_type(Type)).
+
+raw_type(map) ->
+    ?MAP_TYPE(
+       element(2,?MAP_TYPE:update(
+         {update,
+          [
+           {update, {<<"activated">>, ?FLAG_TYPE}, enable},
+           {update, {<<"name">>, ?REG_TYPE}, {assign, <<"Ryan Zezeski">> }},
+           {update, {<<"phones">>, ?SET_TYPE}, {add_all, [<<"555-5555">>, <<"867-5309">>]}},
+           {update, {<<"page_views">>, ?COUNTER_TYPE}, {increment, 1502}},
+           {update, {<<"events">>, ?MAP_TYPE},
+            {update,
+             [
+              {update, {<<"RICON">>, ?REG_TYPE}, {assign, <<"spoke">>}},
+              {update, {<<"Surge">>, ?REG_TYPE}, {assign, <<"attended">>}}
+             ]}}
+          ]}, <<0>>, ?MAP_TYPE:new())));
+raw_type(set) ->
+    ?SET_TYPE(
+       element(2,?SET_TYPE:update({add_all, [<<"Riak">>, <<"Cassandra">>, <<"Voldemort">>]},
+                                  <<0>>, ?SET_TYPE:new()))
+      );
+raw_type(counter) ->
+    ?COUNTER_TYPE(
+       element(2,?COUNTER_TYPE:update({increment, 10}, <<0>>, ?COUNTER_TYPE:new()))).


### PR DESCRIPTION
- Extracts top-level types into fields as described in `yz_dt_extractor`.
- Defines content types that match those used in [`riak_kv`](https://github.com/basho/riak_kv/blob/develop/include/riak_kv_types.hrl)
- Adds fields and dynamic fields to the default schema.

TODO:
- [x] riak_test for indexing CRDTs
