### PR TITLE
update default_schema to return sets in query responses by storing them...

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -95,13 +95,13 @@
 
    <!-- Riak datatypes default fields-->
    <field name="counter" type="int"    indexed="true" stored="true" multiValued="false" />
-   <field name="set"     type="string" indexed="true" stored="false" multiValued="true" />
+   <field name="set"     type="string" indexed="true" stored="true" multiValued="true" />
 
    <!-- Riak datatypes embedded fields -->
    <dynamicField name="*_flag"     type="boolean" indexed="true" stored="true" multiValued="false" />
    <dynamicField name="*_counter"  type="int"     indexed="true" stored="true" multiValued="false" />
    <dynamicField name="*_register" type="string"  indexed="true" stored="true" multiValued="false" />
-   <dynamicField name="*_set"      type="string"  indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*_set"      type="string"  indexed="true" stored="true" multiValued="true" />
 
    <!-- catch-all field -->
    <dynamicField name="*" type="ignored" />


### PR DESCRIPTION
Handles/fixes RIAK-1672 (#480) issue with a missing set in the query response... focused in on the _default_schema_ only. 

In regards to missing data, that's due to something awry in the replication, as YZ queries only use R=1, and one of the partitions is missing the data. That's either caused by errors or will be fixed as part of the AAE expiration testing, #481 (RIAK-1674). 

Goes along w/ riak_test pr https://github.com/basho/riak_test/pull/773.
