### PR TITLE
*use sh for other *nix'es *add additional fetch call for e.g. freebsd in down...

### DIFF
--- a/tools/build-jar.sh
+++ b/tools/build-jar.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Build JAR file containing customer Solr request handlers.
 set -e

--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Script to grab Solr and embed in priv dir. This script assumes it is
 # being called from root dir or tools dir.
@@ -38,12 +38,14 @@ download()
         wget --no-check-certificate --progress=dot:mega $1
     elif which curl > /dev/null; then
         curl --insecure --progress-bar -O $1
+    elif which fetch > /dev/null; then
+        fetch --no-verify-peer $1
     fi
 }
 
 get_solr()
 {
-        if [[ -z ${SOLR_PKG_DIR+x} ]]
+        if [ -z ${SOLR_PKG_DIR+x} ]
         then
             if [ -e $TMP_FILE ]; then
                 echo "Using cached copy of Solr $TMP_FILE"


### PR DESCRIPTION
...load

Fixes/updates on https://github.com/basho/yokozuna/pull/467, RIAK-1587, to work on *nix'es with no bash. @nbari, I basically cleared up a bug here https://github.com/basho/yokozuna/pull/467/files#diff-0111c86b5712576e1bf2c24f23178c01R41 (`;` not `:`. This should still work for the FreeBsd port for example. Let me know otherwise.
