### PR TITLE
Add ability to reload indexes

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -36,6 +36,9 @@
 -type base64() :: binary().
 -type hash() :: binary().
 
+%% milliseconds
+-type ms() :: non_neg_integer().
+
 %% An iso8601 datetime as binary, e.g. <<"20121221T000000">>.
 -type iso8601() :: binary().
 -type tree_name() :: atom().
@@ -267,6 +270,10 @@
 -type indexes() :: orddict(index_name(), index_info()).
 -type index_info() :: #index_info{}.
 -type index_name() :: binary().
+
+-type reload_opt() :: {schema, boolean()} | {timeout, ms()}.
+-type reload_opts() :: [reload_opt()].
+-type reload_errs() :: [{node(), {error, term()}}].
 
 -define(YZ_INDEX_TOMBSTONE, <<"_dont_index_">>).
 -define(YZ_INDEX, search_index).

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -39,6 +39,8 @@
 %% milliseconds
 -type ms() :: non_neg_integer().
 
+-type predicate(A) :: fun((A) -> boolean()).
+
 %% An iso8601 datetime as binary, e.g. <<"20121221T000000">>.
 -type iso8601() :: binary().
 -type tree_name() :: atom().

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -18,6 +18,80 @@
           ]}
         ]).
 
+-define(SCHEMA,
+        <<"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<schema name=\"test\" version=\"1.5\">
+<fields>
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" />
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+</fields>
+
+ <uniqueKey>_yz_id</uniqueKey>
+
+<types>
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
+
+-define(SCHEMA_FIELD_ADDED,
+        <<"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<schema name=\"test\" version=\"1.5\">
+<fields>
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" />
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+   <field name=\"my_new_field\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" />
+</fields>
+
+ <uniqueKey>_yz_id</uniqueKey>
+
+<types>
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
 
 confirm() ->
     Cluster = rt:build_cluster(4, ?CFG),
@@ -30,6 +104,7 @@ confirm() ->
     confirm_get(Cluster, <<"test_index_2">>),
     confirm_404(Cluster, <<"not_an_index">>),
     confirm_delete_409(Cluster, <<"delete_409">>),
+    confirm_field_add(Cluster, <<"field_add">>),
     pass.
 
 %% @doc Test basic creation, no body.
@@ -162,6 +237,50 @@ confirm_delete_409(Cluster, Index) ->
     %% TODO: wait_for_index_delete?
     {ok, "204", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY).
 
+%% @doc Verify that an index's schema can have a field added to it and
+%% reloaded.
+confirm_field_add(Cluster, Index) ->
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    lager:info("confirm_field_add ~s [~p]", [Index, HP]),
+
+    lager:info("upload schema ~s [~p]", [Index, HP]),
+    SchemaURL = schema_url(HP, Index),
+    SchemaHeaders = [{"content-type", "application/xml"}],
+    {ok, Status1, _, _} = http(put, SchemaURL, SchemaHeaders, ?SCHEMA),
+    ?assertEqual("204", Status1),
+
+    lager:info("create index ~s using schema ~s [~p]", [Index, Index, HP]),
+    IndexURL = index_url(HP, Index),
+    IndexHeaders = [{"content-type", "application/json"}],
+    Body = <<"{\"schema\":\"field_add\"}">>,
+    {ok, Status2, _, _} = http(put, IndexURL, IndexHeaders, Body),
+    ?assertEqual("204", Status2),
+
+    yz_rt:wait_for_index(Cluster, Index),
+
+    Node = select_random(Cluster),
+    FieldHP = hd(host_entries(rt:connection_info([Node]))),
+    FieldURL = url(FieldHP, Index) ++ "/schema/fields/my_new_field",
+    lager:info("verify index ~s doesn't have my_new_field [~p]", [Index, Node]),
+    {ok, "404", _, _} = http(get, FieldURL, ?NO_HEADERS, ?NO_BODY),
+
+    lager:info("upload schema ~s with new field [~p]", [Index, HP]),
+    {ok, Status3, _, _} = http(put, SchemaURL, SchemaHeaders, ?SCHEMA_FIELD_ADDED),
+    ?assertEqual("204", Status3),
+
+    lager:info("reload index ~s [~p]", [Index, Node]),
+    {ok, _} = rpc:call(Node, yz_index, reload_index, [Index]),
+
+    F = fun(XNode) ->
+                XHP = yz_rt:solr_http(proplists:get_value(XNode, (yz_rt:connection_info(Cluster)))),
+                XURL = field_url(XHP, Index, "my_new_field"),
+                lager:info("verify my_new_field added ~s", [XURL]),
+
+                {ok, XStatus, _, _} = http(get, XURL, ?NO_HEADERS, ?NO_BODY),
+                XStatus == "200"
+        end,
+    yz_rt:wait_until(Cluster, F).
+
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
@@ -181,6 +300,9 @@ ct(Headers) ->
     Headers2 = [{string:to_lower(Key), Value} || {Key, Value} <- Headers],
     proplists:get_value("content-type", Headers2).
 
+field_url({Host,Port}, Index, FieldName) ->
+    ?FMT("http://~s:~B/solr/~s/schema/fields/~s", [Host, Port, Index, FieldName]).
+
 host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
@@ -194,10 +316,13 @@ index_list_url({Host, Port}) ->
 index_url({Host,Port}, Index) ->
     ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
 
-url({Host,Port}, Suffix) ->
-    ?FMT("http://~s:~B/~s", [Host, Port, Suffix]).
+schema_url({Host,Port}, Name) ->
+    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).
 
 select_random(List) ->
     Length = length(List),
     Idx = random:uniform(Length),
     lists:nth(Idx, List).
+
+url({Host,Port}, Suffix) ->
+    ?FMT("http://~s:~B/~s", [Host, Port, Suffix]).

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -277,7 +277,7 @@ confirm_field_add(Cluster, Index) ->
     ?assertEqual("204", Status3),
 
     lager:info("reload index ~s [~p]", [Index, Node]),
-    {ok, _} = rpc:call(Node, yz_index, reload_index, [Index]),
+    {ok, _} = rpc:call(Node, yz_index, reload, [Index]),
 
     yz_rt:wait_until(Cluster, field_exists(Index, "my_new_field", CI)).
 

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -1,7 +1,14 @@
 %% @doc Test the index adminstration API in various ways.
 -module(yz_index_admin).
 -compile(export_all).
+-include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
+
+%% Copied from rt.erl, would be nice if there was a rt.hrl
+-type interface() :: {http, tuple()} | {pb, tuple()}.
+-type interfaces() :: [interface()].
+-type conn_info() :: [{node(), interfaces()}].
+-type cluster() :: [node()].
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
@@ -240,8 +247,10 @@ confirm_delete_409(Cluster, Index) ->
 %% @doc Verify that an index's schema can have a field added to it and
 %% reloaded.
 confirm_field_add(Cluster, Index) ->
-    HP = select_random(host_entries(rt:connection_info(Cluster))),
-    lager:info("confirm_field_add ~s [~p]", [Index, HP]),
+    CI = yz_rt:connection_info(Cluster),
+    RandCI = select_random(CI),
+    HP = yz_rt:riak_http(RandCI),
+    lager:info("confirm_field_add"),
 
     lager:info("upload schema ~s [~p]", [Index, HP]),
     SchemaURL = schema_url(HP, Index),
@@ -259,8 +268,7 @@ confirm_field_add(Cluster, Index) ->
     yz_rt:wait_for_index(Cluster, Index),
 
     Node = select_random(Cluster),
-    FieldHP = hd(host_entries(rt:connection_info([Node]))),
-    FieldURL = url(FieldHP, Index) ++ "/schema/fields/my_new_field",
+    FieldURL = field_url(yz_rt:solr_http(RandCI), Index, "my_new_field"),
     lager:info("verify index ~s doesn't have my_new_field [~p]", [Index, Node]),
     {ok, "404", _, _} = http(get, FieldURL, ?NO_HEADERS, ?NO_BODY),
 
@@ -271,15 +279,7 @@ confirm_field_add(Cluster, Index) ->
     lager:info("reload index ~s [~p]", [Index, Node]),
     {ok, _} = rpc:call(Node, yz_index, reload_index, [Index]),
 
-    F = fun(XNode) ->
-                XHP = yz_rt:solr_http(proplists:get_value(XNode, (yz_rt:connection_info(Cluster)))),
-                XURL = field_url(XHP, Index, "my_new_field"),
-                lager:info("verify my_new_field added ~s", [XURL]),
-
-                {ok, XStatus, _, _} = http(get, XURL, ?NO_HEADERS, ?NO_BODY),
-                XStatus == "200"
-        end,
-    yz_rt:wait_until(Cluster, F).
+    yz_rt:wait_until(Cluster, field_exists(Index, "my_new_field", CI)).
 
 %%%===================================================================
 %%% Helpers
@@ -299,6 +299,16 @@ contains_index(_Body) ->
 ct(Headers) ->
     Headers2 = [{string:to_lower(Key), Value} || {Key, Value} <- Headers],
     proplists:get_value("content-type", Headers2).
+
+-spec field_exists(index_name(), string(), conn_info()) -> predicate(node()).
+field_exists(Index, Field, ConnInfo) ->
+    fun(Node) ->
+            HP = yz_rt:solr_http(proplists:get_value(Node, ConnInfo)),
+            URL = field_url(HP, Index, Field),
+            lager:info("verify ~s added ~s", [URL]),
+            {ok, Status, _, _} = http(get, URL, ?NO_HEADERS, ?NO_BODY),
+            Status == "200"
+    end.
 
 field_url({Host,Port}, Index, FieldName) ->
     ?FMT("http://~s:~B/solr/~s/schema/fields/~s", [Host, Port, Index, FieldName]).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -230,6 +230,8 @@ set_bucket_type_index(Node, BucketType, Index) ->
     rt:create_and_activate_bucket_type(Node, BucketType, [{?YZ_INDEX, Index}]),
     rt:wait_until_bucket_type_status(BucketType, active, Node).
 
+solr_http({_Node, ConnInfo}) ->
+    solr_http(ConnInfo);
 solr_http(ConnInfo) ->
     proplists:get_value(solr_http, ConnInfo).
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -165,7 +165,7 @@ local_create(Ring, Name) ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,
             ok;
-        {error, _, Reason} ->
+        {error, Reason} ->
             lager:error("Couldn't create index ~s: ~p", [Name, Reason]),
             ok
     end.
@@ -290,7 +290,7 @@ reload_schema_local(Index) ->
         {ok, RawSchema} ->
             SchemaFile = filename:join([ConfDir, yz_schema:filename(SchemaName)]),
             file:write_file(SchemaFile, RawSchema);
-        {error, _, Reason} ->
+        {error, Reason} ->
             {error, Reason}
     end.
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -183,6 +183,37 @@ local_remove(Name) ->
 name(Info) ->
     Info#index_info.name.
 
+%% @doc Reload the `Index' cluster-wide. By default this will also
+%% pull the latest version of the schema associated with the
+%% index. This call will block for up 5 seconds. Any node which could
+%% not reload its index will be returned in a list of failed nodes.
+%%
+%% Options:
+%%
+%%   `{schema, boolean()}' - Whether to reload the schema, defaults to
+%%   true.
+%%
+%%   `{timeout, ms()}' - Timeout in milliseconds.
+-spec reload_index(index_name()) -> {ok, [node()]} | {error, reload_errs()}.
+reload_index(Index) ->
+    reload_index(Index, []).
+
+-spec reload_index(index_name(), reload_opts()) -> {ok, [node()]} |
+                                                   {error, reload_errs()}.
+reload_index(Index, Opts) ->
+    TO = proplists:get_value(timeout, Opts, 5000),
+    {Responses, Down} =
+        riak_core_util:rpc_every_member_ann(?MODULE, reload_index_local, [Index, Opts], TO),
+    Down2 = [{Node, {error,down}} || Node <- Down],
+    BadResponses = [R || {_,{error,_}}=R <- Responses],
+    case Down2 ++ BadResponses of
+        [] ->
+            Nodes = [Node || {Node,_} <- Responses],
+            {ok, Nodes};
+        Errors ->
+            {error, Errors}
+    end.
+
 %% @doc Remove documents in `Index' that are not owned by the local
 %%      node.  Return the list of non-owned partitions found.
 -spec remove_non_owned_data(index_name()) -> [p()].
@@ -221,6 +252,46 @@ add_to_ring(Name, Info) ->
         not_changed ->
             %% index existed already
             ok
+    end.
+
+%% @private
+-spec reload_index_local(index_name(), reload_opts()) ->
+                                ok | {error, term()}.
+reload_index_local(Index, Opts) ->
+    TO = proplists:get_value(timeout, Opts, 5000),
+    ReloadSchema = proplists:get_value(schema, Opts, true),
+    case ReloadSchema of
+        true ->
+            case reload_schema_local(Index) of
+                ok ->
+                    case yz_solr:core(reload, [{core, Index}], TO) of
+                        {ok,_,_} -> ok;
+                        Err -> Err
+                    end;
+                {error,_}=Err ->
+                    Err
+            end;
+        false ->
+            case yz_solr:core(reload, [{core, Index}]) of
+                {ok,_,_} -> ok;
+                Err -> Err
+            end
+    end.
+
+%% @private
+-spec reload_schema_local(index_name()) -> ok | {error, term()}.
+reload_schema_local(Index) ->
+    IndexDir = index_dir(Index),
+    ConfDir = filename:join([IndexDir, "conf"]),
+    Ring = yz_misc:get_ring(transformed),
+    Info = get_info_from_ring(Ring, Index),
+    SchemaName = schema_name(Info),
+    case yz_schema:get(SchemaName) of
+        {ok, RawSchema} ->
+            SchemaFile = filename:join([ConfDir, yz_schema:filename(SchemaName)]),
+            file:write_file(SchemaFile, RawSchema);
+        {error, _, Reason} ->
+            {error, Reason}
     end.
 
 -spec remove_index(indexes(), index_name()) -> indexes().

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -194,16 +194,16 @@ name(Info) ->
 %%   true.
 %%
 %%   `{timeout, ms()}' - Timeout in milliseconds.
--spec reload_index(index_name()) -> {ok, [node()]} | {error, reload_errs()}.
-reload_index(Index) ->
-    reload_index(Index, []).
+-spec reload(index_name()) -> {ok, [node()]} | {error, reload_errs()}.
+reload(Index) ->
+    reload(Index, []).
 
--spec reload_index(index_name(), reload_opts()) -> {ok, [node()]} |
-                                                   {error, reload_errs()}.
-reload_index(Index, Opts) ->
+-spec reload(index_name(), reload_opts()) -> {ok, [node()]} |
+                                             {error, reload_errs()}.
+reload(Index, Opts) ->
     TO = proplists:get_value(timeout, Opts, 5000),
     {Responses, Down} =
-        riak_core_util:rpc_every_member_ann(?MODULE, reload_index_local, [Index, Opts], TO),
+        riak_core_util:rpc_every_member_ann(?MODULE, reload_local, [Index, Opts], TO),
     Down2 = [{Node, {error,down}} || Node <- Down],
     BadResponses = [R || {_,{error,_}}=R <- Responses],
     case Down2 ++ BadResponses of
@@ -255,9 +255,9 @@ add_to_ring(Name, Info) ->
     end.
 
 %% @private
--spec reload_index_local(index_name(), reload_opts()) ->
-                                ok | {error, term()}.
-reload_index_local(Index, Opts) ->
+-spec reload_local(index_name(), reload_opts()) ->
+                          ok | {error, term()}.
+reload_local(Index, Opts) ->
     TO = proplists:get_value(timeout, Opts, 5000),
     ReloadSchema = proplists:get_value(schema, Opts, true),
     case ReloadSchema of

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -84,7 +84,7 @@ process(#rpbyokozunaschemagetreq{name = SchemaName}, State) ->
         {ok, Content} ->
             Schema = #rpbyokozunaschema{name = SchemaName, content = Content},
             {reply, #rpbyokozunaschemagetresp{schema = Schema}, State};
-        {error, _Name, notfound} ->
+        {error, notfound} ->
             {error, "notfound", State}
     end;
 

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -35,7 +35,7 @@ filename(SchemaName) ->
     binary_to_list(SchemaName) ++ ".xml".
 
 %% @doc Retrieve the raw schema from Riak.
--spec get(schema_name()) -> {ok, raw_schema()} | {error, schema_name(), term()}.
+-spec get(schema_name()) -> {ok, raw_schema()} | {error, term()}.
 get(Name) ->
     C = yz_kv:client(),
     R = yz_kv:get(C, ?YZ_SCHEMA_BUCKET, Name),
@@ -43,7 +43,7 @@ get(Name) ->
         {?YZ_DEFAULT_SCHEMA_NAME, {error, _}} ->
             {ok, _RawSchema} = file:read_file(?YZ_DEFAULT_SCHEMA_FILE);
         {_, {error, Reason}} ->
-            {error, Name, Reason};
+            {error, Reason};
         {_, {value, RawSchema}} ->
             {ok, RawSchema}
     end.
@@ -63,7 +63,7 @@ store(Name, RawSchema) when is_binary(RawSchema) ->
 -spec exists(schema_name()) -> true | false.
 exists(SchemaName) ->
     case yz_schema:get(SchemaName) of
-        {error, _, _} -> false;
+        {error, _} -> false;
         _ -> true
     end.
 

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -70,8 +70,14 @@ commit(Core) ->
     end.
 
 %% @doc Perform Core related actions.
--spec core(atom(), proplists:proplist()) -> {ok, any(), any()} | {error, term()}.
+-spec core(atom(), proplist()) -> {ok, list(), binary()} |
+                                  {error, term()}.
 core(Action, Props) ->
+    core(Action, Props, 5000).
+
+-spec core(atom(), proplist(), ms()) -> {ok, list(), binary()} |
+                                        {error, term()}.
+core(Action, Props, Timeout) ->
     BaseURL = base_url() ++ "/admin/cores",
     Action2 = convert_action(Action),
     Params = proplists:substitute_aliases(?CORE_ALIASES,
@@ -80,7 +86,7 @@ core(Action, Props) ->
     Opts = [{response_format, binary}],
     URL = BaseURL ++ "?" ++ Encoded,
 
-    case ibrowse:send_req(URL, [], get, [], Opts) of
+    case ibrowse:send_req(URL, [], get, [], Opts, Timeout) of
         {ok, "200", Headers, Body} ->
             {ok, Headers, Body};
         X ->
@@ -291,7 +297,8 @@ fpn_str(FPN) ->
 
 convert_action(create) -> "CREATE";
 convert_action(status) -> "STATUS";
-convert_action(remove) -> "UNLOAD".
+convert_action(remove) -> "UNLOAD";
+convert_action(reload) -> "RELOAD".
 
 encode_commit() ->
     <<"{}">>.


### PR DESCRIPTION
Add the ability to reload indexes on a running cluster. This is useful
for loading schema changes on the fly. E.g. adding a field to the
schema.

The index reload call is a blocking call that broadcasts cluster-wide.
The caller should always check the return value. If any errors occurred
then the reload should be retried until all nodes report success.
Otherwise you could end up with different version of the schema across
the nodes.

**NOTE:** This PR simply adds the ability to reload indexes on the server. 
It does not add any PB or HTTP support. Thus it only halfway addresses #130.
