### PR TITLE
Cherry picked logging of deletion of core properties file from hotfix…

### DIFF
--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -212,9 +212,12 @@ sync_indexes() ->
                                  yz_index:get_indexes_from_meta()),
             {Removed, Added, Same} = yz_misc:delta(IndexSetFromSolr,
                                                    IndexSetFromMeta),
-            lager:info("Delta: Removed: ~p Added: ~p Same: ~p", [Removed,
-                                                                 Added,
-                                                                 Same]),
+            case {Removed, Added} of
+                {[], []} -> ok;
+                _ ->
+                    lager:info("Delta: Removed: ~p Added: ~p Same: ~p",
+                        [Removed, Added, Same])
+            end,
             ok = sync_indexes(Removed, Added, Same);
         {error, _Reason} ->
             ok

--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -224,7 +224,7 @@ local_create(Name) ->
             %% gets in a state where CREATE thinks the core already
             %% exists but RELOAD says no core exists.
             PropsFile = filename:join([IndexDir, "core.properties"]),
-            file:delete(PropsFile),
+            delete_core_props_file(PropsFile),
 
             core_create(Name, SchemaName, CoreProps);
         {error, _Reason} ->
@@ -232,6 +232,26 @@ local_create(Name) ->
                         [Name, SchemaName]),
             ok
     end.
+
+%% @doc Wrapper around file:delete on the core properties file.
+%% Obeys the same return semantics as file:delete/1
+-spec delete_core_props_file(string()) -> ok | enoent | term().
+delete_core_props_file(PropsFile) ->
+    case file:delete(PropsFile) of
+        ok ->
+            lager:info("Deleted Solr core properties file at path ~p", [PropsFile]), ok;
+        {error, Reason} ->
+            case Reason of
+                enoent -> ok;
+                _ ->
+                    lager:error(
+                        "Failed to delete Solr core properties file at path ~p; Reason: ~p.",
+                        [PropsFile, Reason]
+                    )
+            end,
+            {error, Reason}
+    end.
+
 
 %% @doc
 -spec core_create(index_name(), schema_name(), [{name | index_dir | cfg_file | schema_file,


### PR DESCRIPTION
… branch.  Also toned down logging in yz_events when there is nothing to be done (once/minute, which is choking logs).

This PR addresses some improvements to login when Yokozuna decides to delete the core.properties file for a given Solr core (index).  It also tones down the logging when yokozuna tries to synchronize its view of the cores that are loaded in solr (via cluster metadata) and what it can scrape off the file system.  The current logging spits out an info message every minute, when no work results in the comparison.  This change makes it so that something is logged only if there is something that needs to be done.
