### PR TITLE
fix issue w/ default bucket-types on building AAE trees as per RIAK-1674

### DIFF
--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -191,7 +191,7 @@ extract_results(Docs, {TP, BP, KP}) ->
          {_, BName} = lists:nth(BP, Fields),
          {_, Key} = lists:nth(KP, Fields),
          {{BType, BName}, Key, []}
-     end|| {struct, Fields} <- Docs].
+     end || {struct, Fields} <- Docs].
 
 %% @private
 %%

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -372,7 +372,7 @@ apply_tree(Id, Fun, S=#state{trees=Trees}) ->
 
 -spec do_build_finished(state()) -> state().
 do_build_finished(S=#state{index=Index, built=_Pid}) ->
-    lager:debug("Finished build: ~p", [Index]),
+    lager:debug("Finished YZ build: ~p", [Index]),
     {_,Tree0} = hd(S#state.trees),
     BuildTime = yz_kv:get_tree_build_time(Tree0),
     hashtree:write_meta(<<"built">>, <<1>>, Tree0),
@@ -496,7 +496,7 @@ maybe_expire(S) ->
 
 -spec clear_tree(state()) -> state().
 clear_tree(S=#state{index=Index}) ->
-    lager:debug("Clearing tree ~p", [S#state.index]),
+    lager:debug("Clearing YZ AAE tree: ~p", [S#state.index]),
     S2 = destroy_trees(S),
     IndexN = riak_kv_util:responsible_preflists(Index),
     S3 = init_trees(IndexN, S2#state{trees=orddict:new()}),
@@ -551,14 +551,14 @@ build_or_rehash(Tree, S) ->
 build_or_rehash(Tree, Locked, Type, #state{index=Index, trees=Trees}) ->
     case {Locked, Type} of
         {true, build} ->
-            lager:debug("Starting build: ~p", [Index]),
+            lager:debug("Starting YZ AAE tree build: ~p", [Index]),
             fold_keys(Index, Tree),
-            lager:debug("Finished build: ~p", [Index]),
+            lager:debug("Finished YZ AAE tree build: ~p", [Index]),
             gen_server:cast(Tree, build_finished);
         {true, rehash} ->
-            lager:debug("Starting rehash: ~p", [Index]),
+            lager:debug("Starting YZ AAE tree rehash: ~p", [Index]),
             _ = [hashtree:rehash_tree(T) || {_,T} <- Trees],
-            lager:debug("Finished rehash: ~p", [Index]),
+            lager:debug("Finished YZ AAE tree rehash: ~p", [Index]),
             gen_server:cast(Tree, build_finished);
         {_, _} ->
             gen_server:cast(Tree, build_failed)

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -419,6 +419,10 @@ get_pairs(R) ->
     Docs = kvc:path([<<"response">>, <<"docs">>], R),
     [to_pair(DocStruct) || DocStruct <- Docs].
 
+%% @doc Convert a doc struct into a pair. Remove the bucket_type to match
+%% kv trees when iterating over entropy data to build yz trees.
+to_pair({struct, [{_,_Vsn},{_,<<"default">>},{_,BName},{_,Key},{_,Base64Hash}]}) ->
+    {{BName,Key}, base64:decode(Base64Hash)};
 to_pair({struct, [{_,_Vsn},{_,BType},{_,BName},{_,Key},{_,Base64Hash}]}) ->
     {{{BType, BName},Key}, base64:decode(Base64Hash)}.
 


### PR DESCRIPTION
- handle issue in building-from/iterating-through entropy data to match riak-kv actual_put data w/ default bucket-types and not cause extraneous repairs
- update aae test to test for a custom bucket_type and a default one
- clean-up log messaging in yz_index_hashtree
