### PR TITLE
Don't require the 'text' field

### DIFF
--- a/priv/conf/solrconfig.xml
+++ b/priv/conf/solrconfig.xml
@@ -531,13 +531,9 @@
        queries across multiple shards
     -->
   <requestHandler name="/select" class="solr.SearchHandler">
-    <!-- default values for query parameters can be specified, these
-         will be overridden by parameters in the request
-      -->
      <lst name="defaults">
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
-       <str name="df">text</str>
      </lst>
      <!-- Custom Yokozuna component to translate custom shard filter
           queries. -->
@@ -684,20 +680,11 @@
      </requestHandler>
     -->
 
-  <!-- ping/healthcheck -->
+  <!-- Used by Yokozuna to determine if an index is available. -->
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
     <lst name="invariants">
-      <str name="q">solrpingquery</str>
+      <str name="q">_yz_id:ping_query</str>
     </lst>
-    <lst name="defaults">
-      <str name="echoParams">all</str>
-    </lst>
-    <!-- An optional feature of the PingRequestHandler is to configure the
-         handler with a "healthcheckFile" which can be used to enable/disable
-         the PingRequestHandler.
-         relative paths are resolved against the data dir
-      -->
-    <!-- <str name="healthcheckFile">server-enabled.txt</str> -->
   </requestHandler>
 
   <searchComponent name="fq_shard_translator"


### PR DESCRIPTION
The fact that the `text` field was being set as `df` by the select handler was just artifact of copying Solr example and not paying close enough attention. This removes that mapping so the user must either explicitly use a field for every term or pass the `df` request parameter.
- Use `_yz_id` for the ping handler.
- Remove `df` default from select handler.
- Update basho bench driver.
- Update migration test.

This is related to #306.
