### PR TITLE
enable request-body parameters for content-type `application/x-www-form-urlencoded` POSTs for long queries - RIAK-1875

### DIFF
--- a/riak_test/yz_languages.erl
+++ b/riak_test/yz_languages.erl
@@ -5,8 +5,6 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
--define(NO_HEADERS, []).
--define(NO_BODY, <<>>).
 -define(CFG,
         [
          {riak_core,
@@ -37,24 +35,9 @@ select_random(List) ->
 host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
-index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
-
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",
          [Host, Port, BType, BName, Key]).
-
-http(Method, URL, Headers, Body) ->
-    Opts = [],
-    ibrowse:send_req(URL, Headers, Method, Body, Opts).
-
-create_index(Cluster, HP, Index) ->
-    lager:info("create_index ~s [~p]", [Index, HP]),
-    URL = index_url(HP, Index),
-    Headers = [{"content-type", "application/json"}],
-    {ok, Status, _, _} = http(put, URL, Headers, ?NO_BODY),
-    ok = yz_rt:set_bucket_type_index(hd(Cluster), Index),
-    ?assertEqual("204", Status).
 
 store_and_search(Cluster, Bucket, Index, CT, Body, Field, Term) ->
     Headers = [{"Content-Type", CT}],
@@ -65,7 +48,7 @@ store_and_search(Cluster, Bucket, Index, Headers, CT, Body, Field, Term) ->
 
 store_and_search(Cluster, Bucket, Index, Key, Headers, CT, Body, Field, Term) ->
     HP = select_random(host_entries(rt:connection_info(Cluster))),
-    create_index(Cluster, HP, Index),
+    yz_rt:create_index_http(Cluster, HP, Index),
     URL = bucket_url(HP, Bucket, Key),
     lager:info("Storing to bucket ~s", [URL]),
     {ok, "204", _, _} = ibrowse:send_req(URL, Headers, put, Body),

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -6,8 +6,6 @@
 -include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
 -include("yokozuna.hrl").
 
--define(NO_HEADERS, []).
--define(NO_BODY, <<>>).
 -define(CFG, [{yokozuna, [{enabled, true}]}]).
 -define(CT_JSON, {"Content-Type", "application/json"}).
 
@@ -61,19 +59,9 @@ select_random(List) ->
 host_entries(ClusterConnInfo) ->
     [proplists:get_value(http, I) || {_,I} <- ClusterConnInfo].
 
-schema_url({Host,Port}, Name) ->
-    ?FMT("http://~s:~B/search/schema/~s", [Host, Port, Name]).
-
-index_url({Host,Port}, Index) ->
-    ?FMT("http://~s:~B/search/index/~s", [Host, Port, Index]).
-
 bucket_url({Host,Port}, {BType, BName}, Key) ->
     ?FMT("http://~s:~B/types/~s/buckets/~s/keys/~s",
          [Host, Port, BType, BName, Key]).
-
-http(Method, URL, Headers, Body) ->
-    Opts = [],
-    ibrowse:send_req(URL, Headers, Method, Body, Opts).
 
 create_index(Cluster, BucketType, Index) ->
     create_index(Cluster, BucketType, Index, 3).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -60,11 +60,13 @@ create_index(Node, Index, SchemaName, NVal) ->
                [Index, SchemaName, NVal, Node]),
     ok = rpc:call(Node, yz_index, create, [Index, SchemaName, NVal]).
 
+-spec create_index_http(nodes(), index_name()) -> ok.
 create_index_http(Cluster, Index) ->
     Node = yz_rt:select_random(Cluster),
     HP = hd(host_entries(rt:connection_info([Node]))),
     create_index_http(Cluster, HP, Index).
 
+-spec create_index_http(nodes(), {string(), portnum()}, index_name()) -> ok.
 create_index_http(Cluster, HP, Index) ->
     Node = hd(Cluster),
     URL = yz_rt:index_url(HP, Index),

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -60,13 +60,13 @@ create_index(Node, Index, SchemaName, NVal) ->
                [Index, SchemaName, NVal, Node]),
     ok = rpc:call(Node, yz_index, create, [Index, SchemaName, NVal]).
 
--spec create_index_http(nodes(), index_name()) -> ok.
+-spec create_index_http(cluster(), index_name()) -> ok.
 create_index_http(Cluster, Index) ->
     Node = yz_rt:select_random(Cluster),
     HP = hd(host_entries(rt:connection_info([Node]))),
     create_index_http(Cluster, HP, Index).
 
--spec create_index_http(nodes(), {string(), portnum()}, index_name()) -> ok.
+-spec create_index_http(cluster(), {string(), portnum()}, index_name()) -> ok.
 create_index_http(Cluster, HP, Index) ->
     Node = hd(Cluster),
     URL = yz_rt:index_url(HP, Index),

