### PR TITLE
Constrain index names to ASCII to duck latin-1/UTF-8 conflicts

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -262,7 +262,8 @@ schema_name(Info) ->
 %%      UTF-8 support is available
 -spec verify_name(index_name()) -> {ok, index_name()} | {error, invalid_name}.
 verify_name(Name) ->
-    case lists:dropwhile(fun(X) -> X < 128 end, Name) =:= "" of
+    case lists:dropwhile(fun(X) -> X < 128 end,
+                         binary_to_list(Name)) =:= "" of
         true ->
             case re:run(Name, "/", []) of
                 nomatch ->   {ok, Name};

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -56,7 +56,7 @@ create(Name) ->
     create(Name, ?YZ_DEFAULT_SCHEMA_NAME).
 
 %% @see create/3
--spec create(index_name(), schema_name()) -> 
+-spec create(index_name(), schema_name()) ->
                     ok |
                     {error, schema_not_found} |
                     {error, invalid_name}.
@@ -262,7 +262,7 @@ schema_name(Info) ->
 %%      UTF-8 support is available
 -spec verify_name(index_name()) -> {ok, index_name()} | {error, invalid_name}.
 verify_name(Name) ->
-    case lists:dropwhile(fun(X) -> X < 128 end,
+    case lists:dropwhile(fun(X) -> X < 128 andalso X > 31 end,
                          binary_to_list(Name)) =:= "" of
         true ->
             case re:run(Name, "/", []) of

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -258,12 +258,18 @@ schema_name(Info) ->
     Info#index_info.schema_name.
 
 %% @doc Verify that the index is a name that Solr can use. Some chars
-%%      are invalid, namely "/".
+%%      are invalid, namely "/" or non-ascii characters until full
+%%      UTF-8 support is available
 -spec verify_name(index_name()) -> {ok, index_name()} | {error, invalid_name}.
 verify_name(Name) ->
-    case re:run(Name, "/", []) of
-        nomatch ->   {ok, Name};
-        {match,_} -> {error, invalid_name}
+    case lists:dropwhile(fun(X) -> X < 128 end, Name) =:= "" of
+        true ->
+            case re:run(Name, "/", []) of
+                nomatch ->   {ok, Name};
+                {match,_} -> {error, invalid_name}
+            end;
+        false ->
+            {error, invalid_name}
     end.
 
 %%%===================================================================

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -195,7 +195,7 @@ create_index(RD, S) ->
             Msg = "Bad n_val given ~p~n",
             text_response({halt, 400}, Msg, [NVal], RD, S);
         {error, invalid_name} ->
-            Msg = "Invalid character '/' in index name ~s~n",
+            Msg = "Invalid character in index name ~s~n",
             text_response({halt, 400}, Msg, [IndexName], RD, S)
     end.
 

--- a/test/yz_misc_tests.erl
+++ b/test/yz_misc_tests.erl
@@ -56,3 +56,9 @@ should_copy_overwrite_test() ->
     ?assert(yz_misc:should_copy(overwrite, "<nofile>", "<nofile>")),
     ?assert(yz_misc:should_copy(overwrite, Thisfile, "<nofile>")).
 
+should_verify_name_test() ->
+    ?assertEqual({ok, <<"just-fine">>}, yz_index:verify_name(<<"just-fine">>)),
+    ?assertEqual({error, invalid_name}, yz_index:verify_name(<<"bad/slash">>)),
+    ?assertEqual({error, invalid_name}, yz_index:verify_name(<<"out-of-range-", 129>>)),
+    ?assertEqual({error, invalid_name}, yz_index:verify_name(<<"out-of-range-", 31>>)),
+    ?assertEqual({ok, <<"just-in-range- ">>}, yz_index:verify_name(<<"just-in-range-", 32>>)).


### PR DESCRIPTION
YOLOPR: no docs, no tests, not even any manual tests run other than compiling verify_name separately.

(I'll add tests to the PR before it's ready for final review. Or let someone who actually has touched YZ do so.)
