### PR TITLE
Zl/add ed timeout cause why not really and start kv before yz

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -160,6 +160,14 @@
                         app_helper:get_env(riak_core, platform_data_dir)++"/yz")).
 -define(YZ_TEMP_DIR, app_helper:get_env(?YZ_APP_NAME, temp_dir,
                         app_helper:get_env(riak_core, platform_data_dir)++"/yz_temp")).
+%% The request timeout for Solr calls. Defaults to 60 seconds.
+-define(YZ_SOLR_REQUEST_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
+                                                    solr_request_timeout,
+                                                    60000)).
+%% The request timeout for Solr's entrop_data call. Defaults to 60 seconds.
+-define(YZ_SOLR_ED_REQUEST_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
+                                                    solr_ed_request_timeout,
+                                                    ?YZ_SOLR_REQUEST_TIMEOUT)).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).
 -define(YZ_CORE_CFG_FILE, "solrconfig.xml").
 -define(YZ_INDEX_CMD, #yz_index_cmd).

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -59,3 +59,21 @@
   {datatype, directory},
   hidden
 ]}.
+
+%% @doc The timeout for ibrowse (ibrowse:send_req) requests to Solr endpoints.
+%% Defaults to 60 seconds. It will always round up to the nearest second, e.g.
+%% 1ms = 999 ms = 1s.
+{mapping, "search.solr.request_timeout", "yokozuna.solr_request_timeout", [
+  {default, "60s"},
+  {datatype, {duration, ms}},
+  hidden
+]}.
+
+%% @doc The timeout for ibrowse (ibrowse:send_req) requests to Solr's
+%% entrop_data endpoints. Defaults to 60 seconds. It will always round up to the
+%% nearest second, e.g. 1ms = 999 ms = 1s.
+{mapping, "search.solr.request_ed_timeout", "yokozuna.solr_request_ed_timeout", [
+  {default, "60s"},
+  {datatype, {duration, ms}},
+  hidden
+]}.

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -34,6 +34,9 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
+ %% Ensure that the KV service has fully loaded.
+    riak_core:wait_for_service(riak_kv),
+
     initialize_atoms(),
     Enabled = ?YZ_ENABLED,
     case yz_sup:start_link(Enabled) of

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -172,7 +172,7 @@ entropy_data(Core, Filter) ->
     Opts = [{response_format, binary}],
     URL = ?FMT("~s/~s/entropy_data?~s",
                [base_url(), Core, mochiweb_util:urlencode(Params2)]),
-    case ibrowse:send_req(URL, [], get, [], Opts) of
+    case ibrowse:send_req(URL, [], get, [], Opts, ?YZ_SOLR_ED_REQUEST_TIMEOUT) of
         {ok, "200", _Headers, Body} ->
             R = mochijson2:decode(Body),
             More = kvc:path([<<"more">>], R),

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -20,6 +20,8 @@ basic_schema_test() ->
                                   "./data/yolo/yz_anti_entropy"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "./data/yolo/yz"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "./data/yolo/yz_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 60000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_ed_timeout", 60000),
     ok.
 
 override_schema_test() ->
@@ -34,7 +36,9 @@ override_schema_test() ->
             {["search", "solr", "jvm_options"], "-Xmx10G"},
             {["search", "anti_entropy", "data_dir"], "/data/aae/search"},
             {["search", "root_dir"], "/some/other/volume"},
-            {["search", "temp_dir"], "/some/other/volume_temp"}
+            {["search", "temp_dir"], "/some/other/volume_temp"},
+            {["search", "solr", "request_timeout"], "90s"},
+            {["search", "solr", "request_ed_timeout"], "90s"}
     ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
@@ -48,6 +52,8 @@ override_schema_test() ->
                                   "/data/aae/search"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "/some/other/volume"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "/some/other/volume_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 90000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_ed_timeout", 90000),
     ok.
 
 %% this context() represents the substitution variables that rebar


### PR DESCRIPTION
Need to add a test... I'd say, but wait for kv to start before staring yz... and just throw in the ed timeout separately. 
