### PR TITLE
Normalize riak_test execution process

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,69 +6,44 @@ Testing
 Riak Test is a tool for running integration tests against a Riak
 cluster.  See the [Riak Test README][rt_readme] for more details.
 
-### Build a Riak/Yokozuna devrel
+Follow the instructions in the [Riak Test README][rt_readme] to build
+a `devrel` release and set it up for testing with riak_test.
 
-Make a directory to build the devrel.
+### Add Yokozuna Config
 
-    mkdir ~/testing
-    cd testing
+Open `~/.riak_test.config` and add the following to the configuration
+stanza to be used for yokozuna testing:
 
-The rest is like the [Yokozuna Getting Started][yz_gs] guide but
-checkout riak as `riak_yz`.  Don't start the cluster.  Just build the
-devrel.
+    {basho_bench, "<path-to-basho_bench-repo>"},
+    {yz_dir, "<path-to-yokozuna-repo>"},
 
-    git clone git://github.com/basho/riak.git riak_yz
-    cd riak_yz
-    make stagedevrel
+This will result in a configuration stanza similar to the following:
 
-### Setup rtdev
+    {rtdev, [
+             {basho_bench, "<path-to-basho_bench-repo>"},
+             {yz_dir, "<path-to-yokozuna-repo>"},
+             {rt_project, "riak"},
+             {rt_harness, rtdev},
+             {rtdev_path, [{root,     "/home/you/rt/riak"},
+                           {current,  "/home/you/rt/riak/current"},
+                           {previous, "/home/you/rt/riak/riak-1.3.2"},
+                           {legacy,   "/home/you/rt/riak/riak-1.2.1"}
+                          ]}
 
-This step will create `/tmp/rt` which is specifically setup for Riak
-Test.  It provides the ability to easily rollback the cluster to a
-fresh state.
+            ]}.
 
-    cd ~/testing
-    ./riak_yz/deps/riak_test/bin/rtdev-setup-releases.sh
-
-### Compile Yokozuna Riak Test
+### Compile Yokozuna Riak Test Files
 
     cd <path-to-yokozuna>
     make compile-riak-test
 
 At this point you should see `.beam` files in `riak_test/ebin`.
 
-### Compile Yokozuna Bench Files
-
-    cd <path-to-yokozuna>/misc/bench
-    ../../rebar get-deps
-    ../../rebar compile
-    (cd deps/basho_bench && make)
-
-### Add Yokozuna Config
-
-Open `~/.riak_test.config` and add the following to the end.
-
-
-    {yokozuna, [
-                {rt_project, "yokozuna"},
-                {rt_deps, ["<path-to-testing-dir>/riak_yz/deps"]},
-                {yz_dir, ["<path-to-testing-dir>/riak_yz/deps/yokozuna"]},
-                {rtdev_path, [{root, "/tmp/rt"},
-                              {current, "/tmp/rt/riak_yz"}]}
-               ]}.
-
 ### Run the Test
-
-The `YZ_BENCH_DIR` is needed so Riak Test can find the files to drive
-Basho Bench.
-
-    export YZ_BENCH_DIR=<path/to/yokozuna/home>/misc/bench
 
 Finally, run the test.
 
-    cd <path-to-yokozuna>
-    <path-to-riak-test>/riak_test -c yokozuna -d riak_test/ebin | tee rt.out
+    cd <path-to-riak_test-repo>
+    ./riak_test -c rtdev -d <path-to-yokozuna-repo>/riak_test/ebin/ | tee rt.out
 
 [rt_readme]: https://github.com/basho/riak_test/blob/master/README.md
-
-[yz_gs]: https://github.com/rzezeski/yokozuna#getting-started

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,8 +6,18 @@ Testing
 Riak Test is a tool for running integration tests against a Riak
 cluster.  See the [Riak Test README][rt_readme] for more details.
 
+Clone the riak_test repo with the following command:
+
+    git clone https://github.com/basho/riak_test
+
 Follow the instructions in the [Riak Test README][rt_readme] to build
 a `devrel` release and set it up for testing with riak_test.
+
+To successfully run all of the riak_test tests for yokozuna the
+basho_bench benchmarking tool is also required. Clone the basho_bench
+repo with the following command before running the tests:
+
+    git clone https://github.com/basho/basho_bench
 
 ### Add Yokozuna Config
 

--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -43,7 +43,7 @@
           ]},
          {yokozuna,
           [
-	   {enabled, true},
+          {enabled, true},
 
            %% Perform a full check every second so that non-owned
            %% postings are deleted promptly. This makes sure that
@@ -54,33 +54,38 @@
         ]).
 
 confirm() ->
