### PR TITLE
Add per-node filter queries + remove `_yz_node` field

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -150,7 +150,6 @@
 -define(YZ_SEARCH_CMD, #yz_search_cmd).
 -define(YZ_APP_NAME, yokozuna).
 -define(YZ_SVC_NAME, yokozuna).
--define(YZ_VNODE_MASTER, yokozuna_vnode_master).
 -define(YZ_META_INDEXES, yokozuna_indexes).
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
@@ -334,12 +333,6 @@
 -define(YZ_VTAG_FIELD_XML, ?YZ_FIELD_XML(?YZ_VTAG_FIELD_S)).
 -define(YZ_VTAG_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_vtag\" and @type=\"_yz_str\" and @indexed=\"true\"]").
 
-%% Node
--define(YZ_NODE_FIELD, '_yz_node').
--define(YZ_NODE_FIELD_S, "_yz_node").
--define(YZ_NODE_FIELD_XML, ?YZ_FIELD_XML(?YZ_NODE_FIELD_S)).
--define(YZ_NODE_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_node\" and @type=\"_yz_str\" and @indexed=\"true\"]").
-
 %% Partition Number
 -define(YZ_PN_FIELD, '_yz_pn').
 -define(YZ_PN_FIELD_S, "_yz_pn").
@@ -368,7 +361,6 @@
 -define(YZ_RB_FIELD_XML, ?YZ_FIELD_XML(?YZ_RB_FIELD_S)).
 -define(YZ_RB_FIELD_XPATH, "/schema/fields/field[@name=\"_yz_rb\" and @type=\"_yz_str\" and @indexed=\"true\" and @stored=\"true\"]").
 
-
 %% Riak extraction error
 -define(YZ_ERR_FIELD, '_yz_err').
 -define(YZ_ERR_FIELD_S, "_yz_err").
@@ -381,7 +373,6 @@
         Name == ?YZ_ED_FIELD_S orelse
         Name == ?YZ_FPN_FIELD_S orelse
         Name == ?YZ_VTAG_FIELD_S orelse
-        Name == ?YZ_NODE_FIELD_S orelse
         Name == ?YZ_PN_FIELD_S orelse
         Name == ?YZ_RK_FIELD_S orelse
         Name == ?YZ_RB_FIELD_S orelse

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -75,9 +75,11 @@
 -type filter() :: all | [p()].
 -type p_node() :: {p(), node()}.
 -type lp_node() :: {lp(), node()}.
--type cover_set() :: [p_node()].
--type logical_cover_set() :: [{lp_node(), filter()}].
--type filter_cover_set() :: [{p_node(), filter()}].
+-type p_set() :: [p_node()].
+-type logical_cover_pair() :: {lp_node(), logical_filter()}.
+-type logical_cover_set() :: [logical_cover_pair()].
+-type solr_host_mapping() :: [{node(), {string(),string()}}].
+-type plan() :: {[node()], logical_cover_set(), solr_host_mapping()}.
 
 -type ring_event() :: {ring_event, riak_core_ring:riak_core_ring()}.
 -type event() :: ring_event().

--- a/java_src/com/basho/yokozuna/handler/component/FQShardTranslator.java
+++ b/java_src/com/basho/yokozuna/handler/component/FQShardTranslator.java
@@ -83,7 +83,7 @@ public class FQShardTranslator extends SearchComponent {
         String shards = params.get(ShardParams.SHARDS);
         boolean hasShardURL = shards != null;
 
-        return hasShardURL | distrib;
+        return hasShardURL || distrib;
     }
 
 }

