### PR TITLE
Fix failure with yz_dt_test due to a disable operation in a map

### DIFF
--- a/riak_test/yz_dt_test.erl
+++ b/riak_test/yz_dt_test.erl
@@ -102,7 +102,6 @@ map_update(PB) ->
                             fun(Reg) ->
                                     riakc_register:set(<<"Russell Brown">>, Reg)
                             end},
-                           {{<<"student">>, flag}, fun riakc_flag:disable/1},
                            {{<<"burgers">>, counter}, fun(C) -> riakc_counter:increment(100, C) end}]),
 
     Sean = lists:foldl(fun({Key, Fun}, Map) ->
@@ -133,7 +132,6 @@ map_update(PB) ->
 map_search(Solr) ->
     ?assertSearch(Solr, ?MAP, "burgers_counter", "*", 2),
     ?assertSearch(Solr, ?MAP, "burgers_counter", "[11 TO 1000]", 1),
-    ?assertSearch(Solr, ?MAP, "student_flag", "*", 2),
     ?assertSearch(Solr, ?MAP, "student_flag", "true", 1),
     ?assertSearch(Solr, ?MAP, "name_register", "S*", 2),
     ?assertSearch(Solr, ?MAP, "office_map.cats_counter", "1", 0),


### PR DESCRIPTION
It is currently invalid to disable a flag in a newly created map with
no context. The use of disable on a flag is only valid after the map
has been created, written to Riak, and read from Riak. The context is
then established and the operation is able to complete. The fix for
the test for right now is to remove the disable operation on the flag
for the "Russell" map in the test so that no invalid operation are
attempted.
