### PR TITLE
Storing Zipped Schemas in Cluster Metadata

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -153,6 +153,7 @@
 -define(YZ_APP_NAME, yokozuna).
 -define(YZ_SVC_NAME, yokozuna).
 -define(YZ_META_INDEXES, yokozuna_indexes).
+-define(YZ_META_SCHEMAS, yokozuna_schemas).
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
         "Not enough nodes are up to service this request.").
@@ -304,6 +305,8 @@
 -type raw_schema() :: binary().
 -type schema() :: xmerl_scan:document().
 -type schema_name() :: binary().
+-type compressed_schema() :: binary().
+-type schemas() :: orddict(schema_name(), compressed_schema()).
 
 %%%===================================================================
 %%% Solr Fields

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -305,8 +305,6 @@
 -type raw_schema() :: binary().
 -type schema() :: xmerl_scan:document().
 -type schema_name() :: binary().
--type compressed_schema() :: binary().
--type schemas() :: orddict(schema_name(), compressed_schema()).
 
 %%%===================================================================
 %%% Solr Fields

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -153,7 +153,7 @@
 -define(YZ_APP_NAME, yokozuna).
 -define(YZ_SVC_NAME, yokozuna).
 -define(YZ_META_INDEXES, yokozuna_indexes).
--define(YZ_META_SCHEMAS, yokozuna_schemas).
+-define(YZ_META_SCHEMAS, {yokozuna, schemas}).
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
         "Not enough nodes are up to service this request.").

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -67,9 +67,7 @@ confirm() ->
     verify_repair_count(Cluster, RepairCountBefore + ExpectedNumRepairs),
     yz_rt:stop_tracing(),
     Count = yz_rt:get_call_count(Cluster, ?REPAIR_MFA),
-    %% Add 3 repairs for the fruit schema which is written to a
-    %% non-indexed bucket and will cause 3 instances of tree_repair.
-    ?assertEqual(ExpectedNumRepairs + 3, Count),
+    ?assertEqual(ExpectedNumRepairs, Count),
     %% Verify that there is no indefinite repair.  The have been
     %% several bugs in the past where Yokozuna AAE would indefinitely
     %% repair.
@@ -102,6 +100,7 @@ setup_index(Cluster, PBConn, YZBenchDir) ->
     Node = yz_rt:select_random(Cluster),
     RawSchema = read_schema(YZBenchDir),
     yz_rt:store_schema(PBConn, ?INDEX, RawSchema),
+    yz_rt:wait_for_schema(Cluster, ?INDEX, RawSchema),
     ok = yz_rt:create_index(Node, ?INDEX, ?INDEX),
     ok = yz_rt:set_bucket_type_index(Node, ?INDEX),
     yz_rt:wait_for_index(Cluster, ?INDEX).

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -272,6 +272,7 @@ confirm_field_add(Cluster, Index) ->
 
     lager:info("upload schema ~s with new field [~p]", [Index, HP]),
     {ok, Status3, _, _} = http(put, SchemaURL, SchemaHeaders, ?SCHEMA_FIELD_ADDED),
+    yz_rt:wait_for_schema(Cluster, Index, ?SCHEMA_FIELD_ADDED),
     ?assertEqual("204", Status3),
 
     lager:info("reload index ~s [~p]", [Index, Node]),

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -303,7 +303,7 @@ field_exists(Index, Field, ConnInfo) ->
     fun(Node) ->
             HP = yz_rt:solr_http(proplists:get_value(Node, ConnInfo)),
             URL = field_url(HP, Index, Field),
-            lager:info("verify ~s added ~s", [URL]),
+            lager:info("verify ~s added ~s", [Index, URL]),
             {ok, Status, _, _} = http(get, URL, ?NO_HEADERS, ?NO_BODY),
             Status == "200"
     end.

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -331,8 +331,8 @@ confirm_bad_schema(Cluster) ->
         end,
     yz_rt:wait_until(Cluster, F).
 
-%% @doc Confirm that creating a new shema gets added to the Ring
-%%      metadata as a compressed blob, and is retrievable
+%% @doc Confirm that creating a new shema gets added to the
+%%      cluster metadata as a compressed blob, and is retrievable
 %%      as its original raw text
 confirm_compressed_metadata(Cluster, Name, RawSchema) ->
     Node = select_random(Cluster),

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -336,11 +336,12 @@ confirm_bad_schema(Cluster) ->
 confirm_compressed_metadata(Cluster, Name, RawSchema) ->
     HP = select_random(host_entries(rt:connection_info(Cluster))),
     lager:info("confirm_compressed_metadata ~s [~p]", [Name, HP]),