-    YZBenchDir = rt_config:get(yz_dir) ++ "/misc/bench",
-    code:add_path(filename:join([YZBenchDir, "ebin"])),
-    random:seed(now()),
-    Nodes = rt:deploy_nodes(4, ?CFG),
-    Cluster = join(Nodes, 2),
-    PBConns = yz_rt:open_pb_conns(Cluster),
-    wait_for_joins(Cluster),
-    rt:wait_for_cluster_service(Cluster, yokozuna),
-    setup_indexing(Cluster, PBConns, YZBenchDir),
-    verify_non_existent_index(Cluster, <<"froot">>),
-    {0, _} = yz_rt:load_data(Cluster, ?BUCKET, YZBenchDir, ?NUM_KEYS),
-    %% wait for soft-commit
-    timer:sleep(1000),
-    Ref = async_query(Cluster, YZBenchDir),
-    %% Verify data exists before running join
-    timer:sleep(10000),
-    Cluster2 = join_rest(Cluster, Nodes),
-    rt:wait_for_cluster_service(Cluster2, yokozuna),
-    check_status(wait_for(Ref)),
-    verify_non_owned_data_deleted(Cluster, ?INDEX),
-    ok = test_tagging(Cluster),
-    KeysDeleted = delete_some_data(Cluster2, reap_sleep()),
-    verify_deletes(Cluster2, KeysDeleted, YZBenchDir),
-    ok = test_escaped_key(Cluster2),
-    verify_unique_id(Cluster2, PBConns),
-    yz_rt:close_pb_conns(PBConns),
-    pass.
+    case yz_rt:bb_driver_setup() of
+        {ok, YZBenchDir} ->
+            random:seed(now()),
+            Nodes = rt:deploy_nodes(4, ?CFG),
+            Cluster = join(Nodes, 2),
+            PBConns = yz_rt:open_pb_conns(Cluster),
+            wait_for_joins(Cluster),
+            rt:wait_for_cluster_service(Cluster, yokozuna),
+            setup_indexing(Cluster, PBConns, YZBenchDir),
+            verify_non_existent_index(Cluster, <<"froot">>),
+            {0, _} = yz_rt:load_data(Cluster, ?BUCKET, YZBenchDir, ?NUM_KEYS),
+            %% wait for soft-commit
+            timer:sleep(1000),
+            Ref = async_query(Cluster, YZBenchDir),
+            %% Verify data exists before running join
+            timer:sleep(30000),
+            Cluster2 = join_rest(Cluster, Nodes),
+            rt:wait_for_cluster_service(Cluster2, yokozuna),
+            check_status(wait_for(Ref)),
+            verify_non_owned_data_deleted(Cluster, ?INDEX),
+            ok = test_tagging(Cluster),
+            KeysDeleted = delete_some_data(Cluster2, reap_sleep()),
+            verify_deletes(Cluster2, KeysDeleted, YZBenchDir),
+            ok = test_escaped_key(Cluster2),
+            verify_unique_id(Cluster2, PBConns),
+            yz_rt:close_pb_conns(PBConns),
+            pass;
+        {error, bb_driver_build_failed} ->
+            lager:info("Failed to build the yokozuna basho_bench driver"
+                       " required for this test"),
+            fail
+    end.
 
 %% @doc Verify that indexes for non-owned data have been
 %% deleted. I.e. after a node performs ownership handoff to a joining

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -147,7 +147,7 @@ load_data(Cluster, Bucket, YZBenchDir, NumKeys) ->
     Hosts = host_entries(rt:connection_info(Cluster)),
     KeyGen = {function, yz_driver, fruit_key_val_gen, [NumKeys]},
     Cfg = [{mode,max},
-           {duration,5},
+           {duration,7},
            {concurrent, 3},
            {code_paths, [YZBenchDir]},
            {driver, yz_driver},

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -67,7 +67,7 @@ confirm() ->
     application:start(public_key),
     application:start(ssl),
     application:start(ibrowse),
-    PrivDir = rt_priv_dir(),
+    PrivDir = rt:priv_dir(),
     lager:info("r_t priv: ~p", [PrivDir]),
     CertDir = get_cert_dir(),
     make_certs:rootCA(CertDir, "rootCA"),
@@ -85,13 +85,6 @@ confirm() ->
     create_user(Node, ?HUSER),
     confirm_index_https(Node),
     pass.
-
-%% this is a similar duplicate riak_test fix as rt:priv_dir
-%% otherwise rt:priv_dir() will point to yz's priv
-rt_priv_dir() ->
-    re:replace(code:priv_dir(riak_test),
-        "riak_test(/riak_test)*", "riak_test", [{return, list}]).
-
 
 enable_https(Node) ->
     {Host, Port} = proplists:get_value(http, connection_info(Node)),
@@ -231,7 +224,9 @@ confirm_index_https(Node) ->
     {Host, Port} = proplists:get_value(https, connection_info(Node)),
 
     lager:info("verifying the peer certificate should work if the cert is valid"),
+
     Cacertfile = ?ROOT_CERT(get_cert_dir()),
+
     lager:info("Cacertfile: ~p", [Cacertfile]),
     Opts = [{is_ssl, true}, {ssl_options, [
              {cacertfile, Cacertfile},


### PR DESCRIPTION
Currently the execution of the riak_test modules for yokozuna relies on some specific setup assumption contained in the `tools/verify.sh` script. The focus of this issue is to bring the execution of the yokozuna tests inline with way other riak_tests are executed. This seems appropriate now that yokozuna is a part of riak proper. This will make it easier for people to get the tests up and running and facilitate the testing of yokozuna features in concert with other riak features.

My initial thoughts of the things needed are as follows: 
- [x] Remove requirement of extra step to build the yokozuna basho_bench driver prior to executing riak_test modules.
- [x] Change the expectation for where the `yz_security` test looks for the cert file. 
- [x] Update basho_bench setup and expectations to break the reliance on `verify.sh` and `misc/bench` in the yokozuna repo
- [x] Update the TESTING.md document to reflect the new procedures to run riak_test with yokozuna

There may be other items or hurdles that crop up, but this issue is to represent the exploratory work to attempt this.

cc: @engelsanchez 
