### PR TITLE
Enable warnings_as_errors

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,7 @@
 {cover_enabled, true}.
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{erl_opts, [warnings_as_errors,
+            debug_info,
+            {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 
 {deps,

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -8,7 +8,6 @@
 -type interface() :: {http, tuple()} | {pb, tuple()}.
 -type interfaces() :: [interface()].
 -type conn_info() :: [{node(), interfaces()}].
--type cluster() :: [node()].
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -60,7 +60,7 @@ stop(_State) ->
 initialize_atoms() ->
     %% I had to run `list_to_existing_atom' so compiler wouldn't
     %% optimize out `list_to_atom'.
-    list_to_atom("search_index"),
+    _ = list_to_atom("search_index"),
     search_index = list_to_existing_atom("search_index"),
     ok.
 


### PR DESCRIPTION
Treat compiler warnings as errors and fix current warnings.
