### PR TITLE
yz_security: update how security is enabled to match pb_security

### DIFF
--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -21,8 +21,7 @@
                                        "certs/selfsigned/site3-cert.pem"])},
              {keyfile, filename:join([PrivDir,
                                        "certs/selfsigned/site3-key.pem"])}
-              ]},
-           {security, true}
+              ]}
           ]},
          {riak_api, [
              {certfile, filename:join([PrivDir,
@@ -75,6 +74,8 @@ confirm() ->
     lager:info("r_t priv: ~p", [PrivDir]),
     Cluster = build_cluster(1, ?CFG(PrivDir)),
     Node = hd(Cluster),
+    %% enable security on the cluster
+    ok = rpc:call(Node, riak_core_console, security_enable, [[]]),
     enable_https(Node),
     wait_for_cluster_service(Cluster, yokozuna),
     create_user(Node, ?USER),


### PR DESCRIPTION
example failure: http://giddyup.basho.com/#/projects/riak_ee/scorecards/66/66-1751-yz_security-centos-6-64/30800/artifacts/433086
