### PR TITLE
Security commands no longer require capital keywords

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -165,8 +165,6 @@ Applied permissions
 +----------+----------+----------------------------------------+
 ```
 
-Note that `ON` and `TO` must be capitalized.
-
 Next is `eric` who can admin everything but only query his personal
 index.
 


### PR DESCRIPTION
See basho/riak#513.
