### PR TITLE
RIAK-2068 ++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto in
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
 DIALYZER_FLAGS = -Wno_return
 TEST_PLT = .yokozuna_test_dialyzer_plt
+RIAK_TEST_PATH = riak_test
 
 include tools.mk
 
@@ -39,9 +40,9 @@ ${TEST_PLT}: compile-riak-test
 ifneq (,$(RIAK_TEST_PATH))
 ifneq (,$(wildcard $(TEST_PLT)))
 	dialyzer --check_plt --plt $(TEST_PLT) && \
-		dialyzer --add_to_plt --plt $(TEST_PLT) --apps edoc --output_plt $(TEST_PLT) ebin $(RIAK_TEST_PATH)/ebin $(RIAK_TEST_PATH)/deps/riakc/ebin ; test $$? -ne 1
+		dialyzer --add_to_plt --plt $(TEST_PLT) --apps edoc --output_plt $(TEST_PLT) ebin $(RIAK_TEST_PATH)/ebin ; test $$? -ne 1
 else
-	dialyzer --build_plt --apps edoc --output_plt $(TEST_PLT) ebin $(RIAK_TEST_PATH)/ebin $(RIAK_TEST_PATH)/deps/riakc ; test $$? -ne 1
+	dialyzer --build_plt --apps edoc --output_plt $(TEST_PLT) ebin $(RIAK_TEST_PATH)/ebin ; test $$? -ne 1
 endif
 else
 	@echo "Set RIAK_TEST_PATH"

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -241,11 +241,12 @@
                       {partition, lp()} |
                       {limit, pos_integer()}].
 -type ed_continuation() :: none | base64().
+-type ed_pairs() :: [{DocID::binary(), Hash::base64()}].
 
 -record(entropy_data, {
           more=false :: boolean(),
           continuation :: ed_continuation(),
-          pairs :: [{DocID::binary(), Hash::base64()}]
+          pairs :: ed_pairs()
          }).
 -type entropy_data() :: #entropy_data{}.
 -type keydiff() :: hashtree:keydiff().
@@ -292,6 +293,8 @@
 -define(ERROR(Fmt), lager:error(Fmt)).
 -define(ERROR(Fmt, Args), lager:error(Fmt, Args)).
 -define(INFO(Fmt, Args), lager:info(Fmt, Args)).
+-define(NOTICE(Fmt, Args), lager:notice(Fmt, Args)).
+-define(NOTICE(Fmt), lager:notice(Fmt)).
 -define(WARN(Fmt, Args), lager:warning(Fmt, Args)).
 
 %%%===================================================================

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -160,6 +160,10 @@
                         app_helper:get_env(riak_core, platform_data_dir)++"/yz")).
 -define(YZ_TEMP_DIR, app_helper:get_env(?YZ_APP_NAME, temp_dir,
                         app_helper:get_env(riak_core, platform_data_dir)++"/yz_temp")).
+%% The request timeout for Solr calls. Defaults to 60 seconds.
+-define(YZ_SOLR_REQUEST_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
+                                                    solr_request_timeout,
+                                                    60000)).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).
 -define(YZ_CORE_CFG_FILE, "solrconfig.xml").
 -define(YZ_INDEX_CMD, #yz_index_cmd).

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -59,3 +59,12 @@
   {datatype, directory},
   hidden
 ]}.
+
+%% @doc The timeout for ibrowse (ibrowse:send_req) requests to Solr endpoints.
+%% Defaults to 60 seconds. It will always round up to the nearest second, e.g.
+%% 1ms = 999 ms = 1s.
+{mapping, "search.solr.request_timeout", "yokozuna.solr_request_timeout", [
+  {default, "60s"},
+  {datatype, {duration, ms}},
+  hidden
+]}.

--- a/riak_test/intercepts/yz_solr_intercepts.erl
+++ b/riak_test/intercepts/yz_solr_intercepts.erl
@@ -1,6 +1,25 @@
 -module(yz_solr_intercepts).
 -compile(export_all).
 
