### PR TITLE
Mark AAE trees as built immediately

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -173,11 +173,11 @@
 %% Directory to store the hashtrees.
 -define(YZ_AAE_DIR,
         application:get_env(?YZ_APP_NAME, anti_entropy_data_dir)).
-%% How often to check for entropy, in milliseconds.  Defaults to 1
-%% minute.
+%% How often to check for entropy, in milliseconds.  Defaults to 15
+%% seconds.
 -define(YZ_ENTROPY_TICK,
-        app_helper:get_env(?YZ_APP_NAME, entropy_tick,
-            app_helper:get_env(riak_kv, anti_entropy_tick, 60000)
+        app_helper:get_env(?YZ_APP_NAME, anti_entropy_tick,
+            app_helper:get_env(riak_kv, anti_entropy_tick, 15000)
         )).
 %% The length of time a tree is considered valid, in milliseconds.  If
 %% a tree is older than it is considered expired and must be rebuilt

--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -21,7 +21,7 @@
          {yokozuna,
           [
 	   {enabled, true},
-           {entropy_tick, 1000}
+           {anti_entropy_tick, 1000}
           ]}
         ]).
 

--- a/riak_test/yz_rs_migration_test.erl
+++ b/riak_test/yz_rs_migration_test.erl
@@ -266,7 +266,7 @@ rolling_upgrade(Cluster, Vsn) ->
                 {yokozuna, [{anti_entropy, {on, [debug]}},
                             {anti_entropy_concurrency, 12},
                             {anti_entropy_build_limit, {6,500}},
-                            {entropy_tick, 1000},
+                            {anti_entropy_tick, 1000},
                             {enabled, true},
 			    {solr_port, SolrPort}]}],
 	 rt:upgrade(Node, Vsn, Cfg),

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -142,6 +142,15 @@ init([Index, RPs]) ->
                        built=false,
                        path=Path},
             S2 = init_trees(RPs, S),
+
+            %% If no indexes exist then mark tree as built
+            %% immediately. This allows exchange to start immediately
+            %% rather than waiting a potentially long time for a build.
+            BuiltImmediately = ([] == yz_index:get_indexes_from_meta()),
+            _ = case BuiltImmediately of
+                    true -> gen_server:cast(self(), build_finished);
+                    false -> ok
+                end,
             {ok, S2}
     end.
 

--- a/src/yz_index_hashtree_sup.erl
+++ b/src/yz_index_hashtree_sup.erl
@@ -14,7 +14,6 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init(_Args) ->
-    %% TODO: should shutdown be longer to account for leveldb?
     Spec = {ignored,
             {yz_index_hashtree, start_link, []},
             temporary, 5000, worker, [yz_index_hashtree]},


### PR DESCRIPTION
When possible, mark the index hashtree as built immediately. This allows
exchange to be performed earlier. It is useful when standing up new
nodes which don't have any data yet and you don't want to wait for the
AAE manager to build all partitions.

This can be tested by hand with the following steps.
1. Build a 1 node rel/stage of riak: `make stage`
2. Enable search: `sed -e 's/search = off/search = on/' -i.back rel/riak/etc/riak.conf`
3. Start the node: `./rel/riak/bin/riak start`
4. Attach: `./rel/riak/bin/riak attach`
5. Print Yokozuna tree info: `rp(yz_kv:compute_tree_info()).`
6. Notice that info for all partitions is `undefined`
7. Wait 15s: `timer:sleep(15000).`
8. Print tree info again: `rp(yz_kv:compute_tree_info()).`
9. Notice all the partitions now have a 3-tuple timestampe where defined once was.

NOTE: You need to attach (step 4) immediately after start and print
the tree info to make sure you beat the 15 second AAE tick.
