### PR TITLE
When clearing a tree clear its stats too

### DIFF
--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -493,6 +493,7 @@ clear_tree(S=#state{index=Index}) ->
     S2 = destroy_trees(S),
     IndexN = riak_kv_util:responsible_preflists(Index),
     S3 = init_trees(IndexN, S2#state{trees=orddict:new()}),
+    ok = yz_kv:update_aae_tree_stats(Index, undefined),
     S3#state{built=false, expired=false}.
 
 destroy_trees(S) ->

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -274,7 +274,7 @@ update_aae_exchange_stats(Index, IndexN, Count) ->
     ok.
 
 %% @doc Update AAE hashtree status for Yokozuna.
--spec update_aae_tree_stats(p(), non_neg_integer()) -> ok.
+-spec update_aae_tree_stats(p(), non_neg_integer() | undefined) -> ok.
 update_aae_tree_stats(Index, BuildTime) ->
     riak_kv_entropy_info:tree_built(yz, Index, BuildTime),
     ok.


### PR DESCRIPTION
When a tree is cleared (erased from disk) the corresponding build
status should also be reset.  That is, the `riak-admin search
aae-status` command should display `--` for the last time the tree was
built since it is _not_ built.
