### PR TITLE
Port most of the KV 1.3.2-1.4.0 updates

### DIFF
--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -77,8 +77,10 @@ count_calls(Cluster, MFA={M,F,A}) when is_list(Cluster) ->
     dbg:p(all, call),
     dbg:tpl(M, F, A, [{'_', [], [{return_trace}]}]).
 
+-spec stop_tracing() -> ok.
 stop_tracing() ->
-    dbg:stop_clear().
+    dbg:stop_clear(),
+    ok.
 
 trace_count({trace, _Pid, call, {_M, _F, _A}}, Acc) ->
     Acc;

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -122,7 +122,7 @@ cache_plan(Index) ->
 calc_plan(Index) ->
     Ring = yz_misc:get_ring(transformed),
     Q = riak_core_ring:num_partitions(Ring),
-    BProps = riak_core_bucket:get_bucket(Index, Ring),
+    BProps = riak_core_bucket:get_bucket(Index),
     Selector = all,
     NVal = riak_core_bucket:n_val(BProps),
     NumPrimaries = 1,

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -505,8 +505,8 @@ start_exchange(Index, Preflist, Ring, S) ->
 
     %% NOTE: The riak_kv version of this function wraps this is a
     %% try/catch to guard against the case where a ring size change
-    %% makes the index go way. I disagree with the use of try/catch as
-    %% it could fail for other reaons. I believe this can be solved by
+    %% makes the index go away. I disagree with the use of try/catch as
+    %% it could fail for other reasons. I believe this can be solved by
     %% checking if the index exists in the `maybe_exchange'
     %% function. But first would like to actually test Yokozuna AAE +
     %% ring resizing to see what happens.

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -503,6 +503,13 @@ start_exchange(Index, Preflist, Ring, S) ->
     IsOwner = riak_core_ring:index_owner(Ring, Index) == node(),
     PendingChange = is_pending_change(Ring, Index),
 
+    %% NOTE: The riak_kv version of this function wraps this is a
+    %% try/catch to guard against the case where a ring size change
+    %% makes the index go way. I disagree with the use of try/catch as
+    %% it could fail for other reaons. I believe this can be solved by
+    %% checking if the index exists in the `maybe_exchange'
+    %% function. But first would like to actually test Yokozuna AAE +
+    %% ring resizing to see what happens.
     case {IsOwner, PendingChange} of
         {false, _} ->
             {not_responsible, S};

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -500,16 +500,9 @@ do_exchange_status(_Pid, Index, {StartIdx, N}, Status, S) ->
 
 -spec start_exchange(p(), {p(),n()}, ring(), state()) -> {any(), state()}.
 start_exchange(Index, Preflist, Ring, S) ->
-    IsOwner = riak_core_ring:index_owner(Ring, Index) == node(),
+    IsOwner = yz_misc:index_owner(Ring, Index) == node(),
     PendingChange = is_pending_change(Ring, Index),
 
-    %% NOTE: The riak_kv version of this function wraps this is a
-    %% try/catch to guard against the case where a ring size change
-    %% makes the index go away. I disagree with the use of try/catch as
-    %% it could fail for other reasons. I believe this can be solved by
-    %% checking if the index exists in the `maybe_exchange'
-    %% function. But first would like to actually test Yokozuna AAE +
-    %% ring resizing to see what happens.
     case {IsOwner, PendingChange} of
         {false, _} ->
             {not_responsible, S};

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -156,7 +156,9 @@ key_exchange(timeout, S=#state{index=Index,
     Remote = fun(get_bucket, {L, B}) ->
                      exchange_bucket_kv(KVTree, IndexN, L, B);
                 (key_hashes, Segment) ->
-                     exchange_segment_kv(KVTree, IndexN, Segment)
+                     exchange_segment_kv(KVTree, IndexN, Segment);
+                (_, _) ->
+                     ok
              end,
 
     AccFun = fun(KeyDiff, Count) ->

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -218,7 +218,7 @@ repair(Partition, {_Reason, KeyBin}) ->
     %% match. In either case the object must be re-indexed.
     Ring = yz_misc:get_ring(transformed),
     BKey = binary_to_term(KeyBin),
-    Index = yz_kv:get_index(BKey, Ring),
+    Index = yz_kv:get_index(BKey),
     ShortPL = riak_kv_util:get_index_n(BKey),
     %% Can assume here that Yokozua is enabled and current
     %% node is owner.

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -216,7 +216,6 @@ repair(Partition, {remote_missing, KeyBin}) ->
 repair(Partition, {_Reason, KeyBin}) ->
     %% Either Yokozuna is missing the key or the hash doesn't
     %% match. In either case the object must be re-indexed.
-    Ring = yz_misc:get_ring(transformed),
     BKey = binary_to_term(KeyBin),
     Index = yz_kv:get_index(BKey),
     ShortPL = riak_kv_util:get_index_n(BKey),
@@ -226,6 +225,7 @@ repair(Partition, {_Reason, KeyBin}) ->
         {ok, Obj} ->
             case yz_kv:should_index(Index) of
                 true ->
+                    Ring = yz_misc:get_ring(transformed),
                     yz_kv:index(Obj, anti_entropy, Ring, Partition, BKey, ShortPL, Index),
                     full_repair;
                 false ->

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -201,7 +201,7 @@ repair(Partition, {remote_missing, KeyBin}) ->
     Ring = yz_misc:get_ring(transformed),
     BKey = binary_to_term(KeyBin),
     Index = yz_kv:get_index(BKey, Ring),
-    ShortPL = yz_kv:get_short_preflist(BKey, Ring),
+    ShortPL = riak_kv_util:get_index_n(BKey),
     FakeObj = fake_kv_object(BKey),
     %% Repeat some logic in `yz_kv:index/3' to avoid extra work.  Can
     %% assume that Yokozuna is enabled and current node is owner.
