### PR TITLE
add schema create add remove to cli-wip

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -89,6 +89,9 @@
 -type ring_event() :: {ring_event, riak_core_ring:riak_core_ring()}.
 -type event() :: ring_event().
 
+%% @doc
+-type schema_err() :: {error, string()}.
+
 %% @doc The `component()' type represents components that may be
 %%      enabled or disabled at runtime.  Typically a component is
 %%      disabled in a live, production cluster in order to isolate
@@ -105,7 +108,6 @@
 %%    action to manually index the missing data or wait for AAE to
 %%    take care of it.
 -type component() :: search | index.
-
 %%%===================================================================
 %%% Macros
 %%%===================================================================

--- a/src/yz_console.erl
+++ b/src/yz_console.erl
@@ -20,7 +20,11 @@
 -module(yz_console).
 -include("yokozuna.hrl").
 -export([aae_status/1,
-         switch_to_new_search/1]).
+         switch_to_new_search/1,
+         create_schema/1,
+         show_schema/1,
+         add_to_schema/1,
+         remove_from_schema/1]).
 
 %% @doc Print the Active Anti-Entropy status to stdout.
 -spec aae_status([]) -> ok.
@@ -50,4 +54,65 @@ switch_to_new_search([]) ->
             DownStr = string:join(Down2, " "),
             io:format(standard_error, "The following nodes could not be reached: ~s", [DownStr]),
             {error, {nodes_down, Down}}
+    end.
+
+%% @doc Creates (and overrides) schema for name and file path.
+-spec create_schema([string()|string()]) -> ok | schema_err().
+create_schema([Name, Path]) ->
+    try
+        RawSchema = read_schema(Path),
+        FMTName = list_to_atom(Name),
+        case yz_schema:store(list_to_binary(Name), RawSchema) of
+            ok ->
+                io:format("~p schema created~n", [FMTName]),
+                ok;
+            {error, _} ->
+                io:format("Error creating schema ~p", [FMTName]),
+                error
+        end
+    catch fileReadError:exitError ->
+           exitError
+    end.
+
+%% @doc Shows solr schema for name passed in.
+-spec show_schema([string()]) -> ok | schema_err().
+show_schema([Name]) ->
+    FMTName = list_to_atom(Name),
+    case yz_schema:get(list_to_binary(Name)) of
+        {ok, R} ->
+            io:format("Schema ~p:~n~s", [FMTName, binary_to_list(R)]),
+            ok;
+        {error, notfound} ->
+            io:format("Schema ~p doesn't exist~n", [FMTName]),
+            error
+    end.
+
+%% @doc
+-spec add_to_schema([string()|string()]) -> ok | schema_err().
+add_to_schema([Name|Opts]) ->
+    {Name, Opts}.
+
+%% @doc
+-spec remove_from_schema([string()|string()]) -> ok | schema_err().
+remove_from_schema([Name, FieldName]) ->
+    {Name, FieldName}.
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+%% @doc Reads and returns `RawSchema` from file path.
+-spec read_schema(string()) -> raw_schema() | schema_err().
+read_schema(Path) ->
+    AbsPath = filename:absname(Path),
+    case file:read_file(AbsPath) of
+        {ok, RawSchema} ->
+            RawSchema;
+        {error, enoent} ->
+            io:format("No such file or directory: ~s~n", [Path]),
+            throw({fileReadError, enoent});
+        {error, Reason} ->
+            ?ERROR("Error reading file ~s:~p", [Path, Reason]),
+            io:format("Error reading file ~s, see log for details~n", [Path]),
+            throw({fileReadError, Reason})
     end.

--- a/src/yz_console.erl
+++ b/src/yz_console.erl
@@ -192,8 +192,7 @@ merge(Overriding, Other) ->
 read_schema_test() ->
     {ok, CurrentDir} = file:get_cwd(),
     MissingSchema = CurrentDir ++ "/foo.xml",
-    GoodSchema = filename:join([?YZ_PRIV, "default_schema.xml"]),
-    GoodOutput = read_schema(GoodSchema),
+    GoodOutput = read_schema("../priv/default_schema.xml"),
     ?assertMatch({ok, _}, GoodOutput),
     {ok, RawSchema} = GoodOutput,
     ?assert(is_binary(RawSchema)),

--- a/src/yz_schema.erl
+++ b/src/yz_schema.erl
@@ -24,7 +24,6 @@
 -compile(export_all).
 
 -define(SCHEMA_VSN, "1.5").
--type schema_err() :: {error, string()}.
 
 %%%===================================================================
 %%% API


### PR DESCRIPTION
This PR adds to `yz_console` in order to give the user the ability to create/show solr schemas and add-to/remove-from these schemas (by schema-name) via the riak admin cli interface.

The add-to/remove-from actions are meant to interact with a  _schema update_  interface, passing in a _name_ (for the schema) and a _field_ tuple, which is related to the work @coderoshi is doing with https://bashoeng.atlassian.net/browse/RIAK-1173. 
- The riak-admin related work is currently located at https://github.com/basho/riak/pull/649. 
- The riak-test for console commands has been updated as well -> https://github.com/basho/riak_test/pull/707.

_Eventually_, we should use https://github.com/basho/riak_cli to w/ console, but, in time.
