### PR TITLE
match client operation timeouts for idx creation

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -130,6 +130,7 @@
 
 -define(DATA_DIR, application:get_env(riak_core, platform_data_dir)).
 
+%% Default index creation timeout. Set at 60s to match default client timeouts.
 -define(DEFAULT_IDX_CREATE_TIMEOUT, 60000).
 
 -define(MAYBE(Check, Expression, Default),


### PR DESCRIPTION
Going to develop first... and this will be then be merged into 2.0 for release 2.0.6 (and, afterward, 2.1.2).