--- a/java_src/com/basho/yokozuna/handler/component/FQShardTranslator.java
+++ b/java_src/com/basho/yokozuna/handler/component/FQShardTranslator.java
@@ -1,0 +1,89 @@
+package com.basho.yokozuna.handler.component;
+
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.ShardParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.SearchComponent;
+import org.apache.solr.handler.component.ShardRequest;
+import org.apache.solr.request.SolrQueryRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Translate custom Yokozuna filter query shard params to normal
+ * filter query in the case of a non-distributed request.
+ *
+ * Allow setting filter queries per-node. This allows Yokozuna to
+ * apply a filter query to a specific node without requiring a special
+ * node field. That, in turn, leads to a smaller index, less memory
+ * usage, and less CPU time spent on node filtering.
+ *
+ * It works by translating custom per-node filter queries into a
+ * traditional filter query for the destination node. For example, for
+ * a distributed query across 2 shards the `shards` parameter might
+ * look like so.
+ *
+ *   ?shards=10.0.1.100:10014/solr/index,10.0.1.101:10014/solr/index
+ *
+ * This SearchComponent allows applying a filter query exclusively to
+ * each shard by passing a query param with the name `$host:$port` and
+ * a value of the filter query to run. For example:
+ *
+ *   ?10.0.1.100:10014=_yz_pn:1 OR _yz_pn:7 OR ...\
+ *   &10.0.1.101:10014=_yz_pn:4 OR _yz_pn:10 OR ...
+ *
+ */
+public class FQShardTranslator extends SearchComponent {
+    protected static final Logger log = LoggerFactory.getLogger(FQShardTranslator.class);
+    public static final String COMPONENT_NAME = "fq_shard_translator";
+
+    @Override
+    public void prepare(ResponseBuilder rb) throws IOException {
+        SolrQueryRequest req = rb.req;
+        SolrParams params = req.getParams();
+
+        if (!isDistrib(params)) {
+            String shardUrl = params.get(ShardParams.SHARD_URL);
+            if (shardUrl != null) {
+                String hostPort = shardUrl.substring(0, shardUrl.indexOf('/'));
+                ModifiableSolrParams mp = new ModifiableSolrParams(params);
+                mp.add("fq", params.get(hostPort));
+                req.setParams(mp);
+            }
+        }
+    }
+
+    @Override
+    public void process(ResponseBuilder rb) throws IOException {
+        return;
+    }
+
+    @Override
+    public void modifyRequest(ResponseBuilder rb, SearchComponent who, ShardRequest sreq) {
+        return;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Yokozuna's FQ Shard Translator";
+    }
+
+    @Override
+    public String getSource() {
+        return "https://github.com/basho/yokozuna";
+    }
+
+    private boolean isDistrib(SolrParams params) {
+        // Based on HttpShardHandler because rb.isDistrib is not public.
+        boolean distrib = params.getBool("distrib", false);
+        String shards = params.get(ShardParams.SHARDS);
+        boolean hasShardURL = shards != null;
+
+        return hasShardURL | distrib;
+    }
+
+}

--- a/misc/bench/schemas/fruit_schema.xml
+++ b/misc/bench/schemas/fruit_schema.xml
@@ -22,9 +22,6 @@ rue"/>
    <!-- If there is a sibling, use vtag to differentiate them -->
    <field name="_yz_vtag" type="_yz_str" indexed="true" stored="false"/>
 
-   <!-- Node: The name of the node that this doc was created on. -->
-   <field name="_yz_node" type="_yz_str" indexed="true" stored="false"/>
-
    <field name="_yz_rt" type="_yz_str" indexed="true" stored="true"/>
 
    <!-- Riak Bucket: The bucket of the Riak object this doc corresponds to. -->

--- a/priv/conf/solrconfig.xml
+++ b/priv/conf/solrconfig.xml
@@ -539,16 +539,11 @@
        <int name="rows">10</int>
        <str name="df">text</str>
      </lst>
-    <!-- If the default list of SearchComponents is not desired, that
-         list can either be overridden completely, or components can be
-         prepended or appended to the default list.  (see below)
-      -->
-    <!--
-       <arr name="components">
-         <str>nameOfCustomComponent1</str>
-         <str>nameOfCustomComponent2</str>
-       </arr>
-      -->
+     <!-- Custom Yokozuna component to translate custom shard filter
+          queries. -->
+     <arr name="first-components">
+       <str>fq_shard_translator</str>
+     </arr>
     </requestHandler>
 
   <!-- Update Request Handler.