+-type index_name() :: binary().
+
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+
+-spec slow_cores() -> {ok, []}.
 slow_cores() ->
     timer:sleep(6000),
     {ok, []}.
+
+-spec entropy_data_cant_complete(index_name(), list()) -> {error, term()}.
+entropy_data_cant_complete(Core, Filter) ->
+    Params = [{wt, json}|Filter] -- [{continuation, none}],
+    Params2 = proplists:substitute_aliases([{continuation, continue},
+                                            {limit,n}], Params),
+    Opts = [{response_format, binary}],
+    URL = ?FMT("~s/~s/entropy_data?~s",
+               [yz_solr:base_url(), Core, mochiweb_util:urlencode(Params2)]),
+    case ibrowse:send_req(URL, [], get, [], Opts, 0) of
+        Error ->
+            {error, Error}
+    end.
+

--- a/riak_test/yz_entropy_data.erl
+++ b/riak_test/yz_entropy_data.erl
@@ -1,0 +1,131 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%-------------------------------------------------------------------
+
+%% @doc Test that checks through various entropy_data endpoint calls
+%%      and entropy_data iteration handling
+%% @end
+
+-module(yz_entropy_data).
+
+-compile(export_all).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(RING_SIZE, 32).
+-define(CFG,
+        [
+         {riak_core,
+          [
+           {ring_creation_size, ?RING_SIZE}
+          ]},
+         {riak_kv,
+          [
+           {anti_entropy_tick, 1000},
+           %% allow AAE to build trees and exchange rapidly
+           {anti_entropy_build_limit, {100, 1000}},
+           {anti_entropy_concurrency, 8}
+          ]},
+         {yokozuna,
+          [
+           {enabled, true},
+           {solr_request_timeout, 60000}
+          ]}
+        ]).
+-define(NO_HEADERS, []).
+-define(NO_BODY, <<>>).
+-define(INDEX, <<"test_search_entropy">>).
+-define(TYPE, <<"data_entropy">>).
+-define(BUCKET, {?TYPE, <<"test_search_entropy">>}).
+-define(TOTAL, 1000).
+
+confirm() ->
+    [Node1|_] = Cluster = rt:build_cluster(4, ?CFG),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+    ok = yz_rt:create_bucket_type(Node1, ?TYPE),
+    ok = yz_rt:create_index_http(Cluster, ?INDEX),
+    yz_rt:set_index(Node1, ?BUCKET, ?INDEX),
+    HP = hd(yz_rt:host_entries(rt:connection_info(Cluster))),
+
+    %% write_objs writes a seq of 1000 objects
+    yz_rt:write_objs(Cluster, ?BUCKET),
+
+    %% time for soft auto commit
+    timer:sleep(1100),
+
+    ?assert(yz_rt:search_expect(yokozuna, HP, ?INDEX, "*", "*", ?TOTAL)),
+
+    EDParams = [{wt, json}],
+
+    PartitionList = rpc:call(Node1, yokozuna, partition_list, [?INDEX]),
+
+    EntropyURL = yz_rt:entropy_data_url({rt:select_random(Cluster),
+                                         yz_rt:node_solr_port(Node1)},
+                                        ?INDEX, EDParams),
+
+    test_entropy_get_missing_partition_param(EntropyURL),
+    test_entropy_get(Node1, ?INDEX, PartitionList, EDParams),
+
+    test_ed_timeout_error(Cluster, ?INDEX, rt:select_random(PartitionList),
+                          ?CFG),
+
+    pass.
+
+-spec test_entropy_get_missing_partition_param(string()) -> ok.
+test_entropy_get_missing_partition_param(URL) ->
+    lager:info("Test missing `partition` parameter on entropy url"),
+    {ok, Status, _, _} = yz_rt:http(get, URL, ?NO_HEADERS, ?NO_BODY),
+    ?assertEqual(Status, "500").
+
+test_entropy_get(Node, Index, PartitionList, EDParams) ->
+    lager:info("Test checking through documents on each solr `partition` in the partition list"),
+    EntropyURLs = [yz_rt:entropy_data_url(
+                     {Node, yz_rt:node_solr_port(Node)},
+                     Index,
+                     [{partition, P}|EDParams])
+                  || P <- PartitionList],
+    Results =
+        [begin
+             {ok, "200", _, R} = yz_rt:http(get, URL, ?NO_HEADERS, ?NO_BODY),
+             yz_rt:get_count(R)
+         end || URL <- EntropyURLs],
+
+    [?assert(Count > 0) || Count <- Results],
+    ok.
+
+-spec test_ed_timeout_error([node()], index_name(), p(), proplist()) -> ok.
+test_ed_timeout_error(Cluster, Index, Partition, _Config) ->
+    lager:info("wait for full exchange around before making entropy call"),
+    TS1 = erlang:now(),
+    yz_rt:wait_for_full_exchange_round(Cluster, TS1),
+
+    Node = rt:select_random(Cluster),
+
+    %% load and install the intercept
+    rt_intercept:load_code(Node, [filename:join([rt_config:get(yz_dir),
+        "riak_test", "intercepts", "*.erl"])]),
+    rt_intercept:add(Node, {yz_solr, [{{entropy_data, 2},
+                                      entropy_data_cant_complete}]}),
+
+    Filter = [{partition, Partition}],
+    Fun = fun({_BKey, _Hash}) ->
+                  fake_fun
+          end,
+    ?assertEqual(rpc:call(Node, yz_entropy, iterate_entropy_data,
+                          [Index, Filter, Fun]), error).

