### PR TITLE
Verify schema version

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -110,6 +110,8 @@
 %%% Macros
 %%%===================================================================
 
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+
 -define(IF(Expression, Action),
         if Expression -> Action, ok;
            true -> ok

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -8,7 +8,6 @@
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
 -define(NO_BODY, <<>>).
 -define(CFG,

--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -9,7 +9,6 @@
 -type interfaces() :: [interface()].
 -type conn_info() :: [{node(), interfaces()}].
 
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
 -define(NO_BODY, <<>>).
 -define(CFG,

--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -9,7 +9,6 @@
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 -include("yokozuna.hrl").
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 
 -type host() :: string().
 -type portnum() :: integer().

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -6,7 +6,6 @@
 -include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
 -include("yokozuna.hrl").
 
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
 -define(NO_BODY, <<>>).
 -define(CFG, [{yokozuna, [{enabled, true}]}]).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -2,7 +2,6 @@
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 -include("yokozuna.hrl").
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(YZ_RT_ETS, yz_rt_ets).
 -define(YZ_RT_ETS_OPTS, [public, named_table, {write_concurrency, true}]).
 

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -187,6 +187,42 @@
 </types>
 </schema>">>).
 
+-define(BAD_VSN_SCHEMA,
+        <<"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<schema name=\"test\" version=\"1.0\">
+<fields>
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" />
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+</fields>
+
+ <uniqueKey>_yz_id</uniqueKey>
+
+<types>
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
+
 
 confirm() ->
     Cluster = rt:build_cluster(4, ?CFG),
@@ -202,6 +238,7 @@ confirm() ->
     confirm_bad_yz_field(Cluster, <<"bad_yz_field">>, ?BAD_YZ_FIELD_SCHEMA),
     confirm_default_schema(Cluster, <<"default">>, default_schema(Cluster)),
     confirm_bad_schema(Cluster),
+    confirm_bad_vsn(Cluster, <<"bad_vsn_attr">>, ?BAD_VSN_SCHEMA),
     pass.
 
 %% @doc Confirm a custom schema may be added.
@@ -276,6 +313,16 @@ confirm_bad_uk(Cluster, Name, RawSchema) ->
 confirm_bad_yz_field(Cluster, Name, RawSchema) ->
     HP = select_random(host_entries(rt:connection_info(Cluster))),
     lager:info("confirm_bad_yz_field ~s [~p]", [Name, HP]),
+    URL = schema_url(HP, Name),
+    Headers = [{"content-type", "application/xml"}],
+    {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),
+    ?assertEqual("400", Status),
+    ?assert(size(Body) > 0).
+
+%% @doc Confirm a bad version attribute returns 400.
+confirm_bad_vsn(Cluster, Name, RawSchema) ->
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    lager:info("confirm bad version attribute is rejected ~s [~p]", [Name, HP]),
     URL = schema_url(HP, Name),
     Headers = [{"content-type", "application/xml"}],
     {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -5,7 +5,6 @@
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(NO_HEADERS, []).
 -define(NO_BODY, <<>>).
 -define(CFG, [{yokozuna, [{enabled, true}]}]).
@@ -283,8 +282,8 @@ confirm_truncated(Cluster, Name, RawSchema) ->
     lager:info("confirm_truncated ~s [~p]", [Name, HP]),
     URL = schema_url(HP, Name),
     Headers = [{"content-type", "application/xml"}],
-    {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),
-    ?assertEqual("400", Status),
+    {ok, "400", _, Body} = http(put, URL, Headers, RawSchema),
+    %% ?assertEqual("400", Status),
     %% assert the body contains some kind of msg as to why the schema
     %% failed to parse
     ?assert(size(Body) > 0).

--- a/riak_test/yz_wm_extract_test.erl
+++ b/riak_test/yz_wm_extract_test.erl
@@ -5,7 +5,6 @@
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(CFG,
 	[
 	 {riak_core,

--- a/src/yz_bucket_validator.erl
+++ b/src/yz_bucket_validator.erl
@@ -23,8 +23,6 @@
 -export([validate/4]).
 -include("yokozuna.hrl").
 
--define(FMT(S, Args), list_to_binary(lists:flatten(io_lib:format(S, Args)))).
-
 -type prop() :: {PropName::atom(), PropValue::any()}.
 -type error() :: {PropName::atom(), ErrorReason::atom()}.
 -type props() :: [prop()].
@@ -67,7 +65,7 @@ validate_n_val(Index, INVal, BNVal, BucketProps) ->
         _ ->
             Error = ?FMT("Bucket n_val ~p must match the associated "
                          "search_index ~s n_val ~p", [BNVal,Index,INVal]),
-            {proplists:delete(n_val, BucketProps), [{n_val, Error}]}
+            {proplists:delete(n_val, BucketProps), [{n_val, list_to_binary(Error)}]}
     end.
 
 %% @private
@@ -82,7 +80,7 @@ get_search_index_info(Props) ->
         Index ->
             case yz_index:exists(Index) of
                 false ->
-                    {error, ?FMT("~s does not exist", [Index])};
+                    {error, list_to_binary(?FMT("~s does not exist", [Index]))};
                 true ->
                     {Index, index_n_val(Index)}
             end

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -75,7 +75,7 @@ process(#rpbyokozunaschemaputreq{
         ok  ->
             {reply, #rpbputresp{}, State};
         {error, Reason} ->
-            Msg = io_lib:format("Error storing schema ~p~n", [Reason]),
+            Msg = io_lib:format("Error storing schema ~s~n", [Reason]),
             {error, Msg, State}
     end;
 

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -24,6 +24,7 @@
 -compile(export_all).
 
 -define(SCHEMA_VSN, "1.5").
+-type schema_err() :: {error, string()}.
 
 %% @doc Administration of schemas.
 
@@ -50,7 +51,7 @@ get(Name) ->
     end.
 
 %% @doc Store the `RawSchema' with `Name'.
--spec store(schema_name(), raw_schema()) -> ok | {error, term()}.
+-spec store(schema_name(), raw_schema()) -> ok | schema_err().
 store(Name, RawSchema) when is_binary(RawSchema) ->
     case parse_and_verify(RawSchema) of
         {ok, RawSchema} ->
@@ -82,7 +83,7 @@ setup_schema_bucket() ->
 %% @private
 %%
 %% @doc Parse the schema and verify it contains necessary elements.
--spec parse_and_verify(raw_schema()) -> {ok, raw_schema()} | {error, term()}.
+-spec parse_and_verify(raw_schema()) -> {ok, raw_schema()} | schema_err().
 parse_and_verify(RawSchema) ->
     try
         %% TODO: should this use unicode?
@@ -94,12 +95,13 @@ parse_and_verify(RawSchema) ->
                 Err
         end
     catch exit:Reason ->
-            {error, Reason}
+            Msg = ?FMT("failed to parse ~p", [Reason]),
+            {error, Msg}
     end.
 
 %% @doc Verify the `Schema' contains all necessary configuration for
 %%      Yokozuna to function properly.
--spec verify(schema()) -> {ok, schema()} | {error, term()}.
+-spec verify(schema()) -> {ok, schema()} | schema_err().
 verify(Schema) ->
     verify_fts(verify_fields(verify_vsn(verify_uk(Schema)))).
 
@@ -107,7 +109,7 @@ verify(Schema) ->
 %%
 %% @doc Verify the the schema 'version' attribute is set to correct
 %% value.
--spec verify_vsn({ok, schema()} | {error, term()}) -> {ok, schema()} | {error, term()}.
+-spec verify_vsn({ok, schema()} | schema_err()) -> {ok, schema()} | schema_err().
 verify_vsn({ok, Schema}) ->
     case xmerl_xpath:string("string(/schema/@version)", Schema) of
         {xmlObj, string, ?SCHEMA_VSN} ->
@@ -121,7 +123,7 @@ verify_vsn({error, _}=Err) ->
 %% @private
 %%
 %% @doc Verify the `uniqueKey' element is correct.
--spec verify_uk(schema()) -> {ok, schema()} | {error, term()}.
+-spec verify_uk(schema()) -> {ok, schema()} | schema_err().
 verify_uk(Schema) ->
     case xmerl_xpath:string("/schema/uniqueKey/text()", Schema) of
         [#xmlText{value="_yz_id"}] ->
@@ -133,8 +135,8 @@ verify_uk(Schema) ->
 %% @private
 %%
 %% @doc Verify the necessary fields are present with correct attributes.
--spec verify_fields({ok, schema()} | {error, term()}) ->
-                           {ok, schema()} | {error, term()}.
+-spec verify_fields({ok, schema()} | schema_err()) ->
+                           {ok, schema()} | schema_err().
 verify_fields({ok, Schema}) ->
     Fields = [?YZ_ID_FIELD_XPATH,
               ?YZ_ED_FIELD_XPATH,
@@ -151,17 +153,18 @@ verify_fields({ok, Schema}) ->
         [] ->
             {ok, Schema};
         Errs ->
-            {error, {missing_fields, Errs}}
+            ErrMsg = string:join([Msg || {error, Msg} <- Errs], "\n"),
+            {error, ErrMsg}
     end;
 verify_fields({error, _}=Err) ->
     Err.
 
 %% @private
--spec verify_field(string(), schema()) -> ok | {error, term()}.
+-spec verify_field(string(), schema()) -> ok | {error, string()}.
 verify_field(Path, Schema) ->
     case xmerl_xpath:string(Path, Schema) of
         [] ->
-            {error, {missing_field, Path}};
+            {error, "missing field " ++ Path};
         _ ->
             ok
     end.
@@ -170,12 +173,12 @@ verify_field(Path, Schema) ->
 %%
 %% @doc Verify the necessary field types are present with correct
 %%      attributes.
--spec verify_fts({ok, schema()} | {error, term()}) ->
-                        {ok, schema()} | {error, term()}.
+-spec verify_fts({ok, schema()} | schema_err()) ->
+                        {ok, schema()} | schema_err().
 verify_fts({ok, Schema}) ->
     case xmerl_xpath:string(?YZ_STR_FT_XPATH, Schema) of
         [] ->
-            {error, {missing_field_type, ?YZ_STR_FT_XPATH}};
+            {error, "missing field type " ++ ?YZ_STR_FT_XPATH};
         _ ->
             {ok, Schema}
     end;

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -31,7 +31,6 @@
 -define(DEFAULT_URL, "http://localhost:8983/solr").
 -define(DEFAULT_VCLOCK_N, 1000).
 -define(QUERY(Str), {struct, [{'query', Str}]}).
--define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 
 %% @doc This module provides the interface for making calls to Solr.
 %%      All interaction with Solr should go through this API.

--- a/src/yz_wm_schema.erl
+++ b/src/yz_wm_schema.erl
@@ -132,7 +132,7 @@ store_schema(RD, S) ->
         ok  ->
             {true, RD, S};
         {error, Reason} ->
-            Msg = io_lib:format("Error storing schema ~p~n", [Reason]),
+            Msg = io_lib:format("Error storing schema: ~s~n", [Reason]),
             RD2 = wrq:append_to_response_body(Msg, RD),
             RD3 = wrq:set_resp_header("Content-Type", "text/plain", RD2),
             {{halt,400}, RD3, S}


### PR DESCRIPTION
This patch verifies that the schema version is set to `1.5` and is the
second part of enhancements for issues #321. There was also
supplemental work done around error messages so that they would
display in a more user friendly manner.

Result of uploading schema with wrong version:

```
# curl -i -X PUT -H 'content-type: application/xml' 'http://localhost:10018/search/schema/bad_version' --data-binary @/root/bad-version-schema.xml
HTTP/1.1 100 Continue

HTTP/1.1 400 Bad Request
Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
Date: Tue, 25 Feb 2014 21:08:06 GMT
Content-Type: text/plain
Content-Length: 61

Error storing schema: schema 'version' attribute must be 1.5
```

Attempting to store schema with missing fields (yes, the x-path is
ugly but this is still an improvement from raw erlang terms):

```
# curl -i -X PUT -H 'content-type: application/xml' 'http://localhost:10018/search/schema/bad_version' --data-binary @/root/missing-fields-schema.xml
HTTP/1.1 100 Continue

HTTP/1.1 400 Bad Request
Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
Date: Tue, 25 Feb 2014 21:08:59 GMT
Content-Type: text/plain
Content-Length: 205

Error storing schema: missing field /schema/fields/field[@name="_yz_fpn" and @type="_yz_str" and @indexed="true"]
missing field /schema/fields/field[@name="_yz_pn" and @type="_yz_str" and @indexed="true"]
```

Attempting to store a truncated schema:

```
# curl -i -X PUT -H 'content-type: application/xml' 'http://localhost:10018/search/schema/bad_version' --data-binary @/root/truncated-schema.xml
HTTP/1.1 100 Continue

HTTP/1.1 400 Bad Request
Server: MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)
Date: Tue, 25 Feb 2014 21:10:52 GMT
Content-Type: text/plain
Content-Length: 203

Error storing schema: failed to parse {fatal,
                    {unexpected_end,
                        {file,file_name_unknown},
                        {line,161},
                        {col,1}}}
```
