### PR TITLE
Add logging of basho_bench failures to the yokozuna-essential test

### DIFF
--- a/riak_test/yokozuna_essential.erl
+++ b/riak_test/yokozuna_essential.erl
@@ -68,7 +68,7 @@ confirm() ->
             timer:sleep(30000),
             Cluster2 = join_rest(Cluster, Nodes),
             rt:wait_for_cluster_service(Cluster2, yokozuna),
-            check_status(wait_for(Ref)),
+            check_bb_status(wait_for(Ref)),
             verify_non_owned_data_deleted(Cluster, ?INDEX),
             ok = test_tagging(Cluster),
             KeysDeleted = delete_some_data(Cluster2, reap_sleep()),
@@ -311,8 +311,38 @@ async_query(Cluster, YZBenchDir) ->
     write_terms(File, Cfg),
     run_bb(async, File).
 
-check_status({Status,_}) ->
-    ?assertEqual(?SUCCESS, Status).
+check_bb_status({Status,_}) ->
+    %% If we see an error, it'll be helpful to have the basho bench output here
+    %% in the riak_test log, since otherwise it may get wiped off of the build
+    %% machines before we get a chance to investigate the failure.
+    case Status of
+        ?SUCCESS ->
+            ok;
+        _ ->
+            lager:info("basho_bench returned error status ~p", [Status]),
+            lager:info("basho_bench log dump follows:"),
+            dump_bb_logs(),
+            ?assertEqual(?SUCCESS, Status)
+    end.
+
+dump_bb_logs() ->
+    Logs = filelib:wildcard("/tmp/yz-bb-results/current/*.log"),
+    lists:foreach(fun dump_log/1, Logs).
+
+dump_log(Log) ->
+    lager:info("--- Dumping log file ~p ---", [Log]),
+    {ok, File} = file:open(Log, [read]),
+    dump_file(File),
+    lager:info("--- End log file dump of ~p ---", [Log]).
+
+dump_file(File) ->
+    case file:read_line(File) of
+        eof ->
+            ok;
+        {ok, Data} ->
+            lager:info("~s", [Data]),
+            dump_file(File)
+    end.
 
 delete_key(Cluster, Key) ->
     Node = yz_rt:select_random(Cluster),
@@ -391,7 +421,7 @@ verify_deletes(Cluster, KeysDeleted, YZBenchDir) ->
            {shutdown_on_error, true}],
     File = "bb-verify-deletes",
     write_terms(File, Cfg),
-    check_status(run_bb(sync, File)).
+    check_bb_status(run_bb(sync, File)).
 
 wait_for(Ref) ->
     rt:wait_for_cmd(Ref).


### PR DESCRIPTION
If basho_bench returns a non-zero exit status during the yokozuna-essential test, this code dumps its log files into the main test log. This will help debug future failures on the build machines when the bb logs get wiped before we have a chance to investigate.