@@ -219,7 +219,7 @@ repair(Partition, {_Reason, KeyBin}) ->
     Ring = yz_misc:get_ring(transformed),
     BKey = binary_to_term(KeyBin),
     Index = yz_kv:get_index(BKey, Ring),
-    ShortPL = yz_kv:get_short_preflist(BKey, Ring),
+    ShortPL = riak_kv_util:get_index_n(BKey),
     %% Can assume here that Yokozua is enabled and current
     %% node is owner.
     case yz_kv:local_get(Partition, BKey) of

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -200,7 +200,7 @@ repair(Partition, {remote_missing, KeyBin}) ->
     %% Yokozuna has it but KV doesn't
     Ring = yz_misc:get_ring(transformed),
     BKey = binary_to_term(KeyBin),
-    Index = yz_kv:get_index(BKey, Ring),
+    Index = yz_kv:get_index(BKey),
     ShortPL = riak_kv_util:get_index_n(BKey),
     FakeObj = fake_kv_object(BKey),
     %% Repeat some logic in `yz_kv:index/3' to avoid extra work.  Can

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -96,7 +96,6 @@ exists(Name) ->
     OnDisk = lists:member(Name, DiskIndexNames),
     case yz_solr:is_up() of
         true ->
-            Ping = yz_solr:ping(Name),
             InRing andalso OnDisk andalso yz_solr:ping(Name);
         false ->
             InRing andalso OnDisk

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -36,7 +36,7 @@ associated_buckets(Index, Ring) ->
     Assoc = [riak_core_bucket:name(BProps)
              || BProps <- AllProps,
                 proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE) == Index],
-    case is_default_type_indexed(Index, Ring) of
+    case is_default_type_indexed(Index) of
         true -> [Index|Assoc];
         false -> Assoc
     end.
@@ -344,12 +344,12 @@ index_dir(Name) ->
 %% @private
 %%
 %% @doc Determine if the bucket named `Index' under the default
-%% bucket-type has `search' property set to `true'. If so41 this is a
+%% bucket-type has `search' property set to `true'. If so this is a
 %% legacy Riak Search bucket/index which is associated with a Yokozuna
 %% index of the same name.
--spec is_default_type_indexed(index_name(), ring()) -> boolean().
-is_default_type_indexed(Index, Ring) ->
-    Props = riak_core_bucket:get_bucket(Index, Ring),
+-spec is_default_type_indexed(index_name()) -> boolean().
+is_default_type_indexed(Index) ->
+    Props = riak_core_bucket:get_bucket(Index),
     %% Check against `true' atom in case the value is <<"true">> or
     %% "true" which, hopefully, it should not be.
     true == proplists:get_value(search, Props, false).

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -448,14 +448,7 @@ do_compare(Id, Remote, AccFun, Acc, From, S) ->
 %% TODO: OMG cache this with entry in proc dict, use `_yz_fp` as Index
 %%       and keep an orddict(Bucket,N) in proc dict
 get_index_n(BKey) ->
-    get_index_n(BKey, yz_misc:get_ring(transformed)).
-
-get_index_n({Bucket, Key}, Ring) ->
-    BucketProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    N = proplists:get_value(n_val, BucketProps),
-    ChashKey = riak_core_util:chash_key({Bucket, Key}),
-    Index = riak_core_ring:responsible_index(ChashKey, Ring),
-    {Index, N}.
+    riak_kv_util:get_index_n(BKey).
 
 do_poke(S) ->
     maybe_build(maybe_clear(S)).

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -437,7 +437,9 @@ do_compare(Id, Remote, AccFun, Acc, From, S) ->
         {ok, Tree} ->
             spawn_link(
               fun() ->
+                      Remote(init, self()),
                       Result = hashtree:compare(Tree, Remote, AccFun, Acc),
+                      Remote(final, self()),
                       gen_server:reply(From, Result)
               end)
     end,

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -132,9 +132,9 @@ get_md_entry(MD, Key) ->
 
 %% @doc Extract the index name from the `Bucket'. Return the tombstone
 %% value if there is none.
