### PR TITLE
More AAE ports

### DIFF
--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -160,7 +160,7 @@ verify_exchange_after_expire(Cluster) ->
     _ = [ok = rpc:call(Node, yz_entropy_mgr, expire_trees, [])
          || Node <- Cluster],
 
-    %% The expire is done very cast so just give it a moment
+    %% The expire is async so just give it a moment
     timer:sleep(100),
 
     ok = yz_rt:wait_for_full_exchange_round(Cluster, now()),

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -177,9 +177,15 @@ handle_call(disable, _From, S) ->
     [yz_index_hashtree:stop(T) || {_,T} <- S#state.trees],
     {reply, ok, S};
 
-handle_call({set_mode, Mode}, _From, S) ->
-    S2 = S#state{mode=Mode},
-    {reply, ok, S2};
+handle_call({set_mode, NewMode}, _From, S=#state{mode=CurrentMode}) ->
+    S2 = case {CurrentMode, NewMode} of
+             {automatic, manual} ->
+                 S#state{exchange_queue=[]};
+             _ ->
+                 S
+         end,
+    S3 = S2#state{mode=NewMode},
+    {reply, ok, S3};
 
 handle_call(Request, From, S) ->
     lager:warning("Unexpected call: ~p from ~p", [Request, From]),

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -126,7 +126,7 @@ clear_trees() ->
     gen_server:cast(?MODULE, clear_trees).
 
 %% @doc Expire all the trees. Expired trees can still be exchanged up
-%% until the point they are rebult versus clearing trees which
+%% until the point they are rebuilt versus clearing trees which
 %% destroys them and prevents exchange from occurring until the tree
 %% is rebuilt which can take a long time.
 %%

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -464,7 +464,8 @@ do_poke(S) ->
 
 maybe_clear(S=#state{lock=undefined, built=true}) ->
     Diff = timer:now_diff(os:timestamp(), S#state.build_time),
-    case Diff > (?YZ_ENTROPY_EXPIRE * 1000)  of
+    Expire = ?YZ_ENTROPY_EXPIRE,
+    case (Expire /= never) andalso (Diff > (Expire * 1000))  of
         true -> clear_tree(S);
         false -> S
     end;


### PR DESCRIPTION
More AAE ports from basho/riak_kv#765.
- Allow use of `never` for value of `anti_entropy_expire` to indicate
  that trees should never expire automatically (they can still be
  expired manually).
- Clear any pending AAE exchanges when switching from automatic to
  manual mode. Active exchanges will be allowed to finish. The reason
  for clearing pending exchanges is because manual mode is about
  letting the user control what exchanges happen and thus all pending
  automatic exchanges should be dropped.
- Modify AAE trees to delay clearing trees up until the moment before
  rebuild. Thus when trees expire they are eligible for exchange up
  until the moment they are rebuilt. This is a big improvement from
  before which would immediately clear (delete) the tree upon
  expiration and could mean hours or days of time before that tree
  could be exchanged again thus creating a window of no AAE.
- Add ability to manually expire all trees at once via
  `yz_entropy_mgr:expire_trees/0`. This may be useful in a production
  scenario where the trees are no longer trusted but you still want to
  be able to exchange before they are rebuilt. It may also be useful
  for testing.
- Add a test to verify that trees can still be exchanged while they
  are expired but before they are rebuilt.
