### PR TITLE
Disallow bad schema or index names

### DIFF
--- a/riak_test/yz_index_admin.erl
+++ b/riak_test/yz_index_admin.erl
@@ -102,6 +102,7 @@ confirm() ->
     confirm_create_index_1(Cluster),
     confirm_create_index_2(Cluster),
     confirm_409(Cluster),
+    confirm_bad_name(Cluster),
     confirm_bad_n_val(Cluster),
     confirm_list(Cluster, [<<"test_index_1">>, <<"test_index_2">>, <<"test_index_409">>]),
     confirm_delete(Cluster, <<"test_index_1">>),
@@ -129,6 +130,17 @@ confirm_bad_n_val(Cluster) ->
     {ok, Status2, _, _} = http(put, URL, Headers, Body2),
     ?assertEqual("400", Status2),
 
+    ok.
+
+%% @doc Verify that a bad index name is rejected.
+confirm_bad_name(Cluster) ->
+    Index = <<"bad%2Fname">>,
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    URL = index_url(HP, Index),
+    Headers = [{"content-type", "application/json"}],
+    lager:info("verify name \"bad/name\" is not accepted [~p]", [HP]),
+    {ok, Status1, _, _} = http(put, URL, Headers, <<"{}">>),
+    ?assertEqual("400", Status1),
     ok.
 
 %% @doc Test basic creation, no body.

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -35,9 +35,9 @@ confirm() ->
     Cluster = rt:build_cluster(4, ?CFG),
     rt:wait_for_cluster_service(Cluster, yokozuna),
     confirm_admin_schema(Cluster),
-    confirm_admin_bad_schema_name(Cluster, <<"bad/name">>),
+    confirm_admin_bad_schema_name(Cluster),
     confirm_admin_index(Cluster),
-    confirm_admin_bad_index_name(Cluster, <<"bad/name">>),
+    confirm_admin_bad_index_name(Cluster),
     confirm_basic_search(Cluster),
     confirm_encoded_search(Cluster),
     confirm_multivalued_field(Cluster),
@@ -131,7 +131,7 @@ confirm_admin_schema(Cluster) ->
     riakc_pb_socket:stop(Pid),
     ok.
 
-confirm_admin_bad_schema_name(Cluster, Name) ->
+confirm_admin_bad_schema_name(Cluster) ->
     Name = <<"bad/name">>,
     Node = select_random(Cluster),
     {Host, Port} = yz_rt:riak_pb(hd(rt:connection_info([Node]))),
@@ -160,7 +160,8 @@ confirm_admin_index(Cluster) ->
     riakc_pb_socket:stop(Pid),
     ok.
 
-confirm_admin_bad_index_name(Cluster, Name) ->
+confirm_admin_bad_index_name(Cluster) ->
+    Name = <<"bad/name">>,
     Node = select_random(Cluster),
     [{Host, Port}] = host_entries(rt:connection_info([Node])),
     lager:info("confirm_admin_bad_index_name ~s [~p]", [Name, {Host, Port}]),

--- a/riak_test/yz_schema_admin.erl
+++ b/riak_test/yz_schema_admin.erl
@@ -238,6 +238,7 @@ confirm() ->
     confirm_default_schema(Cluster, <<"default">>, default_schema(Cluster)),
     confirm_bad_schema(Cluster),
     confirm_bad_vsn(Cluster, <<"bad_vsn_attr">>, ?BAD_VSN_SCHEMA),
+    confirm_bad_name(Cluster, <<"bad%2Fname">>, ?TEST_SCHEMA),
     pass.
 
 %% @doc Confirm a custom schema may be added.
@@ -322,6 +323,16 @@ confirm_bad_yz_field(Cluster, Name, RawSchema) ->
 confirm_bad_vsn(Cluster, Name, RawSchema) ->
     HP = select_random(host_entries(rt:connection_info(Cluster))),
     lager:info("confirm bad version attribute is rejected ~s [~p]", [Name, HP]),
+    URL = schema_url(HP, Name),
+    Headers = [{"content-type", "application/xml"}],
+    {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),
+    ?assertEqual("400", Status),
+    ?assert(size(Body) > 0).
+
+%% @doc Confirm a bad schema name returns 400.
+confirm_bad_name(Cluster, Name, RawSchema) ->
+    HP = select_random(host_entries(rt:connection_info(Cluster))),
+    lager:info("confirm schema name is rejected ~s [~p]", [Name, HP]),
     URL = schema_url(HP, Name),
     Headers = [{"content-type", "application/xml"}],
     {ok, Status, _, Body} = http(put, URL, Headers, RawSchema),

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -114,7 +114,9 @@ process(#rpbyokozunaindexputreq{
         ok ->
             {reply, #rpbputresp{}, State};
         {error, schema_not_found} ->
-            {error, "Schema not found", State}
+            {error, "Schema not found", State};
+        {error, invalid_name} ->
+            {error, "Invalid character '/' in index name", State}
     end;
 
 process(rpbyokozunaindexgetreq, State) ->
@@ -140,7 +142,8 @@ process_stream(_,_,State) ->
 %% ---------------------------------
 
 -spec maybe_create_index(binary(), schema_name(), n()) -> ok |
-                                                     {error, schema_not_found}.
+                                                    {error, invalid_name} |
+                                                    {error, schema_not_found}.
 maybe_create_index(IndexName, SchemaName, Nval)->
     case yz_index:exists(IndexName) of
         true  ->

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -99,7 +99,7 @@ init(_Props) ->
 service_available(RD, Ctx=#ctx{}) ->
     IndexName = case wrq:path_info(index, RD) of
                     undefined -> undefined;
-                    V -> list_to_binary(V)
+                    V -> list_to_binary(mochiweb_util:unquote(V))
                 end,
     {true,
      RD,
@@ -193,7 +193,10 @@ create_index(RD, S) ->
             text_response({halt, 500}, Msg, [SchemaName], RD, S);
         {error, bad_n_val} ->
             Msg = "Bad n_val given ~p~n",
-            text_response({halt, 400}, Msg, [NVal], RD, S)
+            text_response({halt, 400}, Msg, [NVal], RD, S);
+        {error, invalid_name} ->
+            Msg = "Invalid character '/' in index name ~s~n",
+            text_response({halt, 400}, Msg, [IndexName], RD, S)
     end.
 
 
@@ -297,7 +300,8 @@ index_body(IndexName) ->
 -spec maybe_create_index(index_name(), schema_name(), n()) ->
                                 ok |
                                 {error, schema_not_found} |
-                                {error, bad_n_val}.
+                                {error, bad_n_val} |
+                                {error, invalid_name}.
 maybe_create_index(IndexName, SchemaName, NVal)->
     case exists(IndexName) of
         true  ->

--- a/src/yz_wm_schema.erl
+++ b/src/yz_wm_schema.erl
@@ -65,7 +65,7 @@ service_available(RD, Ctx=#ctx{}) ->
         RD,
         Ctx#ctx{
             method=wrq:method(RD),
-            schema_name=wrq:path_info(schema, RD)}
+            schema_name=mochiweb_util:unquote(wrq:path_info(schema, RD))}
     }.
 
 allowed_methods(RD, S) ->


### PR DESCRIPTION
Currently, yz allows names that contain a `/` char, which breaks things terribly when yz and solr attempt to create corresponding files/directories. Disallow it.
