### PR TITLE
Add stats formatting for riak-admin and http stats output

### DIFF
--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -93,7 +93,7 @@ search_end(ElapsedTime) ->
 
 %% @doc Optionally produce stats map based on ?YZ_ENABLED
 %% 
--spec stats_map() -> [{term()}].
+-spec stats_map() -> [] | proplists:proplist().
 stats_map() ->
      stats_map(?YZ_ENABLED).
 

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -102,14 +102,12 @@ search_end(ElapsedTime) ->
     update({search_end, ElapsedTime}).
 
 %% @doc Optionally produce stats map based on ?YZ_ENABLED
-%% 
 -spec stats_map() -> [] | proplists:proplist().
 stats_map() ->
      stats_map(?YZ_ENABLED).
 
 %% @doc Map to format stats for legacy "blob" if YZ_ENABLED,
-%% else []
-%% 
+%% else [].
 -spec stats_map(true | false) -> [] | proplists:proplist().
 stats_map(false) -> [];
 stats_map(true) ->

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -61,8 +61,13 @@ get_stats() ->
 %% @doc Return formatted stats
 -spec get_formatted_stats() -> [term()].
 get_formatted_stats() ->
-    Stats = ?MODULE:get_stats(),
-    format_stats(Stats).
+    case yokozuna:is_enabled(index) andalso ?YZ_ENABLED of
+        false -> 
+            [];
+        true -> 
+            Stats = ?MODULE:get_stats(),
+            format_stats(Stats)
+    end.
 
 %% TODO: export stats() type from riak_core_stat_q.
 -spec produce_stats() -> {atom(), list()}.

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -195,62 +195,64 @@ format_stats(Stats) ->
     lists:flatten([format(Stat) || Stat <- Stats]).
 
 format({{_, search, fail},[{count, Count}, {one, One}]}) ->
-    [{yokozuna_search_fail_count, Count},
-     {yokozuna_search_fail_one, One}];
+    [{search_query_fail_count, Count},
+     {search_query_fail_one, One}];
 format({{_, search, throughput},[{count, Count}, {one, One}]}) ->
-    [{yokozuna_search_throughput_count, Count},
-     {yokozuna_search_throughput_one, One}];
+    [{search_query_throughput_count, Count},
+     {search_query_throughput_one, One}];
 format({{_, index, fail},[{count, Count}, {one, One}]}) ->
-    [{yokozuna_index_fail_count, Count},
-     {yokozuna_index_fail_one, One}];
+    [{search_index_fail_count, Count},
+     {search_index_fail_one, One}];
 format({{_, index, throughput},[{count, Count}, {one, One}]}) ->
-    [{yokozuna_index_fail_count, Count},
-     {yokozuna_index_fail_one, One}];
+    [{search_index_throughput_count, Count},
+     {search_index_throughput_one, One}];
 format({{_, search, latency}, ValueList}) ->
-    [format_search_latency(V) || V <- ValueList];
+    [format_query_latency(V) || V <- ValueList];
 format({{_, index, latency}, ValueList}) ->
     [format_index_latency(V) || V <- ValueList];
+format({yokozuna_stat_ts, TS}) ->
+    [{search_stat_ts, TS}];
 format(T) -> T.
 
-format_search_latency({min, Value}) ->
-    {yokozuna_search_latency_min, Value};
-format_search_latency({max, Value}) ->
-    {yokozuna_search_latency_max, Value};
-format_search_latency({median, Value}) ->
-    {yokozuna_search_latency_median, Value};
-format_search_latency({variance, Value}) ->
-    {yokozuna_search_latency_variance, Value};
-format_search_latency({percentile, PList}) ->
-    [ format_search_latency_percentile(P) || P <- PList];
-format_search_latency({_, _}) ->
+format_query_latency({min, Value}) ->
+    {search_query_latency_min, Value};
+format_query_latency({max, Value}) ->
+    {search_query_latency_max, Value};
+format_query_latency({median, Value}) ->
+    {search_query_latency_median, Value};
+format_query_latency({variance, Value}) ->
+    {search_query_latency_variance, Value};
+format_query_latency({percentile, PList}) ->
+    [ format_query_latency_percentile(P) || P <- PList];
+format_query_latency({_, _}) ->
     [].
 
-format_search_latency_percentile({50, Value}) ->
-    {yokozuna_search_latency_percentile_50, Value};
-format_search_latency_percentile({95, Value}) ->
-    {yokozuna_search_latency_percentile_95, Value};
-format_search_latency_percentile({99, Value}) ->
-    {yokozuna_search_latency_percentile_99, Value};
-format_search_latency_percentile(_) -> [].
+format_query_latency_percentile({50, Value}) ->
+    {search_query_latency_percentile_50, Value};
+format_query_latency_percentile({95, Value}) ->
+    {search_query_latency_percentile_95, Value};
+format_query_latency_percentile({99, Value}) ->
+    {search_query_latency_percentile_99, Value};
+format_query_latency_percentile(_) -> [].
 
 format_index_latency({min, Value}) ->
