### PR TITLE
Add ibrowse dep.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,9 @@
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}},
   {riak_kv, ".*",
-   {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}}
+   {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
+  {ibrowse, "4.0.2",
+   {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.


### PR DESCRIPTION
ibrowse became a development only dependency for webmachine, so it now
needs to be explicitly required by yokozuna.