--spec get_index(bkey(), ring()) -> index_name().
-get_index({Bucket, _}, Ring) ->
-    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
+-spec get_index(bkey()) -> index_name().
+get_index({Bucket, _}) ->
+    BProps = riak_core_bucket:get_bucket(Bucket),
     proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE).
 
 %% @doc Called by KV vnode to determine if handoff should start or
@@ -174,7 +174,7 @@ index(Obj, Reason, P) ->
                     T1 = os:timestamp(),
                     BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
                     try
-                        Index = get_index(BKey, Ring),
+                        Index = get_index(BKey),
                         ShortPL = riak_kv_util:get_index_n(BKey),
                         case should_index(Index) of
                             true ->
@@ -338,9 +338,8 @@ max_hashtree_tokens() ->
 -spec put(any(), binary(), binary(), binary(), string()) -> ok.
 put(Client, Bucket, Key, Value, ContentType) ->
     O = riak_object:new(Bucket, Key, Value, ContentType),
-    Ring = yz_misc:get_ring(transformed),
-    BucketProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    N = proplists:get_value(n_val, BucketProps),
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    N = riak_core_bucket:n_val(BucketProps),
     Client:put(O, [{pw,N},{w,N},{dw,N}]).
 
 %%%===================================================================

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -137,16 +137,6 @@ get_index({Bucket, _}, Ring) ->
     BProps = riak_core_bucket:get_bucket(Bucket, Ring),
     proplists:get_value(?YZ_INDEX, BProps, ?YZ_INDEX_TOMBSTONE).
 
-%% @doc Determine the "short" preference list given the `BKey' and
-%% `Ring'.  A short preflist is one that defines the preflist by
-%% partition number and N value.
--spec get_short_preflist(bkey(), ring()) -> short_preflist().
-get_short_preflist({Bucket, _} = BKey, Ring) ->
-    BProps = riak_core_bucket:get_bucket(Bucket, Ring),
-    NVal = riak_core_bucket:n_val(BProps),
-    PrimaryPL = yz_misc:primary_preflist(BKey, Ring, NVal),
-    {first_partition(PrimaryPL), NVal}.
-
 %% @doc Called by KV vnode to determine if handoff should start or
 %% not.  Yokozuna needs to make sure that the bucket types have been
 %% transfered first.  Otherwise the bucket-to-index associations may
@@ -185,7 +175,7 @@ index(Obj, Reason, P) ->
                     BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
                     try
                         Index = get_index(BKey, Ring),
-                        ShortPL = get_short_preflist(BKey, Ring),
+                        ShortPL = riak_kv_util:get_index_n(BKey),
                         case should_index(Index) of
                             true ->
                                 index(Obj, Reason, Ring, P, BKey, ShortPL, Index);

--- a/src/yz_misc.erl
+++ b/src/yz_misc.erl
@@ -168,6 +168,15 @@ group_by_1(Transform) ->
             orddict:update(K, Cons, [V], Acc)
     end.
 
+%% @doc Determine the owner of the index (riak partition).
+-spec index_owner(ring(), p()) -> node() | no_owner.
+index_owner(Ring, Index) ->
+    try
+        riak_core_ring:index_owner(Ring, Index)
+    catch error:{badmatch,_} ->
+            no_owner
+    end.
+
 %% @doc Create the `Dir' if it doesn't already exist.
 -spec make_dir(string()) -> ok.
 make_dir(Dir) ->


### PR DESCRIPTION
This addresses most of #168. I still need to change the index list to be stored in cluster metadata so that Yokozuna can stop relying on ring events. That will be done as a separate PR rather than make this one bigger.

I performed a micro benchmark and there was no noticeable difference between before and after. Which is fine, I didn't necessarily make all the perf optimizations that were made in riak core as they are a bit tricker in Yokozuna.
- Use Riak KV's `get_index_n` instead of custom one.
- Add init/final to AAE compare API.
- Use `get_bucket/1` instead of `get_bucket\2` to make use of bucket cache.
- Add comment about AAE + ring resize (also see #279).
