### PR TITLE
make sure disabled for yz is treated separately and correctly

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -59,3 +59,27 @@
   {datatype, directory},
   hidden
 ]}.
+
+%% @doc To 'enable/disable' AAE for Search.
+%%      * active: out-of-sync keys will be repaired in the background
+%%      * passive: out-of-sync keys are only repaired on read
+%%      * active-debug: like active, but outputs verbose debugging
+%%        information
+{mapping, "search.anti_entropy", "yokozuna.anti_entropy", [
+  {datatype, {enum, [active, passive, 'active-debug']}},
+  {default, active},
+  hidden
+]}.
+
+{translation,
+ "yokozuna.anti_entropy",
+ fun(Conf) ->
+    Setting = cuttlefish:conf_get("search.anti_entropy", Conf),
+    case Setting of
+      active -> {on, []};
+      'active-debug' -> {on, [debug]};
+      passive -> {off, []};
+      _Default -> {on, []}
+    end
+  end
+}.

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -402,10 +402,8 @@ first_partition([{Partition, _}|_]) ->
 
 %% @private
 %%
-%% @doc Get the tree.
+%% @doc Get the tree if yz anti_entropy is enabled.
 %%
-%% NOTE: Relies on the fact that this code runs on the KV vnode
-%%       process.
 -spec get_tree(p()) -> tree() | not_registered.
 get_tree(Partition) ->
     case erlang:get({tree,Partition}) of
@@ -425,13 +423,19 @@ get_tree(Partition) ->
 %% @private
 -spec get_and_set_tree(p()) -> tree() | not_registered.
 get_and_set_tree(Partition) ->
-    case yz_entropy_mgr:get_tree(Partition) of
-        {ok, Tree} ->
-            erlang:put({tree,Partition}, Tree),
-            Tree;
-        not_registered ->
-            erlang:put({tree,Partition}, undefined),
+    case yz_entropy_mgr:enabled() of
+        true ->
+            case yz_entropy_mgr:get_tree(Partition) of
+                {ok, Tree} ->
+                    erlang:put({tree,Partition}, Tree),
+                    Tree;
+                not_registered ->
+                    erlang:put({tree,Partition}, undefined),
+                    not_registered
+            end;
+        false ->
             not_registered
+
     end.
 
 %% @private
@@ -499,7 +503,6 @@ delete_operation(Obj, put, Docs, BKey, LP) ->
     end;
 delete_operation(Obj, _Reason, Docs, BKey, LP) ->
     cleanup(length(Docs), {Obj, BKey, LP}).
-
 
 %%%===================================================================
 %%% Tests

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -20,6 +20,7 @@ basic_schema_test() ->
                                   "./data/yolo/yz_anti_entropy"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "./data/yolo/yz"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "./data/yolo/yz_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.anti_entropy", {on, []}),
     ok.
 
 override_schema_test() ->
@@ -34,7 +35,8 @@ override_schema_test() ->
             {["search", "solr", "jvm_options"], "-Xmx10G"},
             {["search", "anti_entropy", "data_dir"], "/data/aae/search"},
             {["search", "root_dir"], "/some/other/volume"},
-            {["search", "temp_dir"], "/some/other/volume_temp"}
+            {["search", "temp_dir"], "/some/other/volume_temp"},
+            {["search", "anti_entropy"], "passive"}
     ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
@@ -48,6 +50,7 @@ override_schema_test() ->
                                   "/data/aae/search"),
     cuttlefish_unit:assert_config(Config, "yokozuna.root_dir", "/some/other/volume"),
     cuttlefish_unit:assert_config(Config, "yokozuna.temp_dir", "/some/other/volume_temp"),
+    cuttlefish_unit:assert_config(Config, "yokozuna.anti_entropy", {off, []}),
     ok.
 
 %% this context() represents the substitution variables that rebar


### PR DESCRIPTION
As per discussions w/ @fadushin and @jonmeredith, this handles separately disabling yz aae correctly. The handling of entropy_mgr calls was actually the same as riak_kv... so... there's still room for cleanup, but this is something.
