### PR TITLE
Filter indexes that do not exist on Solr

### DIFF
--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -121,7 +121,8 @@ process(#rpbyokozunaindexputreq{
 
 process(rpbyokozunaindexgetreq, State) ->
     Indexes = yz_index:get_indexes_from_meta(),
-    Details = [index_details(IndexName) || IndexName <- Indexes],
+    Details = [index_details(IndexName)
+        || IndexName <- Indexes, yz_index:exists(IndexName)],
     {reply, #rpbyokozunaindexgetresp{index=Details}, State};
 
 process(#rpbyokozunaindexgetreq{name = IndexName}, State) ->

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -206,7 +206,8 @@ read_index(RD, S) ->
     case S#ctx.index_name of
         undefined  ->
             Indexes = yz_index:get_indexes_from_meta(),
-            Details = [index_body(IndexName) || IndexName <- Indexes];
+            Details = [index_body(IndexName)
+                || IndexName <- Indexes, yz_index:exists(IndexName)];
         IndexName ->
             Details = index_body(IndexName)
     end,


### PR DESCRIPTION
Fix issue #395

> If you create an index with a bad schema Solr will fail to create the core but the index will be listed if you perform GET /search/index (or equivalent PB msg). These two code paths should filter the metadata index list by checking for existence.
