### PR TITLE
Remove afunix from EXOMETER_PACKAGES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EXOMETER_PACKAGES = "(basic), +afunix"
+EXOMETER_PACKAGES = "(basic)"
 export EXOMETER_PACKAGES
 
 REBAR ?= $(shell pwd)/rebar


### PR DESCRIPTION
Afunix is not used at this time, and may cause build issues on some
platforms.
