### PR TITLE
Fix handoff check in mixed cluster scenario

### DIFF
--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -160,7 +160,7 @@ get_short_preflist({Bucket, _} = BKey, Ring) ->
 %% check that.
 -spec should_handoff({term(), {p(), node()}}) -> boolean().
 should_handoff({_Reason, {_Partition, TargetNode}}) ->
-    case ?YZ_ENABLED of
+    case ?YZ_ENABLED andalso is_service_up(?YZ_SVC_NAME, TargetNode) of
         true ->
             case is_metadata_consistent(TargetNode) of
                 true ->
@@ -438,6 +438,13 @@ is_metadata_consistent(RemoteNode) ->
 is_owner_or_future_owner(P, Node, Ring) ->
     OwnedAndNext = yz_misc:owned_and_next_partitions(Node, Ring),
     ordsets:is_element(P, OwnedAndNext).
+
+%% @private
+%%
+%% @doc Determine if service is up on node.
+-spec is_service_up(atom(), node()) -> boolean().
+is_service_up(Service, Node) ->
+    lists:member(Service, riak_core_node_watcher:services(Node)).
 
 %% @private
 %%


### PR DESCRIPTION
Perform the metadata check only when Yokozuna is enabled on both the local and remote node. Otherwise just return `true` and let KV perform handoff.

This addresses #258. See commit messages for more detail.

I tested with a modified `verify_handoff_mixed` test. Below is the diff.

``` diff
diff --git a/tests/verify_handoff_mixed.erl b/tests/verify_handoff_mixed.erl
index c4a7441..b278574 100644
--- a/tests/verify_handoff_mixed.erl
+++ b/tests/verify_handoff_mixed.erl
@@ -54,11 +54,13 @@ confirm() ->
     UpgradeVsn = proplists:get_value(upgrade_version,
                                      riak_test_runner:metadata(),
                                      previous),
-    SearchEnabled = [{riak_search, [{enabled, true}]}],
-    Versions = [{current, SearchEnabled},
-                {UpgradeVsn, SearchEnabled}],
+    RSEnabled = [{riak_search, [{enabled, true}]}],
+    YZEnabled = [{yokozuna, [{enabled, true}]}],
+    Versions = [{current, RSEnabled ++ YZEnabled},
+                {UpgradeVsn, RSEnabled}],
     Services = [riak_kv, riak_search, riak_pipe],
     [Current, Old] = Nodes = rt:deploy_nodes(Versions, Services),
+    rt:wait_for_service(Current, yokozuna),

     prepare_vnodes(Current),

@@ -122,7 +124,7 @@ prepare_search_vnodes(Node) ->
       [ list_to_binary(integer_to_list(N))
         || N <- lists:seq(1000, 1000+?SEARCH_COUNT) ]),
     riakc_pb_socket:stop(C).
-                     
+
 prepare_pipe_vnodes(Node) ->
     %% the riak_pipe_w_pass worker produces no archive, but the vnode
     %% still sends its queue (even if empty) through handoff
```
