### PR TITLE
Handled missing maxScore value from Solr #447 [JIRA: RIAK-1498]

### DIFF
--- a/src/yz_pb_search.erl
+++ b/src/yz_pb_search.erl
@@ -84,7 +84,10 @@ maybe_process(true, #rpbsearchqueryreq{index=Index}=Msg, State) ->
 				R = mochijson2:decode(Body),
 				Resp = yz_solr:get_response(R),
 				Pairs = yz_solr:get_doc_pairs(Resp),
-				MaxScore = kvc:path([<<"maxScore">>], Resp),
+				MaxScore = case kvc:path([<<"maxScore">>], Resp) of
+					[] -> 0.0;
+					Score -> Score
+				end,
 				NumFound = kvc:path([<<"numFound">>], Resp),
 
 				RPBResp = #rpbsearchqueryresp{


### PR DESCRIPTION
When a sort is set, maxScore is not set causing `kvc:path([<<"maxScore">>]` to return an empty list.  This causes the encode to break as it expects a float.  Setting maxScore to 0.0 is a total bodge to provide a minimal surface area fix.
