### PR TITLE
prevent race condition on basho_bench run in yokozuna_essential by incre...

### DIFF
--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -29,6 +29,14 @@
            %% more quickly.
            {vnode_management_timer, 1000}
           ]},
+         {riak_kv,
+          [
+           %% Max number of times that a secondary system can block
+           %% handoff of primary key-value data.
+           %% Set to prevent a race-condition when propagating cluster
+           %% meta to newly joined nodes.
+           {handoff_rejected_max, infinity}
+          ]},
          {yokozuna,
           [
           {enabled, true},
@@ -229,7 +237,7 @@ verify_unique_id(Cluster, PBConns) ->
 make_query_fun(PBConns, Index, Query, Expected) ->
     fun() ->
             QueryRes = query_all(PBConns, Index, Query),
-            lists:all(fun(X) -> 
+            lists:all(fun(X) ->
                 lager:info("~p~n", [X]),
                 X == Expected end, QueryRes)
     end.


### PR DESCRIPTION
...asing maximum number of rejections
- Test was failing on 2.0.1 GiddyUp
- Fixes race between handoff and cluster metadata (as well as index propagation) as new nodes join the cluster in the `riak_tests/yokozuna_essential` test by raising the [`handoff.max_rejects`](https://github.com/basho/riak_kv/pull/1010/files#diff-6229b4a6ef6df06ebe5d6fb96c06610bR591) configuration for riak_kv.

Fix referenced from changes made on https://github.com/basho/riak_kv/pull/1010 and talking through things w/ @coderoshi, @jrwest, and @seancribbs.  
