### PR TITLE
add ability to choose upgrade version for riak_search->yokozuna migratio...

### DIFF
--- a/riak_test/yz_rs_migration_test.erl
+++ b/riak_test/yz_rs_migration_test.erl
@@ -65,7 +65,11 @@ confirm() ->
     case yz_rt:bb_driver_setup() of
         {ok, YZBenchDir} ->
             lager:info("YZBenchDir: ~p", [YZBenchDir]),
-            Cluster = rt:build_cluster(lists:duplicate(3, {previous, ?CFG})),
+
+            TestMetaData = riak_test_runner:metadata(),
+            OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+
+            Cluster = rt:build_cluster(lists:duplicate(3, {OldVsn, ?CFG})),
 
             create_index(Cluster, riak_search),
             load_data(Cluster, YZBenchDir, 1000),


### PR DESCRIPTION
...n and get it from giddyup metadata

We're changing our builders to make the `previous` version 2.0.5... but this migration test relies on the 1.4 series, which is the last to use the original riak_search. With the upgrade_version, we can now specify legacy for this test in the test metadata.
