### PR TITLE
Correctly set Jetty temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,15 @@
 deps
 ebin
 priv/java_lib
-priv/solr*
 priv/conf/lang
 priv/conf/*.txt
+priv/solr/etc/create-solrtest.keystore.sh
+priv/solr/etc/webdefault.xml
+priv/solr/lib
+priv/solr/resources
+priv/solr/start.jar
+priv/solr/webapps
+priv/solr/solr-webapp
 build/
 *.class
 *.tgz

--- a/priv/solr/contexts/solr-jetty-context.xml
+++ b/priv/solr/contexts/solr-jetty-context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath"><SystemProperty name="hostContext" default="/solr"/></Set>
+  <Set name="war"><SystemProperty name="jetty.home"/>/webapps/solr.war</Set>
+  <Set name="defaultsDescriptor"><SystemProperty name="jetty.home"/>/etc/webdefault.xml</Set>
+  <Set name="tempDirectory"><SystemProperty name="jetty.home" default="."/>/solr-webapp</Set>
+</Configure>

--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -89,7 +89,6 @@ then
     # which shouldn't be overwritten).  For whatever reason, cp -n causes
     # non-zero exit code when files that would have been overwritten are
     # detected.
-    cp -r $EXAMPLE_DIR/contexts $SOLR_DIR
     cp -r $EXAMPLE_DIR/etc/create-solrtest.keystore.sh $SOLR_DIR/etc
     cp -r $EXAMPLE_DIR/etc/webdefault.xml $SOLR_DIR/etc
     cp -r $EXAMPLE_DIR/lib $SOLR_DIR


### PR DESCRIPTION
Fixes #387.

A custom `solr-jetty-context.xml` must be used so that the
`tempDirectory` is set properly.  `jetty.home` is a system property,
not a regular property.
