### PR TITLE
minimal reproduction of #417

### DIFF
--- a/riak_test/intercepts/yz_solr_intercepts.erl
+++ b/riak_test/intercepts/yz_solr_intercepts.erl
@@ -1,0 +1,6 @@
+-module(yz_solr_intercepts).
+-compile(export_all).
+
+slow_cores() ->
+    timer:sleep(6000),
+    {ok, []}.

--- a/riak_test/yz_handoff_blocking.erl
+++ b/riak_test/yz_handoff_blocking.erl
@@ -1,0 +1,41 @@
+%% @doc Verify yokozuna cannot block kv handoff forever
+-module(yz_handoff_blocking).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+-define(INDEX, <<"handoff_blocking">>).
+-define(CFG,
+        [{riak_core,
+          [
+           {ring_creation_size, 16}
+          ]},
+	 {yokozuna,
+	  [
+	   {enabled, true}
+	  ]}
+        ]).
+
+confirm() ->
+    [Node, Node2] = Cluster = rt:deploy_nodes(2, ?CFG),
+
+    %% create an index on one node and populate it with some data
+    yz_rt:create_index(Node, ?INDEX),
+    ok = yz_rt:wait_for_index([Node], ?INDEX),
+    ok = yz_rt:set_bucket_type_index(Node, ?INDEX),
+    ConnInfo = yz_rt:connection_info([Node]),
+    {Host, Port} = yz_rt:riak_http(proplists:get_value(Node, ConnInfo)),
+    URL = ?FMT("http://~s:~s/types/~s/buckets/~s/keys/~s",
+               [Host, integer_to_list(Port), ?INDEX, <<"bucket">>, <<"key">>]),
+    Headers = [{"content-type", "text/plain"}],
+    Body = <<"yokozuna">>,
+    {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body, []),
+
+    %% load and install the intercept
+    rt_intercept:load_code(Node2, [filename:join([rt_config:get(yz_dir), "riak_test", "intercepts", "*.erl"])]),
+    rt_intercept:add(Node2, {yz_solr, [{{cores,0}, slow_cores}]}),
+
+    %% join a node
+    rt:join_cluster(Cluster),
+    ok = rt:wait_until_no_pending_changes(Cluster),
+
+    pass.


### PR DESCRIPTION
write a single object to node A (with indexing setup), install
intercept to make yz_solr:cores/0 slow on node B and join B to node A.
wait until riak_test times out waiting for no pending changes (there
will always be one, because of the written object)

depends on https://github.com/basho/riak_test/pull/671
