### PR TITLE
Update invalid_name msg in PB index create

### DIFF
--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -116,7 +116,7 @@ process(#rpbyokozunaindexputreq{
         {error, schema_not_found} ->
             {error, "Schema not found", State};
         {error, invalid_name} ->
-            {error, "Invalid character '/' in index name", State}
+            {error, "Invalid character in index name", State}
     end;
 
 process(rpbyokozunaindexgetreq, State) ->


### PR DESCRIPTION
@macintux You missed a spot in #381.

Recently there was a change to only allow ASCII chars in the index name.
This updates the PB interface error message when an index name is
invalid.  The HTTP resource was already updated in the original commit
bb44381.
