### PR TITLE
Bugfix/fd/riak 1937

### DIFF
--- a/riak_test/aae_test.erl
+++ b/riak_test/aae_test.erl
@@ -129,7 +129,7 @@ create_obj_node_partition_tuple(Cluster, BKey={Bucket, Key}) ->
     N = riak_core_bucket:n_val(BProps),
     PL = rpc:call(hd(Cluster), yz_misc, primary_preflist, [BKey, Ring, N]),
     {P, Node} = hd(PL),
-    {Key, Obj, Node, P}.
+    {Obj, Node, P}.
 
 %% @doc Create postings for the given keys without storing
 %%      corresponding KV objects. This is used to simulate scenario where
@@ -145,10 +145,8 @@ create_orphan_postings(Cluster, Bucket, Keys) ->
     Keys2 = [{Bucket, ?INT_TO_BIN(K)} || K <- Keys],
     lager:info("Create orphan postings with keys ~p", [Keys]),
     ObjNodePs = [create_obj_node_partition_tuple(Cluster, Key) || Key <- Keys2],
-    %% NB. The Bucket and Key are ignored if Obj is a plain Riak Object
-    %% (i.e., not the binary encoding of a Riak Object)
-    [ok = rpc:call(Node, yz_kv, index, [Bucket, Key, Obj, put, P])
-     || {Key, Obj, Node, P} <- ObjNodePs],
+    [ok = rpc:call(Node, yz_kv, index, [Obj, put, P])
+     || {Obj, Node, P} <- ObjNodePs],
     ok.
 
 -spec delete_key_in_solr([node()], index_name(), bkey()) -> [ok].

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -334,9 +334,11 @@ set_bucket_type_index(Node, BucketType, Index) ->
     lager:info("Set bucket type ~s index to ~s [~p]", [BucketType, Index, Node]),
     create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index}]).
 
-set_bucket_type_index(Node, BucketType, Index, NVal) ->
+set_bucket_type_index(Node, BucketType, Index, NVal) when is_integer(NVal) ->
+    set_bucket_type_index(Node, BucketType, Index, [{n_val, NVal}]);
+set_bucket_type_index(Node, BucketType, Index, Props) ->
     lager:info("Set bucket type ~s index to ~s [~p]", [BucketType, Index, Node]),
-    create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index},{n_val,NVal}]).
+    create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index} | Props]).
 
 solr_http({_Node, ConnInfo}) ->
     solr_http(ConnInfo);

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -194,7 +194,15 @@ has_indexes(RemoteNode) ->
 is_enabled() ->
     yokozuna:is_enabled(index) andalso ?YZ_ENABLED.
 
-index(Obj, Reason, P) ->
+index(B, K, Obj, Reason, P) when is_binary(Obj) ->
+    case is_enabled() of
+        true ->
+            RObj = riak_object:from_binary(B, K, Obj),
+            index(B, K, RObj, Reason, P);
+        _ ->
+            ok
+    end;
+index(_B, _K, Obj, Reason, P) ->
     case is_enabled() of
         true ->
             Ring = yz_misc:get_ring(transformed),

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -190,47 +190,53 @@ has_indexes(RemoteNode) ->
         _ -> false
     end.
 
--spec is_enabled() -> boolean().
-is_enabled() ->
-    yokozuna:is_enabled(index) andalso ?YZ_ENABLED.
 
-index(B, K, Obj, Reason, P) when is_binary(Obj) ->
-    case is_enabled() of
-        true ->
-            RObj = riak_object:from_binary(B, K, Obj),
-            index(B, K, RObj, Reason, P);
-        _ ->
-            ok
-    end;
-index(_B, _K, Obj, Reason, P) ->
-    case is_enabled() of
+%% @doc Index the data supplied in the Riak Object.
+%% The Riak Object should be a serialized object (a binary,
+%% which has been serialized using riak_object:to_binary/1)
+-spec index_binary(bucket(), key(), binary(), write_reason(), p()) -> ok.
+index_binary(Bucket, Key, Obj, Reason, P) ->
+    index_internal(
+        Bucket, Key, Obj, Reason, P
+    ).
+
+%% @doc Index the data supplied in the Riak Object.
+-spec index(riak_object:riak_object(), write_reason(), p()) -> ok.
+index(Obj, Reason, P) ->
+    index_internal(
+        riak_object:bucket(Obj), riak_object:key(Obj), Obj, Reason, P
+    ).
+
+%% @private
+index_internal(Bucket, Key, Obj, Reason, P) ->
+    case yokozuna:is_enabled(index) andalso ?YZ_ENABLED of
         true ->
             Ring = yz_misc:get_ring(transformed),
             case is_owner_or_future_owner(P, node(), Ring) of
                 true ->
                     T1 = os:timestamp(),
