### PR TITLE
Add PB interface for setting an index n_val

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -71,9 +71,13 @@ create(Name, SchemaName) ->
 %% `ok' - The schema was found and index added to the list.
 %%
 %% `schema_not_found' - The `SchemaName' could not be found.
--spec create(index_name(), schema_name(), n()) ->
+-spec create(index_name(), schema_name(), n() | undefined) ->
                     ok |
                     {error, schema_not_found}.
+create(Name, SchemaName, undefined) ->
+    DefaultNVal = riak_core_bucket:default_object_nval(),
+    create(Name, SchemaName, DefaultNVal);
+
 create(Name, SchemaName, NVal) when is_integer(NVal),
                                     NVal > 0 ->
     case yz_schema:exists(SchemaName) of


### PR DESCRIPTION
Yokozuna indexes new require an n_val to further decouple indexes from kv buckets. This is the server-side PB interface for PR #295, and a component of issue #290.

Testing this PR requires using the erlang client PR: basho/riak-erlang-client#154
