### PR TITLE
Pass JVM opts

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -156,7 +156,6 @@
 -define(YZ_COVER_TICK_INTERVAL, app_helper:get_env(?YZ_APP_NAME, cover_tick, 2000)).
 -define(YZ_DEFAULT_SOLR_PORT, 8983).
 -define(YZ_DEFAULT_SOLR_STARTUP_WAIT, 30).
--define(YZ_DEFAULT_SOLR_JVM_ARGS, "").
 %% TODO: See if using mochiglobal for this makes difference in performance.
 -define(YZ_ENABLED, app_helper:get_env(?YZ_APP_NAME, enabled, false)).
 -define(YZ_ROOT_DIR, app_helper:get_env(?YZ_APP_NAME, root_dir,

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -31,9 +31,9 @@
 
 %% @doc The options to pass to the Solr JVM.  Non-standard options,
 %% i.e. -XX, may not be portable across JVM implementations.
-%% E.g. -XX:+UseCompressedStrings.
+%% E.g. -XX:+UseCompressedStrings
 {mapping, "search.solr.jvm_options", "yokozuna.solr_jvm_opts", [
-  {default, "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
+  {default, "-d64 -Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"}
 ]}.
 
 %% @doc The directory where Search's Active Anti-Entropy data files

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -45,6 +45,7 @@
                         solr_port=_SolrPort,
                         solr_jmx_port=_SolrJMXPort}).
 -define(S_PORT(S), S#state.port).
+-define(YZ_DEFAULT_SOLR_JVM_OPTS, "").
 
 %% @doc This module/process is responsible for administrating the
 %%      external Solr/JVM OS process.
@@ -197,7 +198,7 @@ build_cmd(JavaPath, SolrPort, SolrJMXPort, Dir) ->
     end,
 
     Args = [Headless, JettyHome, Port, SolrHome, CP, CP2, Logging, LibDir]
-        ++ string:tokens(solr_jvm_args(), " ") ++ JMX ++ [Class],
+        ++ string:tokens(solr_jvm_opts(), " ") ++ JMX ++ [Class],
     {JavaPath, Args}.
 
 %% @private
@@ -262,8 +263,8 @@ solr_startup_wait() ->
                        ?YZ_DEFAULT_SOLR_STARTUP_WAIT).
 
 %% @private
--spec solr_jvm_args() -> string().
-solr_jvm_args() ->
+-spec solr_jvm_opts() -> string().
+solr_jvm_opts() ->
     app_helper:get_env(?YZ_APP_NAME,
-                       solr_jvm_args,
-                       ?YZ_DEFAULT_SOLR_JVM_ARGS).
+                       solr_jvm_opts,
+                       ?YZ_DEFAULT_SOLR_JVM_OPTS).

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -15,7 +15,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_port", 12345),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jmx_port", 54321),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_jvm_opts",
-                                  "-Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"),
+                                  "-d64 -Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops"),
     cuttlefish_unit:assert_config(Config, "yokozuna.anti_entropy_data_dir",
                                   "./data/yolo/yz_anti_entropy"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "./data/yolo/yz"),


### PR DESCRIPTION
- Fix bug where options were not being passed to JVM.
- Add `-d64` option.

See commit messages for more detail.
