### PR TITLE
Fix order of arguments passed to `yz_kv:dont_index`

### DIFF
--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -179,7 +179,7 @@ index(Obj, Reason, P) ->
                             true ->
                                 index(Obj, Reason, Ring, P, BKey, ShortPL, Index);
                             false ->
-                                dont_index(Obj, Reason, P, ShortPL, BKey)
+                                dont_index(Obj, Reason, P, BKey, ShortPL)
                         end,
                         yz_stat:index_end(?YZ_TIME_ELAPSED(T1))
                     catch _:Err ->


### PR DESCRIPTION
This patch addresses a seemingly trivial dialyzer warning:

```
yz_kv.erl:182: The call yz_kv:dont_index(Obj::riak_object:riak_object(),Reason::any(),P::non_neg_integer(),ShortPL::{non_neg_integer(),pos_integer()},BKey::{binary(),binary()}) breaks the contract (obj(),write_reason(),p(),bkey(),short_preflist()) -> 'ok'
```

What this warning is saying is that 2 of the arguments to the
`dont_index` function were switched. The `bkey()` and
`short_preflist()` arguments. This means that any time KV data was
written to a bucket without an index associated with it the YZ AAE
trees were not getting updated with the KV hash. This is bad because
without those hashes YZ AAE will constantly think that it is missing
postings for KV data and will invoke repiar for every single KV object
written to any non-indexed bucket. When the repair function is invoked
it will add the missing hash but this would still create a lot of
superfluous repairs while writing non-indexed data.

The fix is simple. Switch the two arguments. Along with the fix I also
added a test to `aae_test` to catch any future regressions. Here is my
test output below. If you switch the arguments back around `aae_test`
will fail. You will also notice that if you run dialyzer the warning
above is no longer present.

```
Test Results:
yz_wm_extract_test-bitcask   : pass
yz_stat_test-bitcask         : pass
yz_solr_start_timeout-bitcask: pass
yz_siblings-bitcask          : pass
yz_security-bitcask          : pass
yz_schema_admin-bitcask      : pass
yz_rs_migration_test-bitcask : pass
yz_pb-bitcask                : pass
yz_monitor_solr-bitcask      : pass
yz_mapreduce-bitcask         : pass
yz_languages-bitcask         : pass
yz_index_admin-bitcask       : pass
yz_fallback-bitcask          : pass
yz_errors-bitcask            : pass
yz_dt_test-bitcask           : pass
yokozuna_essential-bitcask   : pass
aae_test-bitcask             : pass
---------------------------------------------
0 Tests Failed
17 Tests Passed
That's 100.0% for those keeping score
```

I also made some other small tweaks to the `aae_test` that I'm happy
to explain if needed.
