### PR TITLE
Change `/search/Index` to `/search/query/Index`

### DIFF
--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -98,7 +98,6 @@ Here are the contents of the `load-fruit.config`:
 {secure, false}.
 {bucket, {<<"data">>, <<"fruit">>}}.
 {index, <<"fruit">>}.
-{search_path, "/search/fruit"}.
 {pb_conns, [{"127.0.0.1", 10017},
             {"127.0.0.1", 10027},
             {"127.0.0.1", 10037},

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -315,7 +315,7 @@ both be searched at the same time but Ryan does have permission to
 search both in separate requests.
 
 ```
-% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/ryans_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/query/ryans_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 1,
@@ -332,7 +332,7 @@ search both in separate requests.
   }
 }
 
-% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/erics_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user ryan:ryan 'https://127.0.0.1:10012/search/query/erics_index?q=text:structure&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 0,
@@ -348,7 +348,7 @@ zero times in Eric's collection of Dijkstra. What if Eric wants to
 query for a word in both indexes?
 
 ```
-% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/erics_index?q=text:program&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/query/erics_index?q=text:program&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 1,
@@ -365,11 +365,11 @@ query for a word in both indexes?
   }
 }
 
-% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/ryans_index?q=text:program&wt=json&omitHeader=true'
+% curl -s -k --user eric:eric 'https://127.0.0.1:10012/search/query/ryans_index?q=text:program&wt=json&omitHeader=true'
 Permission denied: User 'eric' does not have'search.query' on {<<"index">>,
                                                                <<"ryans_index">>}
 
-% curl -s -k --user god:iruleudrool 'https://127.0.0.1:10012/search/ryans_index?q=text:program&wt=json&omitHeader=true' | jsonpp
+% curl -s -k --user god:iruleudrool 'https://127.0.0.1:10012/search/query/ryans_index?q=text:program&wt=json&omitHeader=true' | jsonpp
 {
   "response": {
     "numFound": 0,

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -273,7 +273,7 @@ search(Type, {Host, Port}, Index, Name0, Term0) ->
                  solr ->
                      "http://~s:~s/internal_solr/~s/select?q=~s:~s&wt=json";
                  yokozuna ->
-                     "http://~s:~s/search/~s?q=~s:~s&wt=json"
+                     "http://~s:~s/solr/~s/select?q=~s:~s&wt=json"
              end,
     URL = ?FMT(FmtStr, [Host, Port, Index, Name, Term]),
     lager:info("Run search ~s", [URL]),

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -34,7 +34,7 @@
 %% @doc Return the list of routes provided by this resource.
 -spec routes() -> [tuple()].
 routes() ->
-    Routes1 = [{["search", index], ?MODULE, []}],
+    Routes1 = [{["search", "query", index], ?MODULE, []}],
     case yz_rs_migration:is_riak_search_enabled() of
         false ->
             [{["solr", index, "select"], ?MODULE, []}|Routes1];


### PR DESCRIPTION
Fixes #383.

The routes for querying and index administration are ambiguous if
there is an index named `index`.  The user will not be able to query
because Yokozuna will interpret `GET /search/index?q=...` as a request
to the index admin resource.  This commit changes the query resource
to `/search/query/Index` so there is no ambiguity.
