### PR TITLE
Add coding statement to files using utf8 chars

### DIFF
--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -1,3 +1,4 @@
+%% -*- coding: utf-8 -*-
 %% @doc Test the index adminstration API in various ways.
 -module(yz_languages).
 -compile(export_all).

--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -68,7 +68,8 @@ store_and_search(Cluster, Bucket, Index, Headers, CT, Body, Field, Term) ->
     {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body),
     %% Sleep for soft commit
     timer:sleep(1000),
-    {ok, "200", _, Body} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
+    {ok, "200", _, ReturnedBody} = ibrowse:send_req(URL, [{"accept", CT}], get, []),
+    ?assertEqual(Body, list_to_binary(ReturnedBody)),
     lager:info("Verify values are indexed"),
     ?assert(yz_rt:search_expect(HP, Index, Field, Term, 1)),
     ok.
@@ -77,22 +78,22 @@ confirm_body_search_encoding(Cluster) ->
     Index = <<"test_iso_8859_8">>,
     Bucket = {Index, <<"b">>},
     lager:info("confirm_iso_8859_8 ~s", [Index]),
-    Body = "א בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ",
+    Body = <<"א בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ"/utf8>>,
     store_and_search(Cluster, Bucket, Index, "text/plain", Body, "text", "בָּרָא").
 
 confirm_language_field_type(Cluster) ->
     Index = <<"test_shift_jis">>,
     Bucket = {Index, <<"b">>},
     lager:info("confirm_shift_jis ~s", [Index]),
-    Body = "{\"text_ja\" : \"私はハイビスカスを食べるのが 大好き\"}",
+    Body = <<"{\"text_ja\" : \"私はハイビスカスを食べるのが 大好き\"}"/utf8>>,
     store_and_search(Cluster, Bucket, Index, "application/json", Body, "text_ja", "大好き").
 
 confirm_tag_encoding(Cluster) ->
     Index = <<"test_iso_8859_6">>,
     Bucket = {Index, <<"b">>},
     lager:info("confirm_iso_8859_6 ~s", [Index]),
-    Body = "أردت أن أقرأ كتابا عن تاريخ المرأة في فرنسا",
+    Body = <<"أردت أن أقرأ كتابا عن تاريخ المرأة في فرنسا"/utf8>>,
     Headers = [{"Content-Type", "text/plain"},
                {"x-riak-meta-yz-tags", "x-riak-meta-arabic_s"},
-               {"x-riak-meta-arabic_s", "أقرأ"}],
+               {"x-riak-meta-arabic_s", <<"أقرأ"/utf8>>}],
     store_and_search(Cluster, Bucket, Index, Headers, "text/plain", Body, "arabic_s", "أقرأ").

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -215,8 +215,8 @@ search(Type, {Host, Port}, Index, Name, Term) when is_integer(Port) ->
     search(Type, {Host, integer_to_list(Port)}, Index, Name, Term);
 
 search(Type, {Host, Port}, Index, Name0, Term0) ->
-    Name = mochiweb_util:quote_plus(Name0),
-    Term = mochiweb_util:quote_plus(Term0),
+    Name = quote_unicode(Name0),
+    Term = quote_unicode(Term0),
     FmtStr = case Type of
                  solr ->
                      "http://~s:~s/solr/~s/select?q=~s:~s&wt=json";
@@ -227,6 +227,9 @@ search(Type, {Host, Port}, Index, Name0, Term0) ->
     lager:info("Run search ~s", [URL]),
     Opts = [{response_format, binary}],
     ibrowse:send_req(URL, [], get, [], Opts).
+
+quote_unicode(Value) ->
+    mochiweb_util:quote_plus(binary_to_list(unicode:characters_to_binary(Value))).
 
 select_random(List) ->
     Length = length(List),

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -1,3 +1,4 @@
+%% -*- coding: utf-8 -*-
 -module(yz_xml_extractor_tests).
 -compile(export_all).
 -include_lib("yz_test.hrl").