-    {yokozuna_index_latency_min, Value};
+    {search_index_latency_min, Value};
 format_index_latency({max, Value}) ->
-    {yokozuna_index_latency_max, Value};
+    {search_index_latency_max, Value};
 format_index_latency({median, Value}) ->
-    {yokozuna_index_latency_median, Value};
+    {search_index_latency_median, Value};
 format_index_latency({variance, Value}) ->
-    {yokozuna_index_latency_variance, Value};
+    {search_index_latency_variance, Value};
 format_index_latency({percentile, PList}) ->
     [ format_index_latency_percentile(P) || P <- PList];
 format_index_latency({_, _}) ->
     [].
 
 format_index_latency_percentile({50, Value}) ->
-    {yokozuna_index_latency_percentile_50, Value};
+    {search_index_latency_percentile_50, Value};
 format_index_latency_percentile({95, Value}) ->
-    {yokozuna_index_latency_percentile_95, Value};
+    {search_index_latency_percentile_95, Value};
 format_index_latency_percentile({99, Value}) ->
-    {yokozuna_index_latency_percentile_99, Value};
+    {search_index_latency_percentile_99, Value};
 format_index_latency_percentile(_) -> [].
 

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -52,7 +52,7 @@ register_stats() ->
 
 %% @doc Transform the yz stats to a format consistent
 %% with "legacy" stats and rename them
--spec  search_stats() -> proplists:proplist().
+-spec search_stats() -> proplists:proplist().
 search_stats() ->
     {Legacy, _Calculated} = lists:foldl(fun({Old, New, Type}, {Acc, Cache}) ->
                                                 riak_kv_stat_bc:bc_stat({Old, New, Type}, Acc, Cache) end,

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -100,6 +100,7 @@ stats_map() ->
 %% @doc Map to format stats for legacy "blob" if YZ_ENABLED,
 %% else []
 %% 
+-spec stats_map(true | false) -> [] | proplists:proplist().
 stats_map(false) -> [];
 stats_map(true) ->
      [

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -220,15 +220,11 @@ format_query_latency({max, Value}) ->
     {search_query_latency_max, Value};
 format_query_latency({median, Value}) ->
     {search_query_latency_median, Value};
-format_query_latency({variance, Value}) ->
-    {search_query_latency_variance, Value};
 format_query_latency({percentile, PList}) ->
     [ format_query_latency_percentile(P) || P <- PList];
 format_query_latency({_, _}) ->
     [].
 
-format_query_latency_percentile({50, Value}) ->
-    {search_query_latency_percentile_50, Value};
 format_query_latency_percentile({95, Value}) ->
     {search_query_latency_percentile_95, Value};
 format_query_latency_percentile({99, Value}) ->
@@ -241,15 +237,11 @@ format_index_latency({max, Value}) ->
     {search_index_latency_max, Value};
 format_index_latency({median, Value}) ->
     {search_index_latency_median, Value};
-format_index_latency({variance, Value}) ->
-    {search_index_latency_variance, Value};
 format_index_latency({percentile, PList}) ->
     [ format_index_latency_percentile(P) || P <- PList];
 format_index_latency({_, _}) ->
     [].
 
-format_index_latency_percentile({50, Value}) ->
-    {search_index_latency_percentile_50, Value};
 format_index_latency_percentile({95, Value}) ->
     {search_index_latency_percentile_95, Value};
 format_index_latency_percentile({99, Value}) ->


### PR DESCRIPTION
YZ stats are not currently displayed on the riak http stats endpoint, or by riak-admin status. Add YZ stats formatting appropriate for console output with 'riak-admin status' and the htts /stats endpoint. The stats namespace for Search is transformed to /search/[query | index]/... instead of 'yokozuna'.

This PR also depends on changes to riak_kv in order to publish the stats to the 2 interfaces:
https://github.com/basho/riak_kv/pull/839

Example stats output:

search_stat_ts : 1392310824
search_query_fail_count : 0
search_query_fail_one : 0
search_index_throughput_count : 0
search_index_throughput_one : 0
search_index_fail_count : 0
search_index_fail_one : 0
search_query_throughput_count : 0
search_query_throughput_one : 0
search_query_latency_min : 0.0
search_query_latency_max : 0.0
search_query_latency_median : 0.0
search_query_latency_percentile_95 : 0.0
search_query_latency_percentile_99 : 0.0
search_index_latency_min : 0.0
search_index_latency_max : 0.0
search_index_latency_median : 0.0
search_index_latency_percentile_95 : 0.0
search_index_latency_percentile_99 : 0.0
