### PR TITLE
move to using mochiglobal to store extractor map

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -165,6 +165,8 @@
 -define(YZ_SVC_NAME, yokozuna).
 -define(YZ_META_INDEXES, {yokozuna, indexes}).
 -define(YZ_META_SCHEMAS, {yokozuna, schemas}).
+-define(YZ_META_EXTRACTORS, {yokozuna, extractors}).
+-define(YZ_CAPS_CMD_EXTRACTORS, {yokozuna, extractor_map_in_cmd}).
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
         "Not enough nodes are up to service this request.").

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -76,6 +76,8 @@ maybe_setup(true) ->
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
     setup_stats(),
+    ok = riak_core_capability:register(?YZ_CAPS_CMD_EXTRACTORS, [true, false],
+                                       false),
     ok = riak_core:register(yokozuna, [{bucket_validator, yz_bucket_validator}]),
     ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),


### PR DESCRIPTION
- have read-through if map not in mochiglobal then check CMD and then the Ring
- add capability to now move extractor map into CMD (and no longer store it in the ring metadata)

Fixes RIAK-1673 (#382).