+    % riak_core_metadata_manager:start_link(),
     ok = yz_schema:store(Name, RawSchema),
-    Ring = yz_misc:get_ring(transformed),
-    Schemas = yz_schema:get_schemas_from_ring(Ring),
-    R = orddict:fetch(Name, Schemas),
+    lager:info("STORED: ~p", [Name]),
+    R = riak_core_metadata:get({yokozuna, schemas}, Name),
     ?assertEqual(RawSchema, yz_misc:decompress(R)).
+
 
 %%%===================================================================
 %%% Helpers

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -262,6 +262,22 @@ set_ring_meta(Name, Default, Fun, Arg) ->
       fun set_ring_trans/2,
       {Name, Default, Fun, Arg}).
 
+-spec compress(iodata()) -> iolist().
+compress(Data) ->
+    Z = zlib:open(),
+    ok = zlib:deflateInit(Z),
+    Compressed = zlib:deflate(Z, Data, finish),
+    ok = zlib:deflateEnd(Z),
+    Compressed.
+
+-spec decompress(iodata()) -> iolist().
+decompress(Data) ->
+    Z = zlib:open(),
+    zlib:inflateInit(Z),
+    Decompressed = zlib:inflate(Z, Data),
+    zlib:inflateEnd(Z),
+    Decompressed.
+
 %%%===================================================================
 %%% Private
 %%%===================================================================

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -268,6 +268,7 @@ compress(Data) ->
     ok = zlib:deflateInit(Z),
     Compressed = zlib:deflate(Z, Data, finish),
     ok = zlib:deflateEnd(Z),
+    zlib:close(Z),
     Compressed.
 
 -spec decompress(iodata()) -> iolist().
@@ -276,6 +277,7 @@ decompress(Data) ->
     zlib:inflateInit(Z),
     Decompressed = zlib:inflate(Z, Data),
     zlib:inflateEnd(Z),
+    zlib:close(Z),
     Decompressed.
 
 %%%===================================================================

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -47,10 +47,6 @@ get(Name) ->
             {ok, iolist_to_binary(yz_misc:decompress(R))}
     end.
 
--spec add_schema(schemas(), {schema_name(), compressed_schema()}) -> schemas().
-add_schema(Schemas, {Name, CompressedSchema}) ->
-    orddict:store(Name, CompressedSchema, Schemas).
-
 %% @doc Store the `RawSchema' with `Name'.
 -spec store(schema_name(), raw_schema()) -> ok | {error, term()}.
 store(Name, RawSchema) when is_binary(RawSchema) ->

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -37,14 +37,14 @@ filename(SchemaName) ->
 %% @doc Retrieve the raw schema from Riak.
 -spec get(schema_name()) -> {ok, raw_schema()} | {error, term()}.
 get(Name) ->
-    R = riak_core_metadata:get({yokozuna, schemas}, Name),
+    R = riak_core_metadata:get(?YZ_META_SCHEMAS, Name),
     case {Name, R} of
         {?YZ_DEFAULT_SCHEMA_NAME, undefined} ->
             {ok, _} = file:read_file(?YZ_DEFAULT_SCHEMA_FILE);
         {_, undefined} ->
             {error, notfound};
         {_, R} ->
-            {ok, yz_misc:decompress(R)}
+            {ok, iolist_to_binary(yz_misc:decompress(R))}
     end.
 
 -spec add_schema(schemas(), {schema_name(), compressed_schema()}) -> schemas().
@@ -57,7 +57,7 @@ store(Name, RawSchema) when is_binary(RawSchema) ->
     case parse_and_verify(RawSchema) of
         {ok, RawSchema} ->
             CompressedSchema = yz_misc:compress(RawSchema),
-            riak_core_metadata:put({yokozuna, schemas}, Name, CompressedSchema),
+            riak_core_metadata:put(?YZ_META_SCHEMAS, Name, CompressedSchema),
             ok;
         {error, _} = Err ->
             Err

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -57,7 +57,7 @@ store(Name, RawSchema) when is_binary(RawSchema) ->
     case parse_and_verify(RawSchema) of
         {ok, RawSchema} ->
             CompressedSchema = yz_misc:compress(RawSchema),
-            riak_core_metadata:put({yokozuna, schemas}, Name, ["CompressedSchema"]),
+            riak_core_metadata:put({yokozuna, schemas}, Name, CompressedSchema),
             ok;
         {error, _} = Err ->
             Err


### PR DESCRIPTION
This is a PR for #234, but this time it's against develop rather than master. It does what the name suggests. Creating a new schema will store the schema name and raw schema xml will first deflate the xml, and store the compressed data as cluster metadata. Getting the schema will inflate the xml and return it. The interface remains unchanged.
