### PR TITLE
Deal with a Solr Core / Riak Index metadata mismatch

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -197,7 +197,7 @@ local_create(Name) ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,
             ok;
-        {error, Reason} ->
+        {error, _Reason} ->
             lager:error("Couldn't create index ~s because the schema ~s isn't found",
                         [Name, SchemaName]),
             ok

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -197,12 +197,9 @@ local_create(Name) ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,
             ok;
-        {error, notfound} ->
+        {error, Reason} ->
             lager:error("Couldn't create index ~s because the schema ~s isn't found",
                         [Name, SchemaName]),
-            ok;
-        {error, Reason} ->
-            lager:error("Couldn't create index ~s: ~p", [Name, Reason]),
             ok
     end.
 

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -189,6 +189,11 @@ local_create(Name) ->
                     lager:info("Created index ~s with schema ~s",
                                [Name, SchemaName]),
                     ok;
+                {error, exists} ->
+                    lager:info("Index ~s already exists in Solr, "
+                               "but not in Riak metadata",
+                               [Name]),
+                    ok;
                 {error, Err} ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -192,8 +192,7 @@ local_create(Name) ->
                 {error, exists} ->
                     lager:info("Index ~s already exists in Solr, "
                                "but not in Riak metadata",
-                               [Name]),
-                    ok;
+                               [Name]);
                 {error, Err} ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -198,6 +198,10 @@ local_create(Name) ->
                     lager:error("Couldn't create index ~s: ~p", [Name, Err])
             end,
             ok;
+        {error, notfound} ->
+            lager:error("Couldn't create index ~s because the schema ~s isn't found",
+                        [Name, SchemaName]),
+            ok;
         {error, Reason} ->
             lager:error("Couldn't create index ~s: ~p", [Name, Reason]),
             ok

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -95,6 +95,13 @@ core(Action, Props, Timeout) ->
     case ibrowse:send_req(URL, [], get, [], Opts, Timeout) of
         {ok, "200", Headers, Body} ->
             {ok, Headers, Body};
+        {ok, "400", Headers, Body} ->
+            case re:run(Body, "already exists") of
+                nomatch ->
+                    {error, {ok, "400", Headers, Body}};
+                _ ->
+                    {error, exists}
+            end.
         X ->
             {error, X}
     end.

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -101,7 +101,7 @@ core(Action, Props, Timeout) ->
                     {error, {ok, "400", Headers, Body}};
                 _ ->
                     {error, exists}
-            end.
+            end;
         X ->
             {error, X}
     end.


### PR DESCRIPTION
Sometimes a solr core is successfully created, but the Riak index metadata isn't aware of it. This is an attempt to communicate, or potentially repair, a situation where these values are out of sync.

JIRA: RIAK-1455
