### PR TITLE
Security "bucket" is a 2-tuple of binary

### DIFF
--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -82,7 +82,7 @@ resource_forbidden(RD, Ctx, _Perm, {_Resource, undefined}) ->
 resource_forbidden(RD, Ctx=#ctx{security=Security}, Permission,
                    {Resource, Subresource}) ->
     Res = riak_core_security:check_permission(
-            {Permission, {Resource, mochiweb_util:unquote(Subresource)}},
+            {Permission, {Resource, list_to_binary(mochiweb_util:unquote(Subresource))}},
             Security
            ),
     case Res of


### PR DESCRIPTION
The security API expects the "bucket" param to be a `{binary(),
binary()}`.  I quote the word bucket because security is actually
broader than buckets but the misnomer remains.

This fixes the following dialyzer error:

```
yz_wm_search.erl:84: The call
riak_core_security:check_permission({_,{_,[any()]}},Security::any())
breaks the contract (Permission::permission(),Context::context()) ->
{'true',context()} | {'false',binary(),context()}
```

This is in reaction to riak_core commit
19be73ab706e3aadbda82047d19f07f0ffc43fe7.
