### PR TITLE
Add notion of n_val to index

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -266,13 +266,7 @@
 %%% Indexes
 %%%===================================================================
 
--record(index_info,
-        {
-          schema_name :: schema_name()
-        }).
-
 -type indexes() :: [index_name()].
--type index_info() :: #index_info{}.
 -type index_name() :: binary().
 
 -type reload_opt() :: {schema, boolean()} | {timeout, ms()}.

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -1,7 +1,6 @@
 -module(yokozuna_essential).
 -compile(export_all).
--import(yz_rt, [create_index/2, create_index/3,
-                host_entries/1,
+-import(yz_rt, [host_entries/1,
                 run_bb/2,
                 search_expect/5, search_expect/6,
                 verify_count/2,
@@ -25,17 +24,32 @@
 -define(FRUIT_SCHEMA_NAME, <<"fruit">>).
 -define(BUCKET_TYPE, <<"data">>).
 -define(INDEX, <<"fruit_index">>).
+-define(INDEX_N_VAL, 4).
 -define(BUCKET, {?BUCKET_TYPE, <<"fruit">>}).
 -define(NUM_KEYS, 10000).
 -define(SUCCESS, 0).
 -define(CFG,
         [{riak_core,
           [
-           {ring_creation_size, 16}
+           %% Allow handoff to happen more quickly.
+           {handoff_concurrency, 3},
+
+           %% Use smaller ring size so that test runs faster.
+           {ring_creation_size, 16},
+
+           %% Reduce the tick so that ownership handoff will happen
+           %% more quickly.
+           {vnode_management_timer, 1000}
           ]},
          {yokozuna,
           [
-	   {enabled, true}
+	   {enabled, true},
+
+           %% Perform a full check every second so that non-owned
+           %% postings are deleted promptly. This makes sure that
+           %% postings are removed concurrent to async query during
+           %% join.
+           {events_full_check_after, 2}
           ]}
         ]).
 
@@ -254,16 +268,18 @@ setup_indexing(Cluster, PBConns, YZBenchDir) ->
     RawSchema = read_schema(YZBenchDir),
     yz_rt:store_schema(PBConn, ?FRUIT_SCHEMA_NAME, RawSchema),
     yz_rt:wait_for_schema(Cluster, ?FRUIT_SCHEMA_NAME, RawSchema),
-    ok = create_index(Node, ?INDEX, ?FRUIT_SCHEMA_NAME),
+    ok = yz_rt:create_index(Node, ?INDEX, ?FRUIT_SCHEMA_NAME, ?INDEX_N_VAL),
     yz_rt:set_index(Node, ?BUCKET, ?INDEX),
+    ok = rpc:call(Node, riak_core_bucket, set_bucket,
+                  [?BUCKET, [{n_val, ?INDEX_N_VAL}]]),
 
-    ok = create_index(Node, <<"tagging">>),
+    ok = yz_rt:create_index(Node, <<"tagging">>),
     yz_rt:set_index(Node, {?BUCKET_TYPE, <<"tagging">>}, <<"tagging">>),
 
-    ok = create_index(Node, <<"escaped">>),
+    ok = yz_rt:create_index(Node, <<"escaped">>),
     yz_rt:set_index(Node, {?BUCKET_TYPE, <<"escaped">>}, <<"escaped">>),
 
-    ok = create_index(Node, <<"unique">>),
+    ok = yz_rt:create_index(Node, <<"unique">>),
     [yz_rt:wait_for_index(Cluster, I)
      || I <- [?INDEX, <<"tagging">>, <<"escaped">>, <<"unique">>]].
 

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -24,8 +24,8 @@
 
 -define(FRUIT_SCHEMA_NAME, <<"fruit">>).
 -define(BUCKET_TYPE, <<"data">>).
--define(INDEX, <<"fruit">>).
--define(BUCKET, {?BUCKET_TYPE, ?INDEX}).
+-define(INDEX, <<"fruit_index">>).
+-define(BUCKET, {?BUCKET_TYPE, <<"fruit">>}).
 -define(NUM_KEYS, 10000).
 -define(SUCCESS, 0).
 -define(CFG,
@@ -265,7 +265,7 @@ setup_indexing(Cluster, PBConns, YZBenchDir) ->
 
     ok = create_index(Node, <<"unique">>),
     [yz_rt:wait_for_index(Cluster, I)
-     || I <- [<<"fruit">>, <<"tagging">>, <<"escaped">>, <<"unique">>]].
+     || I <- [?INDEX, <<"tagging">>, <<"escaped">>, <<"unique">>]].
 
 verify_deletes(Cluster, KeysDeleted, YZBenchDir) ->
     NumDeleted = length(KeysDeleted),

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -45,10 +45,17 @@ create_index(Node, Index) ->
     lager:info("Creating index ~s [~p]", [Index, Node]),
     ok = rpc:call(Node, yz_index, create, [Index]).
 
+-spec create_index(node(), index_name(), schema_name()) -> ok.
 create_index(Node, Index, SchemaName) ->
-    lager:info("Creating index ~s using schema ~s [~p]",
+    lager:info("Creating index ~s with schema ~s [~p]",
                [Index, SchemaName, Node]),
     ok = rpc:call(Node, yz_index, create, [Index, SchemaName]).
+
+-spec create_index(node(), index_name(), schema_name(), n()) -> ok.
+create_index(Node, Index, SchemaName, NVal) ->
+    lager:info("Creating index ~s with schema ~s and n_val: ~p [~p]",
+               [Index, SchemaName, NVal, Node]),
+    ok = rpc:call(Node, yz_index, create, [Index, SchemaName, NVal]).
 
 maybe_create_ets() ->
     case ets:info(?YZ_RT_ETS) of

--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -146,9 +146,8 @@ cache_plan(Index, Ring) ->
 -spec calc_plan(index_name(), ring()) -> {ok, plan()} | {error, term()}.
 calc_plan(Index, Ring) ->
     Q = riak_core_ring:num_partitions(Ring),
-    BProps = riak_core_bucket:get_bucket(Index),
     Selector = all,
-    NVal = riak_core_bucket:n_val(BProps),
+    NVal = yz_index:get_n_val(yz_index:get_index_info(Index)),
     NumPrimaries = 1,
     ReqId = erlang:phash2(erlang:now()),
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -74,7 +74,8 @@ create(Name, SchemaName) ->
 -spec create(index_name(), schema_name(), n()) ->
                     ok |
                     {error, schema_not_found}.
-create(Name, SchemaName, NVal) when is_integer(NVal) ->
+create(Name, SchemaName, NVal) when is_integer(NVal),
+                                    NVal > 0 ->
     case yz_schema:exists(SchemaName) of
         false ->
             {error, schema_not_found};

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -74,7 +74,7 @@ create(Name, SchemaName) ->
 -spec create(index_name(), schema_name(), n()) ->
                     ok |
                     {error, schema_not_found}.
-create(Name, SchemaName, NVal) ->
+create(Name, SchemaName, NVal) when is_integer(NVal) ->
     case yz_schema:exists(SchemaName) of
         false ->
             {error, schema_not_found};

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -22,6 +22,19 @@
 -include("yokozuna.hrl").
 -compile(export_all).
 
+-record(index_info,
+        {
+          %% Each index has it's own N value. This is needed so that
+          %% the query plan can be calculated. It is up to the user to
+          %% make sure that all buckets associated with an index use
+          %% the same N value as the index.
+          n_val :: n(),
+
+          %% The name of the schema this index is using.
+          schema_name :: schema_name()
+        }).
+-type index_info() :: #index_info{}.
+
 %% @doc This module contains functionaity for using and administrating
 %%      indexes.  In this case an index is an instance of a Solr Core.
 
@@ -41,25 +54,32 @@ associated_buckets(Index, Ring) ->
         false -> Assoc
     end.
 
+%% @see create/2
 -spec create(index_name()) -> ok.
 create(Name) ->
     create(Name, ?YZ_DEFAULT_SCHEMA_NAME).
 
+%% @see create/3
+-spec create(index_name(), schema_name()) -> ok | {error, schema_not_found}.
+create(Name, SchemaName) ->
+    DefaultNVal = riak_core_bucket:default_object_nval(),
+    create(Name, SchemaName, DefaultNVal).
+
 %% @doc Create the index `Name' across the entire cluster using
-%%      `SchemaName' as the schema.
+%%      `SchemaName' as the schema and `NVal' as the N value.
 %%
 %% `ok' - The schema was found and index added to the list.
 %%
 %% `schema_not_found' - The `SchemaName' could not be found.
--spec create(index_name(), schema_name()) ->
+-spec create(index_name(), schema_name(), n()) ->
                     ok |
                     {error, schema_not_found}.
-create(Name, SchemaName) ->
+create(Name, SchemaName, NVal) ->
     case yz_schema:exists(SchemaName) of
         false ->
             {error, schema_not_found};
         true  ->
-            Info = make_info(SchemaName),
+            Info = make_info(SchemaName, NVal),
             ok = riak_core_metadata:put(?YZ_META_INDEXES, Name, Info)
     end.
 
@@ -111,6 +131,11 @@ get_indexes_from_meta() ->
 -spec get_index_info(index_name()) -> undefined | index_info().
 get_index_info(Name) ->
     riak_core_metadata:get(?YZ_META_INDEXES, Name).
+
+%% @doc Get the N value from the index info.
+-spec get_n_val(index_info()) -> n().
+get_n_val(IndexInfo) ->
+    IndexInfo#index_info.n_val.
 
 %% @doc Create the index `Name' locally.  Make best attempt to create
 %%      the index, log if a failure occurs.  Always return `ok'.
@@ -291,6 +316,7 @@ is_default_type_indexed(Index) ->
     %% "true" which, hopefully, it should not be.
     true == proplists:get_value(search, Props, false).
 
--spec make_info(binary()) -> index_info().
-make_info(SchemaName) ->
-    #index_info{schema_name=SchemaName}.
+-spec make_info(binary(), n()) -> index_info().
+make_info(SchemaName, NVal) ->
+    #index_info{n_val=NVal,
+                schema_name=SchemaName}.


### PR DESCRIPTION
Add the notion of `n_val` to Yokozuna indexes. This reduces coupling between KV buckets and Yokozuna indexes and fixes a bug in the query plan generation. Removing the coupling to buckets also allows for usage of indexes not yet envisioned, e.g. indexing internal events like audit logs.

This patch also makes small tweeks to the essential test to use a non-default `n_val` to make sure that works. It also uses an index name different from the bucket as that would have caught this bug many months ago.

Finally, this patch extends the HTTP Index API to handle `n_val` but changes are still required for PB as well as the official clients. See #290.
