### PR TITLE
Delete core.properties file during core creation

### DIFF
--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -320,19 +320,18 @@ confirm_bad_schema(Cluster) ->
     lager:info("give solr time to attempt to create core ~s", [Name]),
     timer:sleep(5000),
     lager:info("verify solr core ~s is not up", [Name]),
-    ?assertNot(yz_solr:ping(binary_to_list(Name))),
+    ?assertNot(yz_solr:ping(Name)),
 
     lager:info("upload corrected schema ~s", [Name]),
     {ok, Status3, _, _} = http(put, URL, Headers, ?TEST_SCHEMA),
     ?assertEqual("204", Status3),
 
     lager:info("wait for yz to retry creation of core ~s", [Name]),
-    Node = select_random(Cluster),
     F = fun(Node2) ->
                 lager:info("try to ping core ~s", [Name]),
-                rpc:call(Node2, yz_solr, ping, [binary_to_list(Name)])
+                rpc:call(Node2, yz_solr, ping, [Name])
         end,
-    ?assertEqual(ok, rt:wait_until(Node, F)).
+    yz_rt:wait_until(Cluster, F).
 
 
 %%%===================================================================

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -141,6 +141,15 @@ local_create(Ring, Name) ->
 
             yz_misc:make_dirs([ConfDir, DataDir]),
             yz_misc:copy_files(ConfFiles, ConfDir, update),
+
+            %% Delete `core.properties' file or CREATE may complain
+            %% about the core already existing. This can happen when
+            %% the core is initially created with a bad schema. Solr
+            %% gets in a state where CREATE thinks the core already
+            %% exists but RELOAD says no core exists.
+            PropsFile = filename:join([IndexDir, "core.properties"]),
+            file:delete(PropsFile),
+
             ok = file:write_file(SchemaFile, RawSchema),
 
             CoreProps = [


### PR DESCRIPTION
As of Solr 4.6.0 a Core can get into a weird state when it is CREATEd
with a bad schema file, e.g. a schema including a bad class name.
Solr will create a core.properties file but will ultimately fail to
initialize the Core because of the bad class. Yokozuna has been built to
treat CREATE as in idempotent action that it can retry until it works.
If the user uploads a fixed schema then the next instance of CREATE
should work. However, in 4.6.0 Solr now complains about creating a core
which doesn't exist in memory but has a core.properties file on disk.
The Solr documentation says that a RELOAD operation must be used but the
results in Solr returning an exception saying the core doesn't exist.
Furthermore, an UNLOAD action results in a NullPointerException when the
Core is in this state.

The core.properties file is generated by Solr. It contains minimal
information and deleting it doesn't damage the index. Thus, the easiest
solution was to simply delete the core.properties before calling CREATE.
If this is the first time the Core is being create then the file doesn't
exist anyways. If the Core is in this purgatory state then it allows
CREATE to retry initialization rather than fail.

This addresses #245.
