### PR TITLE
Better index exists.

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -82,13 +82,14 @@ create(Name, SchemaName) ->
             end
     end.
 
+%% @doc Determine if an index exists in the ring and on disk.
 -spec exists(index_name()) -> boolean().
 exists(Name) ->
-    Indexes = get_indexes_from_ring(yz_misc:get_ring(raw)),
-    InRing = orddict:is_key(Name, Indexes),
-    SolrPing = yz_solr:ping(Name),
-    InRing andalso SolrPing.
-
+    RingIndexes = get_indexes_from_ring(yz_misc:get_ring(raw)),
+    DiskIndexNames = get_indexes_from_disk(?YZ_ROOT_DIR),
+    InRing = orddict:is_key(Name, RingIndexes),
+    OnDisk = lists:member(Name, DiskIndexNames),
+    InRing andalso OnDisk.
 
 %% @doc Removed the index `Name' from the entire cluster.
 -spec remove(index_name()) -> ok | {error, badrpc}.
@@ -106,6 +107,22 @@ remove(Name) ->
                     {error, badrpc}
             end
     end.
+
+%% @doc Determine list of indexes based on filesystem as opposed to
+%% the Riak ring or Solr HTTP resource.
+%%
+%% NOTE: This function assumes that all Yokozuna indexes live directly
+%% under the Yokozuna root data directory and that any dir with a
+%% `core.properties' file is an index. DO NOT create a dir with a
+%% `core.properties' for any other reason or it will confuse this
+%% function and potentially have other consequences up the stack.
+-spec get_indexes_from_disk(string()) -> [index_name()].
+get_indexes_from_disk(Dir) ->
+    Files = filelib:wildcard(filename:join([Dir, "*"])),
+    [unicode:characters_to_binary(filename:basename(F))
+     || F <- Files,
+        filelib:is_dir(F) andalso
+            filelib:is_file(filename:join([F, "core.properties"]))].
 
 -spec get_indexes_from_ring(ring()) -> indexes().
 get_indexes_from_ring(Ring) ->

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -175,6 +175,14 @@ index(Core, Docs, DelOps) ->
         Err -> throw({"Failed to index docs", Ops, Err})
     end.
 
+%% @doc Determine if Solr is running.
+-spec is_up() -> boolean().
+is_up() ->
+    case cores() of
+        {ok, _} -> true;
+        _ -> false
+    end.
+
 prepare_json(Docs) ->
     Content = {struct, [{add, encode_doc(D)} || D <- Docs]},
     mochijson2:encode(Content).

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -115,7 +115,7 @@ handle_cast(Req, S) ->
     {noreply, S}.
 
 handle_info({check_solr, WaitTimeSecs}, S=?S_MATCH) ->
-    case is_up() of
+    case yz_solr:is_up() of
         true ->
             %% solr finished its startup, be merry
             ?INFO("solr is up", []),
@@ -239,16 +239,6 @@ get_pid(Port) ->
     case erlang:port_info(Port) of
         undefined -> undefined;
         PI -> proplists:get_value(os_pid, PI)
-    end.
-
-%% @private
-%%
-%% @doc Determine if Solr is running.
--spec is_up() -> boolean().
-is_up() ->
-    case yz_solr:cores() of
-        {ok, _} -> true;
-        _ -> false
     end.
 
 %% @private


### PR DESCRIPTION
Basically, change `yz_index:exists` to check 1) official index list, 2) on-disk and 3) ping if Solr is running. See the commit messages for more detail.

This addresses #249.

There was also a supplementary fix made to the verify script which I broke in a previous commit.There is no longer a top-level `yokozuna` dir in top level working dir. Instead, `riak_yz/deps/yokozuna` is used. You'll need to change your `yz_dir` in the `yz_verify` section of `~/.riak_test.config`.
