### PR TITLE
Add switch-to-new-search command

### DIFF
--- a/src/yz_console.erl
+++ b/src/yz_console.erl
@@ -19,7 +19,8 @@
 %% -------------------------------------------------------------------
 -module(yz_console).
 -include("yokozuna.hrl").
--export([aae_status/1]).
+-export([aae_status/1,
+         switch_to_new_search/1]).
 
 %% @doc Print the Active Anti-Entropy status to stdout.
 -spec aae_status([]) -> ok.
@@ -32,3 +33,21 @@ aae_status([]) ->
     io:format("~n"),
     riak_kv_console:aae_repair_status(ExchangeInfo),
     ok.
+
+%% @doc Switch over HTTP solr route and PB handling from legacy
+%% riak_search to yokozuna. This will multicall to all nodes in the
+%% cluster. If any nodes are down report them to stderr and return an
+%% error tuple. Once the switch is made the system cannot be switched
+%% back without restarting the cluster.
+-spec switch_to_new_search([]) -> ok | {error, {nodes_down, [node()]}}.
+switch_to_new_search([]) ->
+    {_Good, Down} = riak_core_util:rpc_every_member_ann(yokozuna, switch_to_yokozuna, [], 5000),
+    case Down of
+        [] ->
+            ok;
+        _ ->
+            Down2 = [atom_to_list(Node) || Node <- Down],
+            DownStr = string:join(Down2, " "),
+            io:format(standard_error, "The following nodes could not be reached: ~s", [DownStr]),
+            {error, {nodes_down, Down}}
+    end.


### PR DESCRIPTION
Add the switch-to-new-search command under the search command. This is
used when migrating from legacy riak_search to yokozuna. It does a
multicall across the cluster handing over HTTP and PB control from
riak_search to yokozuna.

This is needed for #20.
## Test Instructions

Create a devrel.

Enabled search on all nodes:

```
sed -e 's/search = off/search = on/' -i.bak dev/dev*/etc/riak.conf
```

Enable legacy riak_search on all nodes. First create advanced.config file.

```
[
 {riak_search, [{enabled, true}]}
].
```

Then copy to all nodes.

```
for d in dev/dev*; do cp -v ~/advanced.config $d/etc/; done
```

Start 3 nodes.

```
for d in dev/dev{1,2,3}; do $d/bin/riak start; done
```

Create a 3 node cluster.

```
for d in dev/dev{2,3}; do $d/bin/riak-admin cluster join dev1@127.0.0.1; done
./dev/dev1/bin/riak-admin cluster plan
./dev/dev1/bin/riak-admin cluster commit
```

Wait for transfers to finish.

```
./dev/dev1/bin/riak-admin transfers
```

Attach to console and verify that legacy riak_search controls the HTTP
and PB services.

```
(dev1@127.0.0.1)2> {Res, []} = rpc:multicall(webmachine_router, get_routes, []).
{[[{["search","schema",schema],yz_wm_schema,[]},
   {["search","index"],yz_wm_index,[]},
...
(dev1@127.0.0.1)3> [lists:keyfind(["solr",index,"select"], 1, R) || R <- Res].
[{["solr",index,"select"],riak_solr_searcher_wm,[]},
 {["solr",index,"select"],riak_solr_searcher_wm,[]},
 {["solr",index,"select"],riak_solr_searcher_wm,[]}]
(dev1@127.0.0.1)7> rpc:multicall(riak_api_pb_registrar, lookup, [27]).
{[{ok,riak_search_pb_query},
  {ok,riak_search_pb_query},
  {ok,riak_search_pb_query}],
 []}
(dev1@127.0.0.1)8> rpc:multicall(riak_api_pb_registrar, lookup, [28]).
{[{ok,riak_search_pb_query},
  {ok,riak_search_pb_query},
  {ok,riak_search_pb_query}],
 []}
```

Switch to new search (Yokozuna).

```
./dev/dev1/bin/riak-admin search switch-to-new-search
```

Attach to console and verify that Yokozuna controls HTTP and PB
services.

```
(dev1@127.0.0.1)9> {Res2, []} = rpc:multicall(webmachine_router, get_routes, []).
{[[{["solr",index,"select"],yz_wm_search,[]},
...
(dev1@127.0.0.1)10> [lists:keyfind(["solr",index,"select"], 1, R) || R <- Res2].  
[{["solr",index,"select"],yz_wm_search,[]},
 {["solr",index,"select"],yz_wm_search,[]},
 {["solr",index,"select"],yz_wm_search,[]}]
(dev1@127.0.0.1)11> rpc:multicall(riak_api_pb_registrar, lookup, [27]).           
{[{ok,yz_pb_search},{ok,yz_pb_search},{ok,yz_pb_search}],[]}
(dev1@127.0.0.1)12> rpc:multicall(riak_api_pb_registrar, lookup, [28]).           
{[{ok,yz_pb_search},{ok,yz_pb_search},{ok,yz_pb_search}],[]}
```
