### PR TITLE
maybe expire/poke on initialized of idx_hashtree process for upgrade …

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -169,6 +169,8 @@
 -define(YZ_META_SCHEMAS, {yokozuna, schemas}).
 -define(YZ_META_EXTRACTORS, {yokozuna, extractors}).
 -define(YZ_CAPS_CMD_EXTRACTORS, {yokozuna, extractor_map_in_cmd}).
+-define(YZ_CAPS_HANDLE_LEGACY_DEFAULT_BUCKET_TYPE_AAE,
+        {yokozuna, handle_legacy_default_bucket_type_aae}).
 
 -define(YZ_ERR_NOT_ENOUGH_NODES,
         "Not enough nodes are up to service this request.").

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -78,6 +78,10 @@ maybe_setup(true) ->
     setup_stats(),
     ok = riak_core_capability:register(?YZ_CAPS_CMD_EXTRACTORS, [true, false],
                                        false),
+    ok = riak_core_capability:register(
+           ?YZ_CAPS_HANDLE_LEGACY_DEFAULT_BUCKET_TYPE_AAE,
+           [v1, v0],
+           v0),
     ok = riak_core:register(yokozuna, [{bucket_validator, yz_bucket_validator}]),
     ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -250,10 +250,9 @@ core_create(Name, SchemaName, CoreProps) ->
     %%
     %% To address this, we first unload (local_remove) the core from Solr.
     %% This may be a moderately expensive process, but given we should
-    %% only be issuing creation requests when either AAE believes Solr is
-    %% missing the index, or we are creating it for the first time, the
-    %% impact should be minimal (and somewhat unavoidable; if AAE is
-    %% replacing the whole index, that's what it's going to do anyway).
+    %% only be issuing creation requests when either Solr is can't
+    %% discover the index, or we are creating it for the first time, the
+    %% impact should be minimal.
     ok = local_remove(Name, [{core, Name}]),
     case yz_solr:core(create, CoreProps) of
         {ok, _, _} ->


### PR DESCRIPTION
…reasons related to default_bucket_type fix/change

Completes RIAK-1797 (#491). 

Related to test https://github.com/basho/riak_test/pull/792.
