### PR TITLE
Fix .rebar for 17 [JIRA: RIAK-1596]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ priv/solr/solr-webapp
 build/
 *.class
 *.tgz
-.rebar
+.rebar/*
 riak_test/ebin
 tests/20*
 tests/current


### PR DESCRIPTION
This appears to have been missed during the wave of prep work to make our repos Erlang 17.x-friendly.