@@ -705,48 +700,8 @@
     <!-- <str name="healthcheckFile">server-enabled.txt</str> -->
   </requestHandler>
 
-  <!-- Search Components
-
-       Search components are registered to SolrCore and used by
-       instances of SearchHandler (which can access them by name)
-
-       By default, the following components are available:
-
-       <searchComponent name="query"     class="solr.QueryComponent" />
-       <searchComponent name="facet"     class="solr.FacetComponent" />
-       <searchComponent name="mlt"       class="solr.MoreLikeThisComponent" />
-       <searchComponent name="highlight" class="solr.HighlightComponent" />
-       <searchComponent name="stats"     class="solr.StatsComponent" />
-       <searchComponent name="debug"     class="solr.DebugComponent" />
-
-       Default configuration in a requestHandler would look like:
-
-       <arr name="components">
-         <str>query</str>
-         <str>facet</str>
-         <str>mlt</str>
-         <str>highlight</str>
-         <str>stats</str>
-         <str>debug</str>
-       </arr>
-
-       If you register a searchComponent to one of the standard names,
-       that will be used instead of the default.
-
-       To insert components before or after the 'standard' components, use:
-
-       <arr name="first-components">
-         <str>myFirstComponentName</str>
-       </arr>
-
-       <arr name="last-components">
-         <str>myLastComponentName</str>
-       </arr>
-
-       NOTE: The component registered with the name "debug" will
-       always be executed after the "last-components"
-
-     -->
+  <searchComponent name="fq_shard_translator"
+                   class="com.basho.yokozuna.handler.component.FQShardTranslator" />
 
   <!-- Terms Component
 

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -143,7 +143,7 @@
    <!-- Riak Bucket: The bucket of the Riak object this doc corresponds to. -->
    <field name="_yz_rb" type="_yz_str" indexed="true" stored="true"/>
 
-   <!-- Node: Stores a flag if this doc is the product of a failed object extration -->
+   <!-- Flag indicating if this doc is the product of a failed object extraction -->
    <field name="_yz_err" type="_yz_str" indexed="true" stored="false"/>
  </fields>
 

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -134,9 +134,6 @@
    <!-- If there is a sibling, use vtag to differentiate them -->
    <field name="_yz_vtag" type="_yz_str" indexed="true" stored="false"/>
 
-   <!-- Node: The name of the node that this doc was created on. -->
-   <field name="_yz_node" type="_yz_str" indexed="true" stored="false"/>
-
    <!-- Riak Key: The key of the Riak object this doc corresponds to. -->
    <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"/>
 

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -34,7 +34,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
@@ -71,7 +70,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -20,7 +20,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -17,7 +17,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
@@ -88,7 +87,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
@@ -125,7 +123,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
@@ -162,7 +159,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -42,7 +42,6 @@
    <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
