### PR TITLE
Yokozuna fails to re-index the remainder of a partition after a non-indexable document is encountered

### DIFF
--- a/misc/bench/schemas/fruit_schema.xml
+++ b/misc/bench/schemas/fruit_schema.xml
@@ -6,6 +6,8 @@
 
    <field name="text" type="text_ws" indexed="true" stored="false" multiValued="true"/>
 
+   <field name="date_register" type="tdate" indexed="true" stored="true" multiValued="false" />
+
    <field name="_version_" type="long" indexed="true" stored="true"/>
 
    <!-- Entropy Data: Data related to anti-entropy -->
@@ -41,6 +43,10 @@
     <fieldType name="_yz_str" class="solr.StrField" sortMissingLast="true" />
 
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
+
+    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <!-- A Trie based date field for faster date range queries and date faceting. -->
+    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
 
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">


### PR DESCRIPTION
- update yz_exchange_fsm to catch index error w/ ill-formated/failed document, thank you @kesslerm 
- update aae_test to test for this bug, 
- add a date field to check-up on in fruit_schema.xml

Fixes RIAK-2006 (#525) / https://github.com/basho/yokozuna/issues/525.

Will need to be merged-forward to 2.1 and develop.
