### PR TITLE
Modified waits on queries to pattern match against 0 results

### DIFF
--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -240,7 +240,9 @@ confirm_multivalued_field(Cluster) ->
                     1 -> true;
                     0 -> false
                 end;
-            _ -> false
+            {ok, {search_results, [], _Score, 0}} ->
+                lager:info("Search for multivalued_field has not yet yielded data"),
+                false
             end
         end,
     yz_rt:wait_until(Cluster, F),
@@ -271,7 +273,9 @@ confirm_multivalued_field_json_array(Cluster) ->
                     1 -> true;
                     0 -> false
                 end;
-            _ -> false
+            {ok, {search_results, [], _Score, 0}} ->
+                lager:info("Search for multivalued_field_json_array has not yet yielded data"),
+                false
             end
         end,
     yz_rt:wait_until(Cluster, F),
@@ -303,7 +307,9 @@ confirm_multivalued_field_with_high_n_val(Cluster) ->
                     1 -> true;
                     0 -> false
                 end;
-            _ -> false
+            {ok, {search_results, [], _Score, 0}} ->
+                lager:info("Search for multivalued_field_with_high_n_val has not yet yielded data"),
+                false
             end
         end,
     yz_rt:wait_until(Cluster, F),
@@ -335,16 +341,20 @@ confirm_stored_fields(Cluster) ->
     Search = <<"float_tf:3.14">>,
     {ok, Pid} = riakc_pb_socket:start_link(Host, (Port-1)),
     F = fun(_) ->
-                {ok,{search_results,[{Index,Fields}], _Score, Found}} =
-                    riakc_pb_socket:search(Pid, Index, Search, Params),
-                ?assertEqual(<<"true">>, proplists:get_value(<<"bool_b">>, Fields)),
-                ?assertEqual(3.14,
-                             ?BIN_TO_FLOAT(proplists:get_value(<<"float_tf">>, Fields))),
-                ?assertEqual(Index, proplists:get_value(<<"_yz_rt">>, Fields)),
-                ?assertEqual(<<"b1">>, proplists:get_value(<<"_yz_rb">>, Fields)),
-                case Found of
-                    1 -> true;
-                    0 -> false
+                case riakc_pb_socket:search(Pid, Index, Search, Params) of
+                    {ok, {search_results,[{Index,Fields}], _Score, Found}} ->
+                        ?assertEqual(<<"true">>, proplists:get_value(<<"bool_b">>, Fields)),
+                        ?assertEqual(3.14,
+                            ?BIN_TO_FLOAT(proplists:get_value(<<"float_tf">>, Fields))),
+                        ?assertEqual(Index, proplists:get_value(<<"_yz_rt">>, Fields)),
+                        ?assertEqual(<<"b1">>, proplists:get_value(<<"_yz_rb">>, Fields)),
+                        case Found of
+                            1 -> true;
+                            0 -> false
+                        end;
+                    {ok, {search_results, [], _Score, 0}} ->
+                        lager:info("Search for stored_fields has not yet yielded data"),
+                        false
                 end
         end,
     yz_rt:wait_until(Cluster, F),


### PR DESCRIPTION
Branched off 2.0.  A subsequent PR will be a merge into 2.1.

This fixes an intermittently failing test where we have a bad match on the return value from a query, due to a race condition in indexing the data in Solr.  Also modified other test cases that use the same pattern, so that we match against the case where 0 results come back, and return false from the wait-for function, so that we will try again until a non-zero result comes back.