-                    BKey = {riak_object:bucket(Obj), riak_object:key(Obj)},
+                    BKey = {Bucket, Key},
                     try
                         Index = get_index(BKey),
                         ShortPL = riak_kv_util:get_index_n(BKey),
                         case should_index(Index) of
                             true ->
-                                index(Obj, Reason, Ring, P, BKey, ShortPL, Index);
+                                index(robj(Bucket, Key, Obj), Reason, Ring, P, BKey, ShortPL, Index);
                             false ->
-                                dont_index(Obj, Reason, P, BKey, ShortPL)
+                                dont_index(robj(Bucket, Key, Obj), Reason, P, BKey, ShortPL)
                         end,
                         yz_stat:index_end(?YZ_TIME_ELAPSED(T1))
                     catch _:Err ->
-                            yz_stat:index_fail(),
-                            Trace = erlang:get_stacktrace(),
-                            case Reason of
-                                delete ->
-                                    ?ERROR("failed to delete docid ~p with error ~p because ~p",
-                                           [BKey, Err, Trace]);
-                                _ ->
-                                    ?ERROR("failed to index object ~p with error ~p because ~p",
-                                           [BKey, Err, Trace])
-                            end
+                        yz_stat:index_fail(),
+                        Trace = erlang:get_stacktrace(),
+                        case Reason of
+                            delete ->
+                                ?ERROR("failed to delete docid ~p with error ~p because ~p",
+                                    [BKey, Err, Trace]);
+                            _ ->
+                                ?ERROR("failed to index object ~p with error ~p because ~p",
+                                    [BKey, Err, Trace])
+                        end
                     end;
                 false ->
                     ok
@@ -238,6 +244,12 @@ index(_B, _K, Obj, Reason, P) ->
         false ->
             ok
     end.
+
+%% @private
+robj(Bucket, Key, Obj) when is_binary(Obj) ->
+    riak_object:from_binary(Bucket, Key, Obj);
+robj(_Bucket, _Key, Obj) ->
+    Obj.
 
 %% @private
 %%

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -190,8 +190,12 @@ has_indexes(RemoteNode) ->
         _ -> false
     end.
 
+-spec is_enabled() -> boolean().
+is_enabled() ->
+    yokozuna:is_enabled(index) andalso ?YZ_ENABLED.
+
 index(Obj, Reason, P) ->
-    case yokozuna:is_enabled(index) andalso ?YZ_ENABLED of
+    case is_enabled() of
         true ->
             Ring = yz_misc:get_ring(transformed),
             case is_owner_or_future_owner(P, node(), Ring) of

--- a/test/yz_component_tests.erl
+++ b/test/yz_component_tests.erl
@@ -6,7 +6,7 @@
 
 disable_index_test()->
   yokozuna:disable(index),
-  ?assertEqual(yz_kv:index({},delete,{}), ok).
+  ?assertEqual(yz_kv:index(dummy, dummy, {},delete,{}), ok).
 
 disable_search_test()->
     yokozuna:disable(search),

--- a/test/yz_component_tests.erl
+++ b/test/yz_component_tests.erl
@@ -6,7 +6,7 @@
 
 disable_index_test()->
   yokozuna:disable(index),
-  ?assertEqual(yz_kv:index(dummy, dummy, {},delete,{}), ok).
+  ?assertEqual(yz_kv:index(riak_object:new({<<"type">>, <<"bucket">>}, <<"key">>, <<"value">>), delete, {}), ok).
 
 disable_search_test()->
     yokozuna:disable(search),


### PR DESCRIPTION
This PR changes the signature of the yz_kv:index function to allow clients to pass a Bucket and Key, and to support the case in which the client of this function supplies an encoded Riak Object, as is the case in the write_once put path.  If (but only if) yokozuna is enabled and an encoded Riak Object is passed in, the binary is decoded into a Riak Object and passed into the (normal) index path.  Otherwise, the decoding is skipped, so as not to impose a performance penalty in the write_once path if yokozuna is not enabled.

This PR requires a corresponding fix to riak_kv, which is on the same branch name as this PR.

The yz_pb test has been augmented to include a test for write_once buckets.  The test has been shown to fail without the changes to riak_kv and yokozuna.

Cf. https://github.com/basho/riak_kv/pull/1159