--- a/test/yz_xml_extractor_tests.erl
+++ b/test/yz_xml_extractor_tests.erl
@@ -29,43 +29,43 @@ utf8_test() ->
         [{<<"langs.english">>, <<"The quick brown fox jumps over the lazy dog.">>},
          {<<"langs.english@attr">>, <<"The quick">>},
          {<<"langs.jamaican">>, <<"Chruu, a kwik di kwik brong fox a jomp huova di liezi daag de, yu no siit?">>},
-         {<<"langs.irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\"">>},
-         {<<"langs.dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct.">>},
-         {<<"langs.german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.">>},
-         {<<"langs.german_1@attr">>, <<"Falsches Üben">>},
-         {<<"langs.german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon.">>},
-         {<<"langs.norwegian">>, <<"Blåbærsyltetøy.">>},
-         {<<"langs.danish">>, <<"Høj bly gom vandt fræk sexquiz på wc.">>},
-         {<<"langs.swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor.">>},
-         {<<"langs.icelandic">>, <<"Sævör grét áðan því úlpan var ónýt.">>},
-         {<<"langs.finnish">>, <<"Törkylempijävongahdus.">>},
-         {<<"langs.polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig.">>},
-         {<<"langs.czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy.">>},
-         {<<"langs.slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote.">>},
-         {<<"langs.greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία">>},
-         {<<"langs.greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία">>},
-         {<<"langs.russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю.">>},
-         {<<"langs.bulgarian">>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.">>},
-         {<<"langs.sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža.">>},
-         {<<"langs.hungarian">>, <<"Árvíztűrő tükörfúrógép.">>},
-         {<<"langs.spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.">>},
-         {<<"langs.portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico.">>},
-         {<<"langs.french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés.">>},
-         {<<"langs.esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde.">>},
-         {<<"langs.hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן.">>},
+         {<<"langs.irish">>, <<"\"An ḃfuil do ċroí ag bualaḋ ó ḟaitíos an ġrá a ṁeall lena ṗóg éada ó ṡlí do leasa ṫú?\" \"D'ḟuascail Íosa Úrṁac na hÓiġe Beannaiṫe pór Éava agus Áḋaiṁ.\""/utf8>>},
+         {<<"langs.dutch">>, <<"Pa's wĳze lynx bezag vroom het fikse aquaduct."/utf8>>},
+         {<<"langs.german_1">>, <<"Falsches Üben von Xylophonmusik quält jeden größeren Zwerg."/utf8>>},
+         {<<"langs.german_1@attr">>, <<"Falsches Üben"/utf8>>},
+         {<<"langs.german_2">>, <<"Im finſteren Jagdſchloß am offenen Felsquellwaſſer patzte der affig-flatterhafte kauzig-höf‌liche Bäcker über ſeinem verſifften kniffligen C-Xylophon."/utf8>>},
+         {<<"langs.norwegian">>, <<"Blåbærsyltetøy."/utf8>>},
+         {<<"langs.danish">>, <<"Høj bly gom vandt fræk sexquiz på wc."/utf8>>},
+         {<<"langs.swedish">>, <<"Flygande bäckasiner söka strax hwila på mjuka tuvor."/utf8>>},
+         {<<"langs.icelandic">>, <<"Sævör grét áðan því úlpan var ónýt."/utf8>>},
+         {<<"langs.finnish">>, <<"Törkylempijävongahdus."/utf8>>},
+         {<<"langs.polish">>, <<"Pchnąć w tę łódź jeża lub osiem skrzyń fig."/utf8>>},
+         {<<"langs.czech">>, <<"Příliš žluťoučký kůň úpěl ďábelské kódy."/utf8>>},
+         {<<"langs.slovak">>, <<"Starý kôň na hŕbe kníh žuje tíško povädnuté ruže, na stĺpe sa ďateľ učí kvákať novú ódu o živote."/utf8>>},
+         {<<"langs.greek_monotonic">>, <<"ξεσκεπάζω την ψυχοφθόρα βδελυγμία"/utf8>>},
+         {<<"langs.greek_polytonic">>, <<"ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία"/utf8>>},
+         {<<"langs.russian">>, <<"Съешь же ещё этих мягких французских булок да выпей чаю."/utf8>>},
+         {<<"langs.bulgarian"/utf8>>, <<"Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон."/utf8>>},
+         {<<"langs.sami">>, <<"Vuol Ruoŧa geđggiid leat máŋga luosa ja čuovžža."/utf8>>},
+         {<<"langs.hungarian">>, <<"Árvíztűrő tükörfúrógép."/utf8>>},
+         {<<"langs.spanish">>, <<"El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro."/utf8>>},
+         {<<"langs.portuguese">>, <<"O próximo vôo à noite sobre o Atlântico, põe freqüentemente o único médico."/utf8>>},
+         {<<"langs.french">>, <<"Les naïfs ægithales hâtifs pondant à Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés."/utf8>>},
+         {<<"langs.esperanto">>, <<"Eĥoŝanĝo ĉiuĵaŭde."/utf8>>},
+         {<<"langs.hebrew">>, <<"זה כיף סתם לשמוע איך תנצח קרפד עץ טוב בגן."/utf8>>},
          {<<"langs.japanese_hiragana">>, <<"
     いろはにほへど　ちりぬるを
     わがよたれぞ　つねならむ
     うゐのおくやま　けふこえて
     あさきゆめみじ　ゑひもせず
-  ">>},
+  "/utf8>>},
         {<<"langs.japanese_kanji">>, <<"
     色は匂へど 散りぬるを
     我が世誰ぞ 常ならむ
     有為の奥山 今日越えて
     浅き夢見じ 酔ひもせず
-  ">>},
-         {<<"langs.английский">>, <<"The quick brown fox jumps over the lazy dog.">>},
+  "/utf8>>},
+         {<<"langs.английский"/utf8>>, <<"The quick brown fox jumps over the lazy dog.">>},
          {<<"langs.chinese">>, <<"
     花非花
     雾非雾
@@ -73,9 +73,9 @@ utf8_test() ->
     天明去
     来如春梦几多时
     去似朝云无觅处
-  ">>},
-        {<<"langs.chinese@作者">>, <<"Bai Juyi">>},
-        {<<"langs.chinese@title">>, <<"The Bloom is not a Bloom">>}],
+  "/utf8>>},
+        {<<"langs.chinese@作者"/utf8>>, <<"Bai Juyi">>},
+        {<<"langs.chinese@title"/utf8>>, <<"The Bloom is not a Bloom">>}],
     ?assertEqual(length(Expect), length(Result)),
     Pairs = lists:zip(lists:keysort(1, Expect), lists:keysort(1, Result)),
     [?assertPairsEq(E,R) || {E,R} <- Pairs],


### PR DESCRIPTION
Noticed by @macintux, two of our test files didn't follow the http://www.erlang.org/doc/apps/stdlib/unicode_usage.html guideline for defining utf8 encoding.
