### PR TITLE
Perf/zl/remove unnecessary delete to solr idx when crdt or sc

### DIFF
--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -470,11 +470,13 @@ is_service_up(Service, Node) ->
 %%      strong consistency.
 -spec is_datatype_or_consistent(obj()) -> boolean().
 is_datatype_or_consistent(Obj) ->
-    case riak_kv_crdt:value(Obj) of
-        undefined ->
+    case riak_kv_crdt:is_crdt(Obj) of
+        false ->
             is_strongly_consistent(Obj);
+        true ->
+            true;
         _ ->
-            true
+            false
     end.
 
 %% @private
@@ -483,7 +485,13 @@ is_datatype_or_consistent(Obj) ->
 -spec is_strongly_consistent(riak_object:riak_object()) -> boolean().
 is_strongly_consistent(Obj) ->
     Bucket = riak_object:bucket(Obj),
-    riak_kv_util:consistent_object(Bucket).
+    case riak_kv_util:consistent_object(Bucket) of
+        true ->
+            true;
+        _ ->
+            false
+    end.
+
 
 %% @private
 %%


### PR DESCRIPTION
Fixes https://bashoeng.atlassian.net/browse/RIAK-1504. 

Improves performance by avoiding an extra delete operation to remove siblings through Solr on the put path when riak datatypes or strong consistency is used. Initial patch/issue was discovered by @drewkerrigan, https://github.com/basho-labs/yokozuna_perf_patch.
