### PR TITLE
Remove logging of ops sent to Solr when indexing fails.

### DIFF
--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -171,7 +171,7 @@ index(Core, Docs, DelOps) ->
     Opts = [{response_format, binary}],
     case ibrowse:send_req(URL, Headers, post, JSON, Opts) of
         {ok, "200", _, _} -> ok;
-        Err -> throw({"Failed to index docs", Ops, Err})
+        Err -> throw({"Failed to index docs", Err})
     end.
 
 %% @doc Determine if Solr is running.


### PR DESCRIPTION
If the doc being logged is too large, lager will truncate it, leaving no indication why the actual index failure occurred. Remove the logging of it.

Issue:

https://github.com/basho/yokozuna/issues/352
