### PR TITLE
Add bucket type/index n_val equivalency validator

### DIFF
--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -142,8 +142,8 @@ setup_index(Cluster, PBConn, YZBenchDir) ->
     ok = yz_rt:wait_for_schema(Cluster, ?INDEX, RawSchema),
     ok = yz_rt:create_bucket_type(Node, ?BUCKET_TYPE),
     ok = yz_rt:create_index(Node, ?INDEX, ?INDEX),
-    ok = yz_rt:set_index(Node, ?BUCKET, ?INDEX),
-    ok = yz_rt:wait_for_index(Cluster, ?INDEX).
+    ok = yz_rt:wait_for_index(Cluster, ?INDEX),
+    ok = yz_rt:set_index(Node, ?BUCKET, ?INDEX).
 
 %% @doc Verify that Yokozuna deletes postings which have no
 %% corresponding KV object.

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -276,8 +276,6 @@ setup_indexing(Cluster, PBConns, YZBenchDir) ->
     [yz_rt:wait_for_index(Cluster, I)
      || I <- [?INDEX, <<"tagging">>, <<"escaped">>, <<"unique">>]],
 
-    ok = rpc:call(Node, riak_core_bucket, set_bucket,
-                  [?BUCKET, [{n_val, ?INDEX_N_VAL}]]),
     yz_rt:set_index(Node, ?BUCKET, ?INDEX, ?INDEX_N_VAL),
     yz_rt:set_index(Node, {?BUCKET_TYPE, <<"tagging">>}, <<"tagging">>),
     yz_rt:set_index(Node, {?BUCKET_TYPE, <<"escaped">>}, <<"escaped">>).

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -269,19 +269,18 @@ setup_indexing(Cluster, PBConns, YZBenchDir) ->
     yz_rt:store_schema(PBConn, ?FRUIT_SCHEMA_NAME, RawSchema),
     yz_rt:wait_for_schema(Cluster, ?FRUIT_SCHEMA_NAME, RawSchema),
     ok = yz_rt:create_index(Node, ?INDEX, ?FRUIT_SCHEMA_NAME, ?INDEX_N_VAL),
-    yz_rt:set_index(Node, ?BUCKET, ?INDEX),
+    ok = yz_rt:create_index(Node, <<"tagging">>),
+    ok = yz_rt:create_index(Node, <<"escaped">>),
+    ok = yz_rt:create_index(Node, <<"unique">>),
+
+    [yz_rt:wait_for_index(Cluster, I)
+     || I <- [?INDEX, <<"tagging">>, <<"escaped">>, <<"unique">>]],
+
     ok = rpc:call(Node, riak_core_bucket, set_bucket,
                   [?BUCKET, [{n_val, ?INDEX_N_VAL}]]),
-
-    ok = yz_rt:create_index(Node, <<"tagging">>),
+    yz_rt:set_index(Node, ?BUCKET, ?INDEX, ?INDEX_N_VAL),
     yz_rt:set_index(Node, {?BUCKET_TYPE, <<"tagging">>}, <<"tagging">>),
-
-    ok = yz_rt:create_index(Node, <<"escaped">>),
-    yz_rt:set_index(Node, {?BUCKET_TYPE, <<"escaped">>}, <<"escaped">>),
-
-    ok = yz_rt:create_index(Node, <<"unique">>),
-    [yz_rt:wait_for_index(Cluster, I)
-     || I <- [?INDEX, <<"tagging">>, <<"escaped">>, <<"unique">>]].
+    yz_rt:set_index(Node, {?BUCKET_TYPE, <<"escaped">>}, <<"escaped">>).
 
 verify_deletes(Cluster, KeysDeleted, YZBenchDir) ->
     NumDeleted = length(KeysDeleted),

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -120,7 +120,7 @@ create_index(Cluster, Index) ->
     URL = index_url(HP, Index),
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
+    yz_rt:wait_for_index(Cluster, Index),
     yz_rt:set_bucket_type_index(Node, Index),
     yz_rt:wait_for_bucket_type(Cluster, Index),
-    yz_rt:wait_for_index(Cluster, Index),
     ?assertEqual("204", Status).

--- a/riak_test/yz_fallback.erl
+++ b/riak_test/yz_fallback.erl
@@ -43,6 +43,7 @@ check_fallbacks(Cluster, Index, Bucket, Key) ->
 create_index(Cluster, Index) ->
     Node = yz_rt:select_random(Cluster),
     yz_rt:create_index(Node, Index),
+    yz_rt:wait_for_index(Cluster, Index),
     ok = yz_rt:set_bucket_type_index(Node, Index),
     timer:sleep(5000).
 

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -235,12 +235,12 @@ confirm_delete_409(Cluster, Index) ->
     lager:info("Verify that index ~s cannot be deleted b/c of associated buckets [~p]", [Index, HP]),
     URL = index_url(HP, Index),
     {ok, "204", _, _} = http(put, URL, ?NO_HEADERS, ?NO_BODY),