--- a/riak_test/yz_errors.erl
+++ b/riak_test/yz_errors.erl
@@ -2,9 +2,7 @@
 -module(yz_errors).
 -compile(export_all).
 -import(yz_rt, [host_entries/1,
-                run_bb/2, search_expect/5,
-                select_random/1, verify_count/2,
-                write_terms/2]).
+                run_bb/2, search_expect/5]).
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/riak_test/yz_mapreduce.erl
+++ b/riak_test/yz_mapreduce.erl
@@ -11,7 +11,7 @@
 -include("yokozuna.hrl").
 
 -type host() :: string().
--type portnum() :: integer().
+-type portnum() :: non_neg_integer().
 
 -define(CFG,
         [{riak_core,
@@ -40,7 +40,7 @@ confirm() ->
     yz_rt:create_index(yz_rt:select_random(Cluster), Index),
     yz_rt:set_bucket_type_index(yz_rt:select_random(Cluster), Index),
     timer:sleep(500),
-    write_objs(Cluster, Bucket),
+    yz_rt:write_objs(Cluster, Bucket),
     verify_objs_mr(Cluster, Index),
     ok = yz_rt:load_module(Cluster, ?MODULE),
     %% NOTE: Deliberate choice not to use `wait_unil'.  The data is
@@ -122,23 +122,6 @@ verify_objs_mr(Cluster, Index) ->
                 1000 == A
         end,
     yz_rt:wait_until(Cluster, F).
-
--spec write_objs([node()], index_name()) -> ok.
-write_objs(Cluster, Bucket) ->
-    lager:info("Writing 1000 objects"),
-    lists:foreach(write_obj(Cluster, Bucket), lists:seq(1,1000)).
-
--spec write_obj([node()], bucket()) -> fun().
-write_obj(Cluster, Bucket) ->
-    fun(N) ->
-            PL = [{name_s,<<"yokozuna">>}, {num_i,N}],
-            Key = list_to_binary(io_lib:format("key_~B", [N])),
-            Body = mochijson2:encode(PL),
-            HP = yz_rt:select_random(yz_rt:host_entries(rt:connection_info(Cluster))),
-            CT = "application/json",
-            lager:info("Writing object with bkey ~p [~p]", [{Bucket, Key}, HP]),
-            yz_rt:http_put(HP, Bucket, Key, CT, Body)
-    end.
 
 -spec http_mr({host(), portnum()}, term()) -> binary().
 http_mr({Host,Port}, MR) ->

--- a/riak_test/yz_search_http.erl
+++ b/riak_test/yz_search_http.erl
@@ -28,15 +28,18 @@
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(RING_SIZE, 8).
+-define(DEFAULT_TIMEOUT, 60000).
 -define(CFG,
         [
          {riak_core,
           [
-           {ring_creation_size, 8}
+           {ring_creation_size, ?RING_SIZE}
           ]},
          {yokozuna,
           [
-           {enabled, true}
+           {enabled, true},
+           {solr_request_timeout, ?DEFAULT_TIMEOUT}
           ]}
         ]).
 -define(NO_HEADERS, []).

--- a/riak_test/yz_security.erl
+++ b/riak_test/yz_security.erl
@@ -2,10 +2,7 @@
 %%      if security is activated
 -module(yz_security).
 -compile(export_all).
--import(yz_rt, [host_entries/1,
-                run_bb/2, search_expect/5,
-                select_random/1, verify_count/2,
-                write_terms/2]).
+-import(yz_rt, [host_entries/1]).
 -import(rt, [connection_info/1,
              build_cluster/2, wait_for_cluster_service/2]).
 -include("yokozuna.hrl").

--- a/riak_test/yz_siblings.erl
+++ b/riak_test/yz_siblings.erl
@@ -1,9 +1,7 @@
 %% @doc Ensure that sibling creations/searching workds.
 -module(yz_siblings).
 -compile(export_all).
--import(yz_rt, [run_bb/2, search_expect/5,
-                select_random/1, verify_count/2,
-                write_terms/2]).
+-import(yz_rt, [run_bb/2]).
 -include_lib("eunit/include/eunit.hrl").
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).

--- a/src/yz_entropy.erl
+++ b/src/yz_entropy.erl
@@ -22,32 +22,63 @@
 -compile(export_all).
 -include("yokozuna.hrl").
 
+%% @doc Iterate all the entropy data in `Index' calling `Fun' for
+%%      every 100 entries.
+-spec iterate_entropy_data(index_name(), list(), function()) ->
+                                  ok|error|not_available.
+iterate_entropy_data(Index, Filter, Fun) ->
+    case yz_solr:ping(Index) of
+        true ->
+            Filter2 = [{continuation, none},
+                       {limit,
+                        app_helper:get_env(?YZ_APP_NAME,
+                                           entropy_data_limit, 100)}|Filter],
+            case get_entropy_data(Index, Filter2) of
+                {ok, ED} ->
+                    iterate_entropy_data(Index, Filter2, Fun, ED);
+                {Err, _ED} ->
+                    Err
+            end;
+        _ ->
+            ?NOTICE("Can't ping Solr to start iterating over entropy data"),
+            not_available
+    end.
 
 %%%===================================================================
 %%% Private
 %%%===================================================================
 
-%% @doc Iterate all the entropy data in `Index' calling `Fun' for
-%%      every 100 entries.
--spec iterate_entropy_data(index_name(), list(), function()) -> ok.
-iterate_entropy_data(Index, Filter, Fun) ->
-    case yz_solr:ping(Index) of
-        true ->
-            Filter2 = [{continuation, none},
-                       {limit, app_helper:get_env(?YZ_APP_NAME, entropy_data_limit, 100)}|Filter],
-            ED = yz_solr:entropy_data(Index, Filter2),
-            iterate_entropy_data(Index, Filter2, Fun, ED);
-        _ ->
-            ok
-    end.
-
+-spec iterate_entropy_data(index_name(), list(), function(), ED::entropy_data())
+                          -> ok|error.
 iterate_entropy_data(Index, Filter, Fun, #entropy_data{more=true,
                                                        continuation=Cont,
                                                        pairs=Pairs}) ->
+    %% apply function to pairs before iterating through the next set
     lists:foreach(Fun, Pairs),
     Filter2 = lists:keyreplace(continuation, 1, Filter, {continuation, Cont}),
-    ED = yz_solr:entropy_data(Index, Filter2),
-    iterate_entropy_data(Index, Filter2, Fun, ED);
+    case get_entropy_data(Index, Filter2) of
+        {ok, ED} ->
+            iterate_entropy_data(Index, Filter2, Fun, ED);
+        {Err, _ED} ->
+            Err
+    end;
 iterate_entropy_data(_, _, Fun, #entropy_data{more=false,
                                               pairs=Pairs}) ->
     lists:foreach(Fun, Pairs).
+
+-spec get_entropy_data(index_name(), list()) ->
+                              {ok|error, entropy_data()}.
+get_entropy_data(Index, Filter) ->
+    case yz_solr:entropy_data(Index, Filter) of
+        {error, {error, req_timedout}} ->
+            ?ERROR("failed to iterate over entropy data due to request"
+                   ++ " exceeding timeout ~b for filter params ~p",
+                   [?YZ_SOLR_REQUEST_TIMEOUT, Filter]),
+            {error, #entropy_data{more=false, pairs=[]}};
+        {error, Err} ->
+            ?ERROR("failed to iterate over entropy data due to request"
+                   ++ " error ~p for filter params ~p", [Err, Filter]),
+            {error, #entropy_data{more=false, pairs=[]}};
+        ED ->
+            {ok, ED}
+    end.

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -295,7 +295,7 @@ load_built(#state{trees=Trees}) ->
         _ -> false
     end.
 
--spec fold_keys(p(), tree()) -> ok.
+-spec fold_keys(p(), tree()) -> [ok|timeout|not_available].
 fold_keys(Partition, Tree) ->
     LI = yz_cover:logical_index(yz_misc:get_ring(transformed)),
     LogicalPartition = yz_cover:logical_partition(LI, Partition),
@@ -307,8 +307,7 @@ fold_keys(Partition, Tree) ->
                 insert(async, IndexN, BKey, Hash, Tree, [if_missing])
         end,
     Filter = [{partition, LogicalPartition}],
-    [yz_entropy:iterate_entropy_data(I, Filter, F) || I <- Indexes],
-    ok.
+    [yz_entropy:iterate_entropy_data(I, Filter, F) || I <- Indexes].
 
 -spec do_new_tree({p(),n()}, state()) -> state().
 do_new_tree(Id, S=#state{trees=Trees, path=Path}) ->
@@ -552,9 +551,8 @@ build_or_rehash(Tree, Locked, Type, #state{index=Index, trees=Trees}) ->
     case {Locked, Type} of
         {true, build} ->
             lager:debug("Starting YZ AAE tree build: ~p", [Index]),
-            fold_keys(Index, Tree),
-            lager:debug("Finished YZ AAE tree build: ~p", [Index]),
-            gen_server:cast(Tree, build_finished);
+            IterKeys = fold_keys(Index, Tree),
+            handle_iter_keys(Tree, Index, IterKeys);
         {true, rehash} ->
             lager:debug("Starting YZ AAE tree rehash: ~p", [Index]),
             _ = [hashtree:rehash_tree(T) || {_,T} <- Trees],
@@ -608,4 +606,19 @@ maybe_expire_caps_check(S) ->
         true ->
             S#state{expired=true};
         false -> S
+    end.
+
+-spec handle_iter_keys(pid(), p(), []| [ok|timeout|not_available]) -> ok.
+handle_iter_keys(Tree, Index, []) ->
+    lager:debug("Finished YZ AAE tree build: ~p", [Index]),
+    gen_server:cast(Tree, build_finished),
+    ok;
+handle_iter_keys(Tree, Index, IterKeys) ->
+    case lists:last(IterKeys)  of
+        ok ->
+            lager:debug("Finished YZ AAE tree build: ~p", [Index]),
+            gen_server:cast(Tree, build_finished);
+        _ ->
+            lager:debug("YZ AAE tree build failed: ~p", [Index]),
+            gen_server:cast(Tree, build_failed)
     end.

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -247,7 +247,7 @@ partition_list(Core) ->
 -spec ping(index_name()) -> boolean()|error.
 ping(Core) ->
     URL = ?FMT("~s/~s/admin/ping", [base_url(), Core]),
-    case ibrowse:send_req(URL, [], get) of
+    case ibrowse:send_req(URL, [], head) of
         {ok, "200", _, _} -> true;
         {ok, "404", _, _} -> false;
         _ -> error
@@ -282,7 +282,6 @@ search(Core, Headers, Params) ->
     URL = ?FMT("~s/~s/select", [base_url(), Core]),
     Headers2 = [{content_type, "application/x-www-form-urlencoded"}|Headers],
     Opts = [{response_format, binary}],
-    lager:info("FuckME ~p", [?YZ_SOLR_REQUEST_TIMEOUT]),
     case ibrowse:send_req(URL, Headers2, post, Body, Opts,
                           ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", RHeaders, Resp} -> {RHeaders, Resp};

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -35,7 +35,6 @@
 -define(FIELD_ALIASES, [{continuation, continue},
                         {limit, n}]).
 -define(QUERY(Bin), {struct, [{'query', Bin}]}).
--define(SOLR_TIMEOUT, 60000).
 
 -type delete_op() :: {id, binary()}
                    | {bkey, bkey()}
@@ -72,7 +71,8 @@ commit(Core) ->
     URL = ?FMT("~s/~s/update?~s", [base_url(), Core, Encoded]),
     Headers = [{content_type, "application/json"}],
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, Headers, post, JSON, Opts, ?SOLR_TIMEOUT) of
+    case ibrowse:send_req(URL, Headers, post, JSON, Opts,
+                          ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _, _} -> ok;
         Err -> throw({"Failed to commit", Err})
     end.
@@ -81,7 +81,7 @@ commit(Core) ->
 -spec core(atom(), proplist()) -> {ok, list(), binary()} |
                                   {error, term()}.
 core(Action, Props) ->
-    core(Action, Props, ?SOLR_TIMEOUT).
+    core(Action, Props, ?YZ_SOLR_REQUEST_TIMEOUT).
 
 -spec core(atom(), proplist(), ms()) -> {ok, list(), binary()} |
                                         {error, term()}.
@@ -137,7 +137,8 @@ delete(Index, Ops) ->
     URL = ?FMT("~s/~s/update", [base_url(), Index]),
     Headers = [{content_type, "application/json"}],
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, Headers, post, JSON, Opts, ?SOLR_TIMEOUT) of
+    case ibrowse:send_req(URL, Headers, post, JSON, Opts,
+                          ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _, _} -> ok;
         Err -> {error, Err}
     end.
@@ -172,7 +173,7 @@ entropy_data(Core, Filter) ->
     Opts = [{response_format, binary}],
     URL = ?FMT("~s/~s/entropy_data?~s",
                [base_url(), Core, mochiweb_util:urlencode(Params2)]),
-    case ibrowse:send_req(URL, [], get, [], Opts) of
+    case ibrowse:send_req(URL, [], get, [], Opts, ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _Headers, Body} ->
             R = mochijson2:decode(Body),
             More = kvc:path([<<"more">>], R),
@@ -196,7 +197,8 @@ index(Core, Docs, DelOps) ->
     URL = ?FMT("~s/~s/update", [base_url(), Core]),
     Headers = [{content_type, "application/json"}],
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, Headers, post, JSON, Opts, ?SOLR_TIMEOUT) of
+    case ibrowse:send_req(URL, Headers, post, JSON, Opts,
+                          ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _, _} -> ok;
         Err -> throw({"Failed to index docs", Err})
     end.
@@ -236,7 +238,7 @@ partition_list(Core) ->
     Encoded = mochiweb_util:urlencode(Params),
     URL = ?FMT("~s/~s/select?~s", [base_url(), Core, Encoded]),
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, [], get, [], Opts, ?SOLR_TIMEOUT) of
+    case ibrowse:send_req(URL, [], get, [], Opts, ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _, Resp} -> {ok, Resp};
         Err -> {error, Err}
     end.
@@ -280,7 +282,9 @@ search(Core, Headers, Params) ->
     URL = ?FMT("~s/~s/select", [base_url(), Core]),
     Headers2 = [{content_type, "application/x-www-form-urlencoded"}|Headers],
     Opts = [{response_format, binary}],
-    case ibrowse:send_req(URL, Headers2, post, Body, Opts, ?SOLR_TIMEOUT) of
+    lager:info("FuckME ~p", [?YZ_SOLR_REQUEST_TIMEOUT]),
+    case ibrowse:send_req(URL, Headers2, post, Body, Opts,
+                          ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", RHeaders, Resp} -> {RHeaders, Resp};
         {ok, CodeStr, _, Err} ->
             {Code, _} = string:to_integer(CodeStr),

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -20,6 +20,7 @@ basic_schema_test() ->
                                   "./data/yolo/yz_anti_entropy"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "./data/yolo/yz"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "./data/yolo/yz_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 60000),
     ok.
 
 override_schema_test() ->
@@ -34,7 +35,8 @@ override_schema_test() ->
             {["search", "solr", "jvm_options"], "-Xmx10G"},
             {["search", "anti_entropy", "data_dir"], "/data/aae/search"},
             {["search", "root_dir"], "/some/other/volume"},
-            {["search", "temp_dir"], "/some/other/volume_temp"}
+            {["search", "temp_dir"], "/some/other/volume_temp"},
+            {["search", "solr", "request_timeout"], "90s"}
     ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
@@ -48,6 +50,7 @@ override_schema_test() ->
                                   "/data/aae/search"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "/some/other/volume"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "/some/other/volume_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 90000),
     ok.
 
 %% this context() represents the substitution variables that rebar

--- a/tools.mk
+++ b/tools.mk
@@ -122,8 +122,8 @@ dialyzer-run:
 		| grep -F -f dialyzer.ignore-warnings.tmp -v \
 		| sed -E 's/^[[:space:]]*[0-9]+[[:space:]]*//' \
 		| sed -E 's/([]\^:+?|()*.$${}\[])/\\\1/g' \
-		| sed -E 's/(\\\.erl\\\:)/\1\\d+:/g' \
-		| sed -E 's/^(.*)$$/^\1$$/g' \
+		| sed -E 's/(\\\.erl\\\:)/\1[[:digit:]]+:/g' \
+		| sed -E 's/^(.*)$$/^[[:space:]]*\1$$/g' \
 		> dialyzer_unhandled_warnings ; \
 		rm dialyzer.ignore-warnings.tmp; \
 		if [ $$(cat dialyzer_unhandled_warnings | wc -l) -gt 0 ]; then \


### PR DESCRIPTION
- Increase and handle ibrowse _timedout_ for `entropy_data` Solr request  https://github.com/basho/yokozuna/issues/324 to prevent crash during iteration or allowing the build to _pass_ if an error occurs in iterating over the tree or if solr was not pingable. 
- make `solr_request_timeout` configurable, which is used by all Solr localhost http request and add macro timeout to `entropy_data` call.
- clean-up tests and update tools.mk
- make yz_solr:ping use a HEAD request. 
