### PR TITLE
Update previous hash during event tick + general refactoring

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -127,6 +127,16 @@
 
 -define(DATA_DIR, application:get_env(riak_core, platform_data_dir)).
 
+
+-define(MAYBE(Check, Expression, Default),
+        case Check of
+            true -> Expression;
+            false -> Default
+        end).
+
+-define(MAYBE(Check, Expression),
+        ?MAYBE(Check, Expression, ok)).
+
 %% Core security requires `{BucketType, Bucket}'. Technically, these
 %% arent so strict, and so we refer to them as `{Resource,
 %% SubResource}' where `Resource' is a resource like index or schema

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -35,13 +35,15 @@
          terminate/2]).
 -include("yokozuna.hrl").
 
+-define(NUM_TICKS_START, 1).
+
 -record(state, {
           %% The number of ticks since the last time this value was
-          %% reset to 0. This value along with
+          %% reset to 1. This value along with
           %% `get_full_check_after/0' is used to determine when a
           %% "full check" should be performed. This is to prevent
           %% expensive checks occurring on every tick.
-          num_ticks = 0                 :: non_neg_integer(),
+          num_ticks = ?NUM_TICKS_START  :: non_neg_integer(),
 
           %% The hash of the index cluster meta last time it was
           %% checked.
@@ -74,7 +76,7 @@ handle_info(tick, S) ->
     PrevHash = S#state.prev_index_hash,
     CurrHash = riak_core_metadata:prefix_hash(?YZ_META_INDEXES),
     NumTicks = S#state.num_ticks,
-    FullCheck = NumTicks == 0,
+    FullCheck = (NumTicks == ?NUM_TICKS_START),
 
     case yz_solr:is_up() of
         true ->
@@ -157,7 +159,7 @@ get_tick_interval() ->
 -spec incr_or_wrap(non_neg_integer(), non_neg_integer()) -> non_neg_integer().
 incr_or_wrap(N, M) ->
     case N == M of
-        true -> 0;
+        true -> ?NUM_TICKS_START;
         false -> N + 1
     end.
 

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -94,7 +94,9 @@ handle_info(tick, S) ->
     ok = set_tick(),
 
     NumTicks2 = incr_or_wrap(NumTicks, get_full_check_after()),
-    {noreply, S#state{num_ticks=NumTicks2}}.
+    S2 = S#state{num_ticks=NumTicks2,
+                 prev_index_hash=CurrHash},
+    {noreply, S2}.
 
 handle_call(Req, _, S) ->
     ?WARN("unexpected request ~p", [Req]),


### PR DESCRIPTION
Currently `yz_events:sync_indexes` is called on every tick because the previous hash is not being updated. I noticed this when investigating #304.
- Sync indexes IFF full check or hash has changed.
- Fix off-by-one error in full check.
- Add `MAYBE` macro for tighter code.

This can be verified by using redbug to verify `sync_indexes` is called every 60 seconds.

```
> redbug:start("yz_events:sync_indexes -> return", [{time, 180000}]).
```
