### PR TITLE
Fix sort param in `search_fold` to guarantee unique values

### DIFF
--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -41,12 +41,70 @@ confirm() ->
     yz_rt:wait_for_index(Cluster, Index),
     yz_rt:set_bucket_type_index(yz_rt:select_random(Cluster), Index),
     timer:sleep(500),
-    write_100_objs(Cluster, Bucket),
-    verify_100_objs_mr(Cluster, Index),
+    write_objs(Cluster, Bucket),
+    verify_objs_mr(Cluster, Index),
+    ok = yz_rt:load_module(Cluster, ?MODULE),
+    %% NOTE: Deliberate choice not to use `wait_unil'.  The data is
+    %% known to be indexed at this point; therefore the fold should
+    %% ALWAYS return the full unique set of results.
+    _ = [ok = verify_unique(Node, Index) || Node <- Cluster],
     pass.
 
--spec verify_100_objs_mr(list(), string()) -> ok.
-verify_100_objs_mr(Cluster, Index) ->
+%% @doc Verify `yokozuna:search_fold' returns the total set of unique
+%% results.  This check is related to issue #355.  Pagination can
+%% break depending on the `sort' parameter.
+%%
+%% https://github.com/basho/yokozuna/issues/355
+-spec verify_unique(node(), index_name()) -> ok.
+verify_unique(Node, Index) ->
+    lager:info("Verify search_fold on ~s returns entire unique result set",
+               [Node]),
+    Args = [Index, <<"name_s:yokozuna">>, <<"">>,
+            fun collect_results/2, {Index, []}],
+    {_, Results} = rpc:call(Node, yokozuna, search_fold, Args),
+    ?assertEqual(1000, length(lists:usort(Results))),
+    ok.
+
+%% @private
+%%
+%% @doc Collect the results from `yokozuna:search_fold'.  This
+%% function is running on a server process, not the riak test process.
+collect_results(_, {_, failed_to_change_query_plan}) ->
+    failed_to_change_query_plan;
+collect_results(Results, {Index, Acc}) ->
+    case change_query_plan(Index) of
+        ok ->
+            {Index, Acc ++ Results};
+        fail ->
+            {Index, failed_to_change_query_plan}
+    end.
+
+%% @private
+%%
+%% @doc Wait for the query plan to change.  This function runs on a
+%% server process, not the riak test process.
+-spec change_query_plan(index_name()) -> ok | fail.
+change_query_plan(Index) ->
+    change_query_plan(Index, 10).
+
+change_query_plan(_, 0) ->
+    fail;
+change_query_plan(Index, Num) ->
+    Plan1 = yz_cover:plan(Index),
+    gen_server:cast(yz_cover, update_all_plans),
+    %% NOTE: this sleep is here to give the server a chance to
+    %% update the cache, dont' remove it.
+    timer:sleep(500),
+    Plan2 = yz_cover:plan(Index),
+    case Plan1 /= Plan2 of
+        true ->
+            ok;
+        false ->
+            change_query_plan(Index, Num - 1)
+    end.
+
+-spec verify_objs_mr(list(), index_name()) -> ok.
+verify_objs_mr(Cluster, Index) ->
     MakeTick = [{map, [{language, <<"javascript">>},
                        {keep, false},
                        {source, <<"function(v) { return [1]; }">>}]}],
@@ -61,15 +119,15 @@ verify_100_objs_mr(Cluster, Index) ->
                 HP = hd(yz_rt:host_entries(rt:connection_info([Node]))),
                 A = hd(mochijson2:decode(http_mr(HP, MR))),
                 lager:info("Running map-reduce job on ~p", [Node]),
-                lager:info("E: 100, A: ~p", [A]),
-                100 == A
+                lager:info("E: 1000, A: ~p", [A]),
+                1000 == A
         end,
     yz_rt:wait_until(Cluster, F).
 
--spec write_100_objs([node()], index_name()) -> ok.
-write_100_objs(Cluster, Bucket) ->
-    lager:info("Writing 100 objects"),
-    lists:foreach(write_obj(Cluster, Bucket), lists:seq(1,100)).
+-spec write_objs([node()], index_name()) -> ok.
+write_objs(Cluster, Bucket) ->
+    lager:info("Writing 1000 objects"),
+    lists:foreach(write_obj(Cluster, Bucket), lists:seq(1,1000)).
 
 -spec write_obj([node()], bucket()) -> fun().
 write_obj(Cluster, Bucket) ->

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -161,6 +161,17 @@ load_data(Cluster, Bucket, YZBenchDir, NumKeys) ->
     write_terms(File, Cfg),
     run_bb(sync, File).
 
+%% @doc Load the BEAM for `Module' across the `Nodes'.  This allows
+%% use of higher order functions, defined in a riak test module, on
+%% the Riak node.
+%%
+%% @see yz_mapreduce:collect_results/2
+-spec load_module([node()], module()) -> ok.
+load_module(Nodes, Module) ->
+    {Mod, Bin, File} = code:get_object_code(Module),
+    {_, []} = rpc:multicall(Nodes, code, load_binary, [Mod, File, Bin]),
+    ok.
+
 %% @doc Open a protobuff connection to each node and return the list
 %% of connections.
 %%

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -131,8 +131,9 @@ search_fold(Index, Query, Filter, F, Acc) ->
     Params = [{q, Query},
               {fq, Filter},
               {start, Start},
-              {rows, 10},
+              {rows, 100},
               {fl, <<?YZ_RT_FIELD_S,",",?YZ_RB_FIELD_S,",",?YZ_RK_FIELD_S>>},
+              {sort, <<?YZ_RT_FIELD_S," asc, ",?YZ_RB_FIELD_S," asc, ",?YZ_RK_FIELD_S," asc">>},
               {omitHeader, <<"true">>},
               {wt, <<"json">>}],
     {_, Body} = yz_solr:dist_search(Index, Params),
@@ -219,10 +220,10 @@ positions({struct,[X, Y, Z]}) ->
 search_fold([], _, _, _, _, _, _, _, Acc) ->
     Acc;
 search_fold(Results, Start, Params, Positions, Index, Query, Filter, F, Acc) ->
-    F(Results, Acc),
-    Start2 = Start + 10,
+    Acc2 = F(Results, Acc),
+    Start2 = Start + 100,
     Params2 = lists:keystore(start, 1, Params, {start, Start2}),
     {_, Body} = yz_solr:dist_search(Index, Params2),
     Docs = extract_docs(Body),
     E = extract_results(Docs, Positions),
-    search_fold(E, Start2, Params, Positions, Index, Query, Filter, F, Acc).
+    search_fold(E, Start2, Params, Positions, Index, Query, Filter, F, Acc2).


### PR DESCRIPTION
Fixes #356.

The sort parameter must be type/bucket/key, as described in issue
duplicate values.  Other modifications include:
- Make sure to pass the new accumulator after calling `F` in
  `search_fold/9`.
- Increase the page size to 100 so less HTTP requests are made.  This
  should result in lower latency.
- Modify `yz_mapreduce` to use 1000 keys so since the page size was
  increased to 100.
- Add a test case to `yz_mapreduce` to verify that all 1000 unique
  results are returned.
- Add `yz_rt:load_module/2` to be used for loading a module's BEAM
  onto a set of nodes.  This is needed by the new test to have the HOF
  passed to `search_fold` available on the server process.