+    yz_rt:wait_for_index(Cluster, Index),
     H = [{"content-type", "application/json"}],
     B = <<"{\"props\":{\"search_index\":\"delete_409\"}}">>,
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B),
     {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B),
 
-    yz_rt:wait_for_index(Cluster, Index),
     %% Sleeping for bprops (TODO: convert to `wait_for_bprops')
     timer:sleep(4000),
 

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -110,6 +110,7 @@ confirm() ->
     confirm_404(Cluster, <<"not_an_index">>),
     confirm_delete_409(Cluster, <<"delete_409">>),
     confirm_field_add(Cluster, <<"field_add">>),
+    confirm_bad_bucket_associations(Cluster),
     pass.
 
 %% @doc Verify that bad n_val is rejected.
@@ -254,14 +255,19 @@ confirm_delete_409(Cluster, Index) ->
     %% Can't be deleted because of associated buckets
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
-    {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B2),
+    %% Associate bucket with new index
+    NewIndex = <<"new_index">>,
+    ok = yz_rt:create_index(Node, NewIndex),
+    yz_rt:wait_for_index(Cluster, NewIndex),
 
-    %% Still can't delete because of associated bucket
+    B2 = <<"{\"props\":{\"search_index\":\"",NewIndex/binary,"\"}}">>,
+    {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B2),
+
+    %% Still can't delete because of one associated bucket
     {ok, "409", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY),
 
-    B2 = <<"{\"props\":{\"search_index\":\"_yz_default\"}}">>,
-    {ok, "204", _, _} = http(put, bucket_url(HP, <<"b1">>), H, B2),
+    %% Associate second bucket with new index
+    {ok, "204", _, _} = http(put, bucket_url(HP, <<"b2">>), H, B2),
 
     %% TODO: wait_for_index_delete?
     {ok, "204", _, _} = http(delete, URL, ?NO_HEADERS, ?NO_BODY).
@@ -303,6 +309,19 @@ confirm_field_add(Cluster, Index) ->
     {ok, _} = rpc:call(Node, yz_index, reload, [Index]),
 
     yz_rt:wait_until(Cluster, field_exists(Index, "my_new_field", CI)).
+
+confirm_bad_bucket_associations(Cluster) ->
+    Node = yz_rt:select_random(Cluster),
+    Index = <<"diff_n_val_index">>,
+    Bucket = <<"diff_n_val">>,
+    %% attempt to associate bucket with nonexistant index
+    {error, [{search_index,_}]} = yz_rt:set_index(Node, Bucket, Index, 2),
+    ok = yz_rt:create_index(Node, Index, ?YZ_DEFAULT_SCHEMA_NAME, 4),
+    yz_rt:wait_for_index(Cluster, Index),
+    %% attempt to associate bucket with incongruent n_val
+    {error, [{n_val,_}]} = yz_rt:set_index(Node, Bucket, Index, 2),
+    %% sucessfully associate bucket with matchin n_val
+    ok = yz_rt:set_index(Node, Bucket, Index, 4).
 
 %%%===================================================================
 %%% Helpers

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -51,8 +51,8 @@ create_index(Cluster, HP, Index) ->
     URL = index_url(HP, Index),
     Headers = [{"content-type", "application/json"}],
     {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
-    ok = yz_rt:set_bucket_type_index(hd(Cluster), Index),
     yz_rt:wait_for_index(Cluster, Index),
+    ok = yz_rt:set_bucket_type_index(hd(Cluster), Index),
     ?assertEqual("204", Status).
 
 store_and_search(Cluster, Bucket, Index, CT, Body, Field, Term) ->

--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -39,9 +39,9 @@ confirm() ->
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),
     yz_rt:create_index(yz_rt:select_random(Cluster), Index),
+    yz_rt:wait_for_index(Cluster, Index),
     yz_rt:set_bucket_type_index(yz_rt:select_random(Cluster), Index),
     timer:sleep(500),
-    yz_rt:wait_for_index(Cluster, Index),
     write_100_objs(Cluster, Bucket),
     verify_100_objs_mr(Cluster, Index),
     pass.

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -78,10 +78,10 @@ create_index(Cluster, BucketType, Index, Nval) ->
     %% set index in props with the same name as the bucket
     ?assertEqual(ok,
         riakc_pb_socket:create_search_index(Pid, Index, SchemaName, [NvalT])),
-    % Add the index to the bucket props
-    yz_rt:set_bucket_type_index(Node, BucketType, Index),
-    yz_rt:wait_for_bucket_type(Cluster, BucketType),
     yz_rt:wait_for_index(Cluster, Index),
+    % Add the index to the bucket props
+    yz_rt:set_bucket_type_index(Node, BucketType, Index, Nval),
+    yz_rt:wait_for_bucket_type(Cluster, BucketType),
     %% Check that the index exists
     {ok, IndexData} = riakc_pb_socket:get_search_index(Pid, Index),
     ?assertEqual([{index, Index}, {schema, SchemaName}, NvalT], IndexData),

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -239,6 +239,11 @@ set_index(Node, Bucket, Index) ->
     Props = [{?YZ_INDEX, Index}],
     ok = rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
 
+-spec set_index(node(), bucket(), index_name(), n()) -> ok.
+set_index(Node, Bucket, Index, NVal) ->
+    Props = [{?YZ_INDEX, Index}, {n_val, NVal}],
+    ok = rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
+
 -spec remove_index(node(), binary()) -> ok.
 remove_index(Node, BucketType) ->
     lager:info("Remove index from bucket type ~s [~p]", [BucketType, Node]),
@@ -251,6 +256,10 @@ set_bucket_type_index(Node, BucketType) ->
 set_bucket_type_index(Node, BucketType, Index) ->
     lager:info("Set bucket type ~s index to ~s [~p]", [BucketType, Index, Node]),
     create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index}]).
+
+set_bucket_type_index(Node, BucketType, Index, NVal) ->
+    lager:info("Set bucket type ~s index to ~s [~p]", [BucketType, Index, Node]),
+    create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index},{n_val,NVal}]).
 
 solr_http({_Node, ConnInfo}) ->
     solr_http(ConnInfo);

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -236,17 +236,17 @@ select_random(List) ->
 
 %% @doc Associate the `Index' with the `Bucket', sending the request
 %% to `Node'.
--spec set_index(node(), bucket(), index_name()) -> ok.
+-spec set_index(node(), bucket(), index_name()) -> ok | {error, any()}.
 set_index(Node, Bucket, Index) ->
     Props = [{?YZ_INDEX, Index}],
     set_bucket_props(Node, Bucket, Props).
 
--spec set_index(node(), bucket(), index_name(), n()) -> ok.
+-spec set_index(node(), bucket(), index_name(), n()) -> ok | {error, any()}.
 set_index(Node, Bucket, Index, NVal) ->
     Props = [{?YZ_INDEX, Index}, {n_val, NVal}],
     set_bucket_props(Node, Bucket, Props).
 
--spec set_bucket_props(node(), bucket(), props()) -> ok.
+-spec set_bucket_props(node(), bucket(), props()) -> ok | {error, any()}.
 set_bucket_props(Node, Bucket, Props) ->
     rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
 

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -13,6 +13,8 @@
 -type interface() :: {http, tuple()} | {pb, tuple()}.
 -type interfaces() :: [interface()].
 -type conn_info() :: [{node(), interfaces()}].
+-type prop() :: {atom(), any()}.
+-type props() :: [prop()].
 
 -type cluster() :: [node()].
 
@@ -237,12 +239,16 @@ select_random(List) ->
 -spec set_index(node(), bucket(), index_name()) -> ok.
 set_index(Node, Bucket, Index) ->
     Props = [{?YZ_INDEX, Index}],
-    ok = rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
+    set_bucket_props(Node, Bucket, Props).
 
 -spec set_index(node(), bucket(), index_name(), n()) -> ok.
 set_index(Node, Bucket, Index, NVal) ->
     Props = [{?YZ_INDEX, Index}, {n_val, NVal}],
-    ok = rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
+    set_bucket_props(Node, Bucket, Props).
+
+-spec set_bucket_props(node(), bucket(), props()) -> ok.
+set_bucket_props(Node, Bucket, Props) ->
+    rpc:call(Node, riak_core_bucket, set_bucket, [Bucket, Props]).
 
 -spec remove_index(node(), binary()) -> ok.
 remove_index(Node, BucketType) ->

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -110,5 +110,5 @@ create_index(Cluster, HP, Index) ->
     URL = index_url(HP, Index),
     Headers = [{"content-type", "application/json"}],
     {ok, "204", _, _} = http(put, URL, Headers, ?NO_BODY),
-    ok = yz_rt:set_bucket_type_index(hd(Cluster), Index),
-    yz_rt:wait_for_index(Cluster, Index).
+    yz_rt:wait_for_index(Cluster, Index),
+    ok = yz_rt:set_bucket_type_index(hd(Cluster), Index).

--- a/riak_test/yz_stat_test.erl
+++ b/riak_test/yz_stat_test.erl
@@ -30,8 +30,8 @@ prepare_cluster(NumNodes) ->
 
 create_indexed_bucket(Pid, Cluster, Index) ->
     ?assertEqual(ok, riakc_pb_socket:create_search_index(Pid, Index)),
-    yz_rt:set_bucket_type_index(hd(Cluster), Index),
     yz_rt:wait_for_index(Cluster, Index),
+    yz_rt:set_bucket_type_index(hd(Cluster), Index),
     ok.
 
 %% populate random plain text values

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -75,6 +75,7 @@ maybe_setup(true) ->
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
     setup_stats(),
+    ok = riak_core:register(yokozuna, [{bucket_validator, yz_bucket_validator}]),
     ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),
     ok.

--- a/src/yz_bucket_validator.erl
+++ b/src/yz_bucket_validator.erl
@@ -65,7 +65,7 @@ validate_n_val(Index, INVal, BNVal, BucketProps) ->
         INVal when INVal == BNVal ->
             {BucketProps, []};
         _ ->
-            Error = ?FMT("Bucket type n_val ~p must match the associated "
+            Error = ?FMT("Bucket n_val ~p must match the associated "
                          "search_index ~s n_val ~p", [BNVal,Index,INVal]),
             {proplists:delete(n_val, BucketProps), [{n_val, Error}]}
     end.

--- a/src/yz_bucket_validator.erl
+++ b/src/yz_bucket_validator.erl
@@ -1,0 +1,98 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc yz_bucket_validator verifies that a bucket type's
+%%      n_val property matches any associated indexe's n_val
+-module(yz_bucket_validator).
+-export([validate/4]).
+-include("yokozuna.hrl").
+
+-define(FMT(S, Args), list_to_binary(lists:flatten(io_lib:format(S, Args)))).
+
+-type prop() :: {PropName::atom(), PropValue::any()}.
+-type error() :: {PropName::atom(), ErrorReason::atom()}.
+-type props() :: [prop()].
+-type errors() :: [error()].
+
+%% @doc Performs two validations. The first is validating that an index
+%% exists before a bucket type can be associated to it by setting search_index.
+%% The second checks that the bucket type has the same n_val as the associated
+%% index's n_val.
+-spec validate(create | update,
+               {riak_core_bucket_type:bucket_type(), undefined | binary()} | binary(),
+               undefined | props(),
+               props()) -> {props(), errors()}.
+validate(_CreateOrUpdate, _Bucket, ExistingProps, BucketProps) ->
+    Props = case {ExistingProps, BucketProps} of
+        {undefined, BucketProps} ->
+            BucketProps;
+        {ExistingProps, undefined} ->
+            ExistingProps;
+        {ExistingProps, BucketProps} ->
+            riak_core_bucket_props:merge(ExistingProps, BucketProps)
+    end,
+    case get_search_index_info(Props) of
+        {error, no_search_index} ->
+            {BucketProps, []};
+        {error, Msg} ->
+            {proplists:delete(search_index, BucketProps),
+                [{search_index, Msg}]};
+        {Index, INVal} ->
+            BNVal = proplists:get_value(n_val, Props),
+            validate_n_val(Index, INVal, BNVal, BucketProps)
+    end.
+
+%% @private
+%%
+
+-spec validate_n_val(index_name(), n(), n(), props()) -> {props(), errors()}.
+validate_n_val(Index, INVal, BNVal, BucketProps) ->
+    case INVal of
+        INVal when INVal == BNVal ->
+            {BucketProps, []};
+        _ ->
+            Error = ?FMT("Bucket type n_val ~p must match the associated "
+                         "search_index ~s n_val ~p ", [BNVal,Index,INVal]),
+            %% Removing search_index from valid props,
+            %% since we cannot remove n_val
+            {proplists:delete(search_index, BucketProps),
+                [{search_index, Error}]}
+    end.
+
+-spec get_search_index_info(props()) -> {error,binary()} | {index_name(),n()}.
+get_search_index_info(Props) ->
+    case proplists:get_value(search_index, Props) of
+        undefined ->
+            {error, no_search_index};
+        ?YZ_INDEX_TOMBSTONE ->
+            {error, no_search_index};
+        Index ->
+            case yz_index:exists(Index) of
+                false ->
+                    {error, ?FMT("~s does not exist", [Index])};
+                true ->
+                    {Index, index_n_val(Index)}
+            end
+    end.
+
+%% @doc Get search_index from the bucket props, and return the
+%%      index's n_val. If it doesn't exist, return undefined.
+% index_n_val(Props) ->
+index_n_val(Index) ->
+    yz_index:get_n_val(yz_index:get_index_info(Index)).


### PR DESCRIPTION
Registers a create/update bucket type property validator for yokozuna. This ensures that setting properties on a bucket type will validate that 1) the index exists, and 2) the bucket types n_val equals the index's n_val.

This forced a change to the tests, whereby an index must first be created, then `wait_for_index`, then associate the index with the bucket. Before this check, waiting didn't matter until values were written.
