### PR TITLE
Add support for pulling down dependencies via curl

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,6 +71,11 @@ Download using wget.
     wget http://s3.amazonaws.com/files.basho.com/yokozuna/pkgs/riak-yokozuna-0.14.0-src.tar.gz
     wget http://s3.amazonaws.com/files.basho.com/yokozuna/pkgs/riak-yokozuna-0.14.0-src.tar.gz.sha1
 
+Download using curl.
+
+    curl -O http://s3.amazonaws.com/files.basho.com/yokozuna/pkgs/riak-yokozuna-0.14.0-src.tar.gz
+    curl -O http://s3.amazonaws.com/files.basho.com/yokozuna/pkgs/riak-yokozuna-0.14.0-src.tar.gz.sha1
+
 Verify the sha1 (might need to use `sha1sum`).
 
     shasum -a1 -c riak-yokozuna-0.14.0-src.tar.gz.sha1 riak-yokozuna-0.14.0-src.tar.gz

--- a/tools/build-solr.sh
+++ b/tools/build-solr.sh
@@ -97,8 +97,10 @@ else
     SOLR_FILE=$(basename $URL)
     SOLR_DIR=${SOLR_FILE%-src.tgz}
 
-    if test ! -e $SOLR_FILE; then
+    if which wget > /dev/null && test ! -e $SOLR_FILE; then
         wget $URL
+    elif which curl > /dev/null && test ! -e $SOLR_FILE; then
+        curl -O $URL
     fi
 
     if test ! -e $SOLR_DIR; then

--- a/tools/build-solr.sh
+++ b/tools/build-solr.sh
@@ -33,6 +33,15 @@ apply_patches()
     fi
 }
 
+download()
+{
+    if which wget > /dev/null; then
+        wget --no-check-certificate --progress=dot:mega $1
+    elif which curl > /dev/null; then
+        curl --insecure --progress-bar -O $1
+    fi
+}
+
 IS_GIT=0
 PATCH_DIR=""
 while test $# -gt 0
@@ -97,10 +106,8 @@ else
     SOLR_FILE=$(basename $URL)
     SOLR_DIR=${SOLR_FILE%-src.tgz}
 
-    if which wget > /dev/null && test ! -e $SOLR_FILE; then
-        wget $URL
-    elif which curl > /dev/null && test ! -e $SOLR_FILE; then
-        curl -O $URL
+    if test ! -e $SOLR_FILE; then
+        download $URL
     fi
 
     if test ! -e $SOLR_DIR; then

--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -32,6 +32,15 @@ check_for_solr()
     test -e $SOLR_DIR/start.jar
 }
 
+download()
+{
+    if which wget > /dev/null; then
+        wget --no-check-certificate --progress=dot:mega $1
+    elif which curl > /dev/null; then
+        curl --insecure --progress-bar -O $1
+    fi
+}
+
 get_solr()
 {
         if [[ -z ${SOLR_PKG_DIR+x} ]]
@@ -41,7 +50,7 @@ get_solr()
                 ln -s $TMP_FILE $FILENAME
             else
                 echo "Pulling Solr from S3"
-                wget --no-check-certificate --progress=dot:mega http://s3.amazonaws.com/files.basho.com/solr/$FILENAME
+                download "http://s3.amazonaws.com/files.basho.com/solr/$FILENAME"
                 if [ -d $TMP_DIR ]; then
                     cp $FILENAME $TMP_DIR
                 else
@@ -110,7 +119,7 @@ then
     fi
 
     echo "Downloading $YZ_JAR_NAME"
-    wget --no-check-certificate --progress=dot:mega http://s3.amazonaws.com/files.basho.com/yokozuna/$YZ_JAR_NAME
+    download "http://s3.amazonaws.com/files.basho.com/yokozuna/$YZ_JAR_NAME"
     mv $YZ_JAR_NAME $JAVA_LIB/$YZ_JAR_NAME
 fi
 
@@ -121,6 +130,6 @@ MON_JAR_NAME=yz_monitor-$MON_JAR_VSN.jar
 if [ ! -e $EXT_LIB/$MON_JAR_NAME ]
 then
     echo "Downloading $MON_JAR_NAME"
-    wget --no-check-certificate --progress=dot:mega http://s3.amazonaws.com/files.basho.com/yokozuna/$MON_JAR_NAME
+    download "http://s3.amazonaws.com/files.basho.com/yokozuna/$MON_JAR_NAME"
     mv $MON_JAR_NAME $EXT_LIB/$MON_JAR_NAME
 fi

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -96,8 +96,8 @@ function sanity_check()
         error "Apache Ant 1.8.2 or greater required"
     fi
 
-    if ! which wget > /dev/null; then
-        error "wget is required"
+    if ! which wget > /dev/null && ! which curl > /dev/null; then
+        error "wget or curl is required"
     fi
 
     if ! which make > /dev/null; then


### PR DESCRIPTION
OS X doesn't have `wget` installed by default. Despite the fact that most of us have figured out a way to install it, I'd like to add support for `curl` so that we can make one less inconvenience for those who don't have `wget` installed.
