### PR TITLE
Compile bb before misc/bench compile

### DIFF
--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -119,6 +119,14 @@ function compile_yz_bench()
         error "failed to get deps for yokozuna/misc/bench"
     fi
 
+    pushd deps/basho_bench
+
+    if ! make; then
+        error "failed to compile yokozuna/misc/bench/deps/basho_bench"
+    fi
+
+    popd
+
     if ! ../../rebar compile; then
         error "failed to compile yokozuna/misc/bench"
     fi


### PR DESCRIPTION
A change in basho_bench (basho/basho_bench@8fd27d3) now requires it be compiled before the rest of the bench code can be.
