### PR TITLE
Add AAE flush + new test

### DIFF
--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -73,7 +73,7 @@ confirm() ->
 
     _ = verify_removal_of_orphan_postings(Cluster),
 
-    verify_no_repair(Cluster),
+    verify_no_indefinite_repair(Cluster),
 
     _ = verify_no_repair_for_non_indexed_data(Cluster, PBConns),
     yz_rt:close_pb_conns(PBConns),
@@ -162,7 +162,7 @@ verify_removal_of_orphan_postings(Cluster) ->
 %% @doc Verify that there is no indefinite repair.  There have been
 %% several bugs in the past where Yokozuna AAE would indefinitely
 %% repair.
-verify_no_repair(Cluster) ->
+verify_no_indefinite_repair(Cluster) ->
     lager:info("Verify no indefinite repair"),
     yz_rt:count_calls(Cluster, ?REPAIR_MFA),
     TS = erlang:now(),

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -159,7 +159,7 @@ verify_removal_of_orphan_postings(Cluster) ->
     ?assertEqual(Num, yz_rt:get_call_count(Cluster, ?REPAIR_MFA)),
     ok.
 
-%% @doc Verify that there is no indefinite repair.  The have been
+%% @doc Verify that there is no indefinite repair.  There have been
 %% several bugs in the past where Yokozuna AAE would indefinitely
 %% repair.
 verify_no_repair(Cluster) ->


### PR DESCRIPTION
Two things:
1. Add a test to verify that AAE doesn't repair after a restart when it doesn't need to.
2. Make sure to flush hashtrees during shutdown. This is one of the changes needed for #253.

The test is not necessarily meant to test the flushing logic. Even without the added flush call during close the test still passes (probably because of flush getting called via other code paths). I added it to for #248 but realized that my problems are probably related to riak test and not Yokozuna itself. Since I already did the work of writing the test and added the new flush logic I figured I might as well make a PR to add both of them.
