### PR TITLE
Bugfix/im/handle get ring timeouts

### DIFF
--- a/src/yz_cover.erl
+++ b/src/yz_cover.erl
@@ -45,14 +45,13 @@
 %% to the caller how to interpret this.
 -spec get_ring_used() -> ring() | unknown.
 get_ring_used() ->
-    try gen_server:call(?MODULE, get_ring_used, 5000) of
-        undefined -> unknown;
-        Ring -> Ring
-    catch
-        _:_ ->
-            %% If the call failed then not sure what ring is
-            %% being used.
-            unknown
+    case riak_core_util:proxy_spawn(fun() -> gen_server:call(?MODULE, get_ring_used, 5000) end) of
+	{error, _} ->
+	    unknown;
+	undefined ->
+	    unknown;
+	Ring ->
+	    Ring
     end.
 
 -spec logical_partitions(ring(), ordset(p())) -> ordset(lp()).

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -180,6 +180,7 @@ remove_non_owned_data(unknown) ->
     %% The ring used to calculate the current coverage plan could not
     %% be determined. In this case do nothing to prevent removing data
     %% that the current coverage plan is using.
+    ?DEBUG("the current ring is unknown, no data can be removed", []),
     ok;
 remove_non_owned_data(Ring) ->
     case yz_solr:cores() of


### PR DESCRIPTION
Fixes issue #437 (RIAK-1567) by adding a catch-all clause to yz_events:handle_info. Also adds logging to yz_events:remove_non_owned_data so that failed calls to yz_cover:get_ring_used can be detected.