--- a/riak_test/yz_search_http.erl
+++ b/riak_test/yz_search_http.erl
@@ -1,0 +1,104 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%-------------------------------------------------------------------
+
+%% @doc Test that checks through various HTTP calls and methods
+%%      related to Yokozuna
+%% @end
+
+-module(yz_search_http).
+
+-compile(export_all).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CFG,
+        [
+         {riak_core,
+          [
+           {ring_creation_size, 8}
+          ]},
+         {yokozuna,
+          [
+           {enabled, true}
+          ]}
+        ]).
+-define(NO_HEADERS, []).
+-define(NO_BODY, <<>>).
+-define(INDEX, <<"test_search_http">>).
+-define(TYPE, <<"data_foo">>).
+-define(BUCKET, {?TYPE, <<"test_search_http">>}).
+
+confirm() ->
+    [Node1|_] = Cluster = rt:build_cluster(4, ?CFG),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+    ok = yz_rt:create_bucket_type(Node1, ?TYPE),
+    ok = yz_rt:create_index_http(Cluster, ?INDEX),
+    yz_rt:set_index(Node1, ?BUCKET, ?INDEX),
+    HP = hd(yz_rt:host_entries(rt:connection_info(Cluster))),
+    Key = <<"Problem">>,
+    Value = <<"FOR YOU">>,
+    ok = yz_rt:http_put(HP, ?BUCKET, Key, Value),
+
+    %% time for soft auto commit
+    timer:sleep(1100),
+
+    URL = yz_rt:search_url(HP, ?INDEX),
+
+    test_search_get_and_post_query(HP, URL, ?INDEX),
+    test_post_as_get(URL),
+    test_post_as_get_with_wrong_content_types(URL),
+
+    pass.
+
+test_search_get_and_post_query(HP, URL, Index) ->
+    lager:info("Check post with content-type ~s and message body"),
+    {ok, "200", _, _} = yz_rt:search(HP, Index, "*", "*"),
+    ?assert(yz_rt:search_expect(yokozuna, HP, Index, "text", "F*", 1)),
+    CT = {content_type, "application/x-www-form-urlencoded"},
+    Headers = [CT],
+    Params = [{q, "text:F*"}, {wt, "json"}],
+    Body = mochiweb_util:urlencode(Params),
+    {ok, "200", _, R} = yz_rt:http(post, URL, Headers, Body),
+    yz_rt:verify_count(1, R),
+    ok.
+
+test_post_as_get(URL) ->
+    CT = {content_type, "application/x-www-form-urlencoded"},
+    Headers = [CT],
+    {ok, "200", _, R} = yz_rt:http(post, URL ++ "?q=text:F*&wt=json",
+                                   Headers, ?NO_BODY),
+    yz_rt:verify_count(1, R),
+    ok.
+
+test_post_as_get_with_wrong_content_types(URL) ->
+    CT1 = {content_type, "application/x-www-form-urlen"},
+    lager:info("Check misspelled content-type ~s", [element(2, CT1)]),
+    Headers1 = [CT1],
+    {ok, Status1, _, _} = yz_rt:http(post, URL ++ "?q=text:F*&wt=json",
+                                    Headers1, ?NO_BODY),
+    ?assertEqual("415", Status1),
+
+    CT2 = {content_type, "application/json"},
+    Headers2 = [CT2],
+    lager:info("Check non-applicable content-type ~s", [element(2, CT2)]),
+    Params = [{q, "text:F*"}, {wt, "json"}],
+    Body = mochiweb_util:urlencode(Params),
+    {ok, Status2, _, _} = yz_rt:http(post, URL, Headers2, Body),
+    ?assertEqual("415", Status2).

--- a/riak_test/yz_search_http.erl
+++ b/riak_test/yz_search_http.erl
@@ -64,17 +64,18 @@ confirm() ->
     test_search_get_and_post_query(HP, URL, ?INDEX),
     test_post_as_get(URL),
     test_post_as_get_with_wrong_content_types(URL),
+    test_get_and_post_no_params(URL),
 
     pass.
 
 test_search_get_and_post_query(HP, URL, Index) ->
-    lager:info("Check post with content-type ~s and message body"),
     {ok, "200", _, _} = yz_rt:search(HP, Index, "*", "*"),
     ?assert(yz_rt:search_expect(yokozuna, HP, Index, "text", "F*", 1)),
     CT = {content_type, "application/x-www-form-urlencoded"},
     Headers = [CT],
     Params = [{q, "text:F*"}, {wt, "json"}],
     Body = mochiweb_util:urlencode(Params),
+    lager:info("Check post with content-type ~s and message body"),
     {ok, "200", _, R} = yz_rt:http(post, URL, Headers, Body),
     yz_rt:verify_count(1, R),
     ok.
@@ -102,3 +103,10 @@ test_post_as_get_with_wrong_content_types(URL) ->
     Body = mochiweb_util:urlencode(Params),
     {ok, Status2, _, _} = yz_rt:http(post, URL, Headers2, Body),
     ?assertEqual("415", Status2).
