### PR TITLE
Confbal schema changes for Yokozuna

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -1,58 +1,51 @@
 %% -*- erlang -*-
 %% @doc To enable Search set this 'on'.
-%% @datatype enum on, off
 {mapping, "search", "yokozuna.enabled", [
   {default, off},
-  {datatype, {enum, [on, off]}}
+  {datatype, flag}
 ]}.
 
-{ translation,
-  "yokozuna.enabled",
-  fun(Conf) ->
-          Setting = cuttlefish:conf_get("search", Conf),
-          case Setting of
-              on -> true;
-              off -> false;
-              _Default -> false
-          end
-  end}.
-
-
-%% @doc The startup wait time, in seconds, Riak will wait for Solr to
-%% start. The start sequence will be tried twice. If both timeout
-%% then the node will be shutdown. This may need to be increased as
-%% more data is indexed and Solr takes longer to start.
-{mapping, "search.solr_startup_wait", "yokozuna.solr_startup_wait", [
-  {default, 30},
-  {datatype, integer}
+%% @doc How long Riak will wait for Solr to start. The start sequence
+%% will be tried twice. If both attempts timeout, then the Riak node
+%% will be shutdown. This may need to be increased as more data is
+%% indexed and Solr takes longer to start. Values lower than 1s will
+%% be rounded up to the minimum 1s.
+{mapping, "search.solr.start_timeout", "yokozuna.solr_startup_wait", [
+  {default, "30s"},
+  {datatype, {duration, s}}
 ]}.
 
 %% @doc The port number which Solr binds to.
-{mapping, "search.solr_port", "yokozuna.solr_port", [
+%%   NOTE: Binds on every interface.
+{mapping, "search.solr.port", "yokozuna.solr_port", [
   {default, {{yz_solr_port}} },
   {datatype, integer}
 ]}.
 
 %% @doc The port number which Solr JMX binds to.
-{mapping, "search.solr_jmx_port", "yokozuna.solr_jmx_port", [
+%%   NOTE: Binds on every interface.
+{mapping, "search.solr.jmx_port", "yokozuna.solr_jmx_port", [
   {default, {{yz_solr_jmx_port}} },
   {datatype, integer}
 ]}.
 
-%% @doc The options to pass to the Solr JVM.  Non-standard
-%% options, i.e. -XX, may not be portable across JVM
-%% implementations.  E.g. -XX:+UseCompressedStrings.
-{mapping, "search.solr_jvm_opts", "yokozuna.solr_jvm_opts", [
+%% @doc The options to pass to the Solr JVM.  Non-standard options,
+%% i.e. -XX, may not be portable across JVM implementations.
+%% E.g. -XX:+UseCompressedStrings.
+{mapping, "search.solr.jvm_options", "yokozuna.solr_jvm_opts", [
   {default, "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
 ]}.
 
-%% @doc The directory where AAE data files are stored
+%% @doc The directory where Search's Active Anti-Entropy data files
+%% are stored
 {mapping, "search.anti_entropy.data_dir", "yokozuna.anti_entropy_data_dir", [
-  {default, "{{platform_data_dir}}/yz_anti_entropy" }
+  {default, "{{platform_data_dir}}/yz_anti_entropy"},
+  {datatype, directory}
 ]}.
 
-%% @doc The root directory for Yokozuna, under which index data and
+%% @doc The root directory for Search, under which index data and
 %% configuration is stored.
 {mapping, "search.root_dir", "yokozuna.root_dir", [
-  {default, "{{platform_data_dir}}/yz" }
+  {default, "{{platform_data_dir}}/yz"},
+  {datatype, directory}
 ]}.

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -11,6 +11,7 @@ basic_schema_test() ->
                "../priv/yokozuna.schema", [], context()),
 
     cuttlefish_unit:assert_config(Config, "yokozuna.enabled", false),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_startup_wait", 30),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_port", 12345),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jmx_port", 54321),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jvm_opts",
@@ -26,9 +27,10 @@ override_schema_test() ->
     %% conf_parse module
     Conf = [
             {["search"], on},
-            {["search", "solr_port"], 5678},
-            {["search", "solr_jmx_port"], 8765},
-            {["search", "solr_jvm_opts"], "-Xmx10G"},
+            {["search", "solr", "start_timeout"], "1m"},
+            {["search", "solr", "port"], 5678},
+            {["search", "solr", "jmx_port"], 8765},
+            {["search", "solr", "jvm_options"], "-Xmx10G"},
             {["search", "anti_entropy", "data_dir"], "/data/aae/search"},
             {["search", "root_dir"], "/some/other/volume"}
     ],
@@ -36,6 +38,7 @@ override_schema_test() ->
                "../priv/yokozuna.schema", Conf, context()),
 
     cuttlefish_unit:assert_config(Config, "yokozuna.enabled", true),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_startup_wait", 60),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_port", 5678),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jmx_port", 8765),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jvm_opts", "-Xmx10G"),


### PR DESCRIPTION
- Made a 'search.solr.*' namespace
- Edited documentation
- changed search's datatype to flag
- added directory datatorp where appropriate.