-   <field name=\"_yz_node\" type=\"_yz_str\" indexed=\"true\"/>
    <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
    <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -76,7 +76,6 @@ make_fields({DocId, {Bucket, Key}, FPN, Partition, none, EntropyData}) ->
     [{?YZ_ID_FIELD, DocId},
      {?YZ_ED_FIELD, EntropyData},
      {?YZ_FPN_FIELD, FPN},
-     {?YZ_NODE_FIELD, ?ATOM_TO_BIN(node())},
      {?YZ_PN_FIELD, Partition},
      {?YZ_RK_FIELD, Key},
      {?YZ_RT_FIELD, yz_kv:bucket_type(Bucket)},

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -82,7 +82,6 @@ handle_info(tick, S) ->
     Current = names(yz_index:get_indexes_from_ring(Ring)),
     {Removed, Added, Same} = yz_misc:delta(Previous, Current),
     ok = sync_indexes(Ring, Removed, Added, Same),
-    remove_non_owned_data(),
 
     remove_non_owned_data(),
 

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -82,6 +82,7 @@ handle_info(tick, S) ->
     Current = names(yz_index:get_indexes_from_ring(Ring)),
     {Removed, Added, Same} = yz_misc:delta(Previous, Current),
     ok = sync_indexes(Ring, Removed, Added, Same),
+    remove_non_owned_data(),
 
     remove_non_owned_data(),
 

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -122,7 +122,6 @@ verify_fields({ok, Schema}) ->
               ?YZ_ED_FIELD_XPATH,
               ?YZ_FPN_FIELD_XPATH,
               ?YZ_VTAG_FIELD_XPATH,
-              ?YZ_NODE_FIELD_XPATH,
               ?YZ_PN_FIELD_XPATH,
               ?YZ_RK_FIELD_XPATH,
               ?YZ_RT_FIELD_XPATH,

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -283,10 +283,6 @@ group_by_node({{Partition, Owner}, all}) ->
 group_by_node({{Partition, Owner}, FPFilter}) ->
     {Owner, {Partition, FPFilter}}.
 
-group_to_str({Owner, Partitions}) ->
-    OwnerQ = ?YZ_NODE_FIELD_S ++ ":" ++ atom_to_list(Owner),
-    "(" ++ OwnerQ ++ " AND " ++ "(" ++ partitions_to_str(Partitions) ++ "))".
-
 partitions_to_str(Partitions) ->
     F = fun({Partition, FPFilter}) ->
                 PNQ = pn_str(Partition),

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -251,11 +251,6 @@ search(Core, Headers, Params) ->
 base_url() ->
     "http://localhost:" ++ integer_to_list(port()) ++ "/solr".
 
-build_fq(Partitions) ->
-    GroupedByNode = yz_misc:group_by(Partitions, fun group_by_node/1),
-    Fields = [group_to_str(G) || G <- GroupedByNode],
-    string:join(Fields, " OR ").
-
 %% @private
 %%
 %% @doc Build list of per-node filter queries.

--- a/tools/build-jar.sh
+++ b/tools/build-jar.sh
@@ -35,7 +35,11 @@ if [ ! -e $SOLR_JAR_DIR ]; then
 fi
 
 echo "Compile..."
-javac -cp "$SOLR_JAR_DIR/*" ../java_src/com/basho/yokozuna/handler/*.java ../java_src/com/basho/yokozuna/query/*.java ../java_src/com/basho/yokozuna/monitor/*.java
+javac -cp "$SOLR_JAR_DIR/*" \
+    ../java_src/com/basho/yokozuna/handler/*.java \
+    ../java_src/com/basho/yokozuna/handler/component/*.java \
+    ../java_src/com/basho/yokozuna/query/*.java \
+    ../java_src/com/basho/yokozuna/monitor/*.java
 echo "Create yokozuna.jar..."
 if [ ! -e "../priv/java_lib" ]; then
     mkdir ../priv/java_lib


### PR DESCRIPTION
Create a custom SearchComponent which allows Yokozuna to perform
per-node filter queries. This removes the need for the `_yz_node` field
and the use of a monolithic filter query. Allowing smaller index size
and less overhead per query.

Preliminary micro benchmark demonstrated 15% improvement in query
throughput. More detailed results to come.
## Benchmark Results

Using my "fruit" micro benchmark I was able to produce a 17% increase
in query throughput from 2665 queries per second to 3124
QPS. Strangely enough there was no reduction in index time or index
disk usage. Perhaps Lucene is really good at optimizing that away
using it's underlying PFOR encoding. I'm honestly not sure but I don't
have the time to dig for more details.
### Indexing

|  | Throughput (WPS) | Median Latency | 99th Latency | Index du |
| --- | --- | --- | --- | --- |
| Monolithic | 1584 | 11.84 ms | 114.10 ms | 41M |
| Per Node | 1593 | 11.57 ms | 114.33 ms | 41M |
### Querying

|  | Throughput (QPS) | Median Latency | 99th Latency |
| --- | --- | --- | --- |
| Monolithic | 2665 | 13.28 ms | 24.03 ms |
| Per Node | 3124 (+ 17%) | 10.62 ms (- 20%) | 22.53 ms (- 6%) |