+
+test_get_and_post_no_params(URL) ->
+    {ok, "200", _, _} = yz_rt:http(get, URL, ?NO_HEADERS, ?NO_BODY),
+
+    CT = {content_type, "application/x-www-form-urlencoded"},
+    Headers = [CT],
+    {ok, "200", _, _} = yz_rt:http(post, URL, Headers, ?NO_BODY).

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -120,8 +120,6 @@ search(Req, S) ->
     Params = wrq:req_qs(Req),
     search(Req, S, Params).
 
-search(Req, S, []) ->
-    search(Req, S);
 search(Req, S, Params) ->
     {FProf, FProfFile} = check_for_fprof(Req),
     ?IF(FProf, fprof:trace(start, FProfFile)),
@@ -188,7 +186,11 @@ decode_body_from_ctype(_CT, V) ->
 %%      `select search
 post_search(Req, S, CT) ->
     Body = wrq:req_body(Req),
-    Params = decode_body_from_ctype(CT, Body),
+    BodyParams = decode_body_from_ctype(CT, Body),
+    case BodyParams of
+        [] -> Params = wrq:req_qs(Req);
+        _ -> Params = BodyParams
+    end,
     case search(Req, S, Params) of
         {Val, Req2, S2} when is_binary(Val) ->
             Req3 = wrq:set_resp_body(Val, Req2),

--- a/src/yz_wm_search.erl
+++ b/src/yz_wm_search.erl
@@ -42,7 +42,6 @@ routes() ->
             Routes1
     end.
 
-
 %%%===================================================================
 %%% Callbacks
 %%%===================================================================
@@ -93,9 +92,8 @@ resource_forbidden(RD, Ctx=#ctx{security=Security}, Permission,
     end.
 
 
-
-%% Uses the riak_kv,secure_referer_check setting rather
-%% as opposed to a special yokozuna-specific config
+%% @doc Uses the riak_kv,secure_referer_check setting rather
+%%      as opposed to a special yokozuna-specific config
 forbidden(RD, Ctx=#ctx{security=undefined}) ->
     {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
 forbidden(RD, Ctx) ->
@@ -107,24 +105,28 @@ forbidden(RD, Ctx) ->
                                {?YZ_SECURITY_INDEX, wrq:path_info(index, RD)})
     end.
 
-%% Treat POST as GET in order to work with existing Solr clients.
-process_post(Req, S) ->
-    case search(Req, S) of
-        {Val, Req2, S2} when is_binary(Val) ->
-            Req3 = wrq:set_resp_body(Val, Req2),
-            {true, Req3, S2};
-        Other ->
-            %% In this case assume Val is `{halt,Code}' or
-            %% `{error,Term}'
-            Other
+%% @doc Handle POST to work with existing Solr clients and long queries
+%%      when the correct Content-Type is supplied.
+process_post(RD, Ctx) ->
+    CType = wrq:get_req_header(?HEAD_CTYPE, RD),
+    case CType of
+        "application/x-www-form-urlencoded" ->
+            post_search(RD, Ctx, CType);
+        _ ->
+            {{halt, 415}, RD, Ctx}
     end.
 
 search(Req, S) ->
+    Params = wrq:req_qs(Req),
+    search(Req, S, Params).
+
+search(Req, S, []) ->
+    search(Req, S);
+search(Req, S, Params) ->
     {FProf, FProfFile} = check_for_fprof(Req),
     ?IF(FProf, fprof:trace(start, FProfFile)),
     T1 = os:timestamp(),
     Index = list_to_binary(wrq:path_info(index, Req)),
-    Params = wrq:req_qs(Req),
     try
         Result = yz_solr:dist_search(Index, Params),
         case Result of
@@ -174,3 +176,25 @@ resource_exists(RD, Context) ->
 %% ====================================================================
 %% Private
 %% ====================================================================
+
+-spec decode_body_from_ctype(string(), binary()) -> term().
+%% @doc Decode the req_body binary based on content type that can be used.
+decode_body_from_ctype("application/x-www-form-urlencoded", V) ->
+    mochiweb_util:parse_qs(V);
+decode_body_from_ctype(_CT, V) ->
+    V.
+
+%% @doc Treat POST as GET after decoding body as params for Solr
+%%      `select search
+post_search(Req, S, CT) ->
+    Body = wrq:req_body(Req),
+    Params = decode_body_from_ctype(CT, Body),
+    case search(Req, S, Params) of
+        {Val, Req2, S2} when is_binary(Val) ->
+            Req3 = wrq:set_resp_body(Val, Req2),
+            {true, Req3, S2};
+        Other ->
+            %% In this case assume Val is `{halt,Code}' or
+            %% `{error,Term}'
+            Other
+    end.


### PR DESCRIPTION
Add ability to handle POSTs for search queries, when given the content-type **application/x-www-form-urlencoded**, or return a `415` if given another CT on POST. Should solve this issue: https://github.com/basho/yokozuna/issues/503, which references  RIAK-1875. 

Run riak_test w/ `riak/2.0` branch -> https://github.com/basho/riak_test/tree/riak/2.0/tests.

@kuenishi @shino @JeetKunDoug @fadushin may want to take a gander/review. 
