### PR TITLE
Bugfix/zl/delete handling

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -301,6 +301,7 @@
 -type reload_opts() :: [reload_opt()].
 -type reload_errs() :: [{node(), {error, term()}}].
 
+-define(TOMBSTONE, <<>>).
 -define(YZ_INDEX_TOMBSTONE, <<"_dont_index_">>).
 -define(YZ_INDEX, search_index).
 

--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -29,6 +29,12 @@
 -define(YZ_ID_VER, "1").
 -define(YZ_ED_VER, <<"3">>).
 
+-ifdef(namespaced_types).
+-type riak_object_dict() :: dict:dict().
+-else.
+-type riak_object_dict() :: dict().
+-endif.
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -55,25 +61,38 @@ doc_id(O, Partition, Sibling) ->
     end.
 
 % @doc `true' if this Object has multiple contents
+-spec has_siblings(obj()) -> boolean().
 has_siblings(O) -> riak_object:value_count(O) > 1.
+
+% @doc count of Object contents that are siblings and not tombstones
+-spec live_siblings([{riak_object_dict(), riak_object:value()}]) -> non_neg_integer().
+live_siblings(Cs) -> length([1 || {MD, _V} <- Cs, not yz_kv:is_tombstone(MD)]).
 
 %% @doc Given an object generate the doc to be indexed by Solr.
 -spec make_docs(obj(), hash(), binary(), binary()) -> [doc()].
 make_docs(O, Hash, FPN, Partition) ->
-    [make_doc(O, Hash, Content, FPN, Partition)
-     || Content <- riak_object:get_contents(O)].
+    Contents = riak_object:get_contents(O),
+    LiveSiblings = live_siblings(Contents),
+    [make_doc(O, Hash, LiveSiblings, Content, FPN, Partition)
+     || Content <- Contents].
 
--spec make_doc(obj(), hash(), {yz_dict(), yz_dict()}, binary(), binary()) -> doc().
-make_doc(O, Hash, {MD, V}, FPN, Partition) ->
-    Vtag = get_vtag(O, MD),
-    DocId = doc_id(O, Partition, Vtag),
-    EntropyData = gen_ed(O, Hash, Partition),
-    Bkey = {yz_kv:get_obj_bucket(O), yz_kv:get_obj_key(O)},
-    Fields = make_fields({DocId, Bkey, FPN,
-                          Partition, Vtag, EntropyData}),
-    ExtractedFields = extract_fields({MD, V}),
-    Tags = extract_tags(MD),
-    {doc, lists:append([Tags, ExtractedFields, Fields])}.
+-spec make_doc(obj(), hash(), non_neg_integer(), {yz_dict(), yz_dict()}, binary(),
+               binary()) -> doc().
+make_doc(O, Hash, LiveSiblings, {MD, V}, FPN, Partition) ->
+    case yz_kv:is_tombstone(MD) of
+        false ->
+            Vtag = get_vtag(MD, LiveSiblings),
+            DocId = doc_id(O, Partition, Vtag),
+            EntropyData = gen_ed(O, Hash, Partition),
+            Bkey = {yz_kv:get_obj_bucket(O), yz_kv:get_obj_key(O)},
+            Fields = make_fields({DocId, Bkey, FPN,
+                                  Partition, Vtag, EntropyData}),
+            ExtractedFields = extract_fields({MD, V}),
+            Tags = extract_tags(MD),
+            {doc, lists:append([Tags, ExtractedFields, Fields])};
+        true ->
+            {doc, [{tombstone, ?TOMBSTONE}]}
+    end.
 
 %% @private
 %% @doc encode `*' as %1, and `%' as %2. This is so we can reasonably use
@@ -106,38 +125,32 @@ make_fields({DocId, BKey, FPN, Partition, Vtag, EntropyData}) ->
     Fields = make_fields({DocId, BKey, FPN, Partition, none, EntropyData}),
     [{?YZ_VTAG_FIELD, Vtag}|Fields].
 
-%% @doc If this is a sibling, return its binary vtag
-get_vtag(O, MD) ->
-    case has_siblings(O) of
+%% @doc If this is a sibling and not a tombstone val, return its binary vtag
+get_vtag(MD, LiveSiblings) ->
+    case LiveSiblings > 1 of
         true -> list_to_binary(yz_kv:get_md_entry(MD, ?MD_VTAG));
         _ -> none
     end.
 
--spec extract_fields({obj_metadata(), term()}) ->  fields() | {error, any()}.
+-spec extract_fields({obj_metadata(), term()}) -> fields() | [{error, any()}].
 extract_fields({MD, V}) ->
-    case yz_kv:is_tombstone(MD) of
-        false ->
-            CT = yz_kv:get_obj_ct(MD),
-            ExtractorDef = yz_extractor:get_def(CT, [check_default]),
-            try
-                case yz_extractor:run(V, ExtractorDef) of
-                    {error, Reason} ->
-                        yz_stat:index_fail(),
-                        ?ERROR("failed to index fields from value with reason ~s~nValue: ~s", [Reason, V]),
-                        [{?YZ_ERR_FIELD_S, 1}];
-                    Fields ->
-                        Fields
-                end
-            catch _:Err ->
-                    yz_stat:index_fail(),
-                    Trace = erlang:get_stacktrace(),
-                    ?ERROR("failed to index fields from value with reason ~s ~p~nValue: ~s", [Err, Trace, V]),
-                    [{?YZ_ERR_FIELD_S, 1}]
-            end;
-        true ->
-            []
+    CT = yz_kv:get_obj_ct(MD),
+    ExtractorDef = yz_extractor:get_def(CT, [check_default]),
+    try
+        case yz_extractor:run(V, ExtractorDef) of
+            {error, Reason} ->
+                yz_stat:index_fail(),
+                ?ERROR("failed to index fields from value with reason ~s~nValue: ~s", [Reason, V]),
+                [{?YZ_ERR_FIELD_S, 1}];
+            Fields ->
+                Fields
+        end
+    catch _:Err ->
+            yz_stat:index_fail(),
+            Trace = erlang:get_stacktrace(),
+            ?ERROR("failed to index fields from value with reason ~s ~p~nValue: ~s", [Err, Trace, V]),
+            [{?YZ_ERR_FIELD_S, 1}]
     end.
-
 
 %% @private
 %%

--- a/src/yz_kv.erl
+++ b/src/yz_kv.erl
@@ -31,7 +31,7 @@
 -endif.
 
 -type write_reason() :: delete | handoff | put | anti_entropy.
-
+-type delops() :: []|[{id, _}]|[{siblings, _}].
 
 %%%===================================================================
 %%% TODO: move to riak_core
@@ -256,7 +256,10 @@ index(_, delete, _, P, BKey, ShortPL, Index) ->
     ok = yz_solr:delete(Index, [{bkey, BKey}]),
     ok = update_hashtree(delete, P, ShortPL, BKey),
     ok;
-index(Obj, Reason, Ring, P, BKey, ShortPL, Index) ->
+index(Obj0, Reason, Ring, P, BKey, ShortPL, Index) ->
+    {Bucket, _} = BKey,
+    BProps = riak_core_bucket:get_bucket(Bucket),
+    Obj = maybe_merge_siblings(BProps, Obj0),
     case riak_object:get_values(Obj) of
         [notfound] ->
             ok = index(Obj, delete, Ring, P, BKey, ShortPL, Index);
@@ -264,10 +267,12 @@ index(Obj, Reason, Ring, P, BKey, ShortPL, Index) ->
             LI = yz_cover:logical_index(Ring),
             LFPN = yz_cover:logical_partition(LI, element(1, ShortPL)),
             LP = yz_cover:logical_partition(LI, P),
-            Hash = hash_object(Obj),
+            %% Use the original hash to match kv's hashes for aae as kv doesn't
+            %% *maybe* merge siblings
+            Hash = hash_object(Obj0),
             Docs = yz_doc:make_docs(Obj, Hash, ?INT_TO_BIN(LFPN), ?INT_TO_BIN(LP)),
-            ok = yz_solr:index(Index, Docs, delete_operation(Obj, Reason, Docs,
-                                                             BKey, LP)),
+            DelOps = delete_operation(BProps, Obj, Reason, Docs, BKey, LP),
+            ok = solr_index(Index, Docs, DelOps),
             ok = update_hashtree({insert, Hash}, P, ShortPL, BKey)
     end.
 
@@ -382,6 +387,19 @@ check_flag(Flag) ->
     true == erlang:get(Flag).
 
 %% @private
+%%
+%% @doc Cleanup tombstones and siblings accordingly... cleanup/3
+%% TODO: deprecate 1/2 versions in favor of generic solution for sibling value
+%% Objects, focused on allow_mult=true case
+-spec cleanup(non_neg_integer()|[doc()], {obj(), bkey(), lp()}|bkey()) ->
+                     [{id, binary()}|{siblings, bkey()}|{bkey, bkey()}].
+cleanup([], _BKey) ->
+    [];
+cleanup([{doc, Fields}|T], BKey) ->
+    case proplists:is_defined(tombstone, Fields) of
+        true -> [{bkey, BKey}];
+        false -> cleanup(T, BKey)
+    end;
 cleanup(1, {_Obj, BKey, _LP}) ->
     %% Delete any siblings
     [{siblings, BKey}];
@@ -466,40 +484,77 @@ is_service_up(Service, Node) ->
 
 %% @private
 %%
-%% @doc Check if object has 2.0 CRDT datatype entry or property for
-%%      strong consistency.
--spec is_datatype_or_consistent(obj()) -> boolean()|{error, _}.
-is_datatype_or_consistent(Obj) ->
-    Bucket = riak_object:bucket(Obj),
-    case riak_core_bucket:get_bucket(Bucket) of
-        BProps when is_list(BProps) ->
-            is_datatype(BProps) orelse lists:member({consistent, true}, BProps);
-        {error, _}=Err ->
-            Err
-    end.
+%% @doc Check if bucket props have 2.0 CRDT datatype entry or
+%%      property for strong consistency.
+-spec is_datatype_or_consistent(riak_kv_bucket:props()) -> boolean().
+is_datatype_or_consistent(BProps) when is_list(BProps) ->
+    is_datatype(BProps) orelse lists:member({consistent, true}, BProps);
+is_datatype_or_consistent(_) -> false.
 
 %% @private
 %%
 %% @doc Check if Bucket Properties contain CRDT datatype.
 -spec is_datatype(riak_kv_bucket:props()) -> boolean().
-is_datatype(BProps) ->
+is_datatype(BProps) when is_list(BProps) ->
     Type = proplists:get_value(datatype, BProps),
     Mod = riak_kv_crdt:to_mod(Type),
-    riak_kv_crdt:supported(Mod).
+    riak_kv_crdt:supported(Mod);
+is_datatype(_) -> false.
 
 %% @private
 %%
-%% @doc Set yz_solr:index delete operation(s) on write_reason.
--spec delete_operation(obj(), put|handoff|anti_entropy, [doc()], bkey(), lp()) ->
-                              []|[{id, _}]|[{siblings, _}].
-delete_operation(Obj, put, Docs, BKey, LP) ->
-    case is_datatype_or_consistent(Obj) of
-        true -> [];
-        false -> cleanup(length(Docs), {Obj, BKey, LP})
+%% @doc Check if bucket props allow for siblings.
+-spec should_have_siblings(riak_kv_bucket:props()) -> boolean().
+should_have_siblings(BProps) when is_list(BProps) ->
+    case {is_datatype_or_consistent(BProps),
+          proplists:get_bool(allow_mult, BProps),
+          proplists:get_bool(last_write_wins, BProps)} of
+        {true, _, _} -> false;
+        {false, _, true} -> false;
+        {false, false, _} -> false;
+        {_, _, _} -> true
     end;
-delete_operation(Obj, _Reason, Docs, BKey, LP) ->
-    cleanup(length(Docs), {Obj, BKey, LP}).
+should_have_siblings(_) -> true.
 
+%% @private
+%%
+%% @doc Set yz_solr:index delete operation(s).
+%%      If object relates to lww=true/allow_mult=false/datatype/sc
+%%      do cleanup of tombstones only.
+-spec delete_operation(riak_kv_bucket:props(), obj(), write_reason(), [doc()],
+                       bkey(), lp()) -> delops().
+delete_operation(BProps, Obj, _Reason, Docs, BKey, LP) ->
+    case should_have_siblings(BProps) of
+        true -> cleanup(length(Docs), {Obj, BKey, LP});
+        false -> cleanup(Docs, BKey)
+    end.
+
+%% @private
+%%
+%% @doc Merge siblings for objects that shouldn't have them.
+-spec maybe_merge_siblings(riak_kv_bucket:props(), obj()) -> obj().
+maybe_merge_siblings(BProps, Obj) ->
+    case should_have_siblings(BProps) of
+        true ->
+            Obj;
+        false ->
+            case is_datatype(BProps) of
+                true -> riak_kv_crdt:merge(Obj);
+                false -> riak_object:reconcile([Obj], false)
+            end
+    end.
+
+%% @private
+%%
+%% @doc Determine which docs/ops make it solr index call and make the call.
+-spec solr_index(index_name(), [doc()], delops()) -> ok.
+solr_index(Index, Docs, DelOps) ->
+    %% remove docs which have tombstone, <<>>, values in preparation
+    %% for add updates
+    yz_solr:index(Index,
+                  [{doc, Fields} ||  {doc, Fields} <- Docs,
+                                    not proplists:is_defined(tombstone, Fields)],
+                  DelOps).
 
 %%%===================================================================
 %%% Tests
@@ -507,7 +562,7 @@ delete_operation(Obj, _Reason, Docs, BKey, LP) ->
 
 -ifdef(TEST).
 
-is_datatype_or_consistent_test_() ->
+should_have_siblings_test_() ->
 {setup,
      fun() ->
              meck:new(riak_core_capability, []),
@@ -555,9 +610,13 @@ is_datatype_or_consistent_test_() ->
                  BTProps = riak_core_bucket:get_bucket(Bucket2),
                  ?assert(proplists:get_value(consistent, BTProps)),
                  ?assertEqual(Bucket2, proplists:get_value(name, BTProps)),
-                 [?assert(is_datatype_or_consistent(riak_object:new(B, K, V)))
-                  || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
-                                 {Bucket2, <<"k2">>, hey}]]
+                 [begin
+                      Object = riak_object:new(B, K, V),
+                      CheckBucket = riak_object:bucket(Object),
+                      CheckBucketProps = riak_core_bucket:get_bucket(CheckBucket),
+                      ?assertNot(should_have_siblings(CheckBucketProps))
+                  end || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
+                                     {Bucket2, <<"k2">>, hey}]]
              end),
       ?_test(begin
                  BucketType1 = <<"counters">>,
@@ -572,24 +631,52 @@ is_datatype_or_consistent_test_() ->
                  BTProps2 = riak_core_bucket:get_bucket(Bucket2),
                  ?assertEqual(counter, proplists:get_value(datatype, BTProps1)),
                  ?assertEqual(map, proplists:get_value(datatype, BTProps2)),
-                 [?assert(is_datatype_or_consistent(riak_object:new(B, K, V)))
-                  || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
-                                 {Bucket2, <<"k2">>, hey}]]
+                 [begin
+                      Object = riak_object:new(B, K, V),
+                      CheckBucket = riak_object:bucket(Object),
+                      CheckBucketProps = riak_core_bucket:get_bucket(CheckBucket),
+                      ?assertNot(should_have_siblings(CheckBucketProps))
+                  end || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
+                                     {Bucket2, <<"k2">>, hey}]]
+             end),
+      ?_test(begin
+                 Bucket1 = <<"lww">>,
+                 BucketType = <<"allow_multz">>,
+                 Bucket2 = {BucketType, <<"allowz">>},
+                 riak_core_bucket:set_bucket(Bucket1, [{last_write_wins, true}]),
+                 riak_core_bucket_type:create(BucketType, [{allow_mult, false}]),
+                 riak_core_bucket_type:activate(BucketType),
+                 BTProps1 = riak_core_bucket:get_bucket(Bucket1),
+                 BTProps2 = riak_core_bucket:get_bucket(Bucket2),
+                 ?assertEqual(true, proplists:get_bool(last_write_wins, BTProps1)),
+                 ?assertEqual(false, proplists:get_bool(allow_mult, BTProps2)),
+                 [begin
+                      Object = riak_object:new(B, K, V),
+                      CheckBucket = riak_object:bucket(Object),
+                      CheckBucketProps = riak_core_bucket:get_bucket(CheckBucket),
+                      ?assertNot(should_have_siblings(CheckBucketProps))
+                  end || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
+                                     {Bucket2, <<"k2">>, hey}]]
              end),
       ?_test(begin
                  Bucket1 = <<"buckety">>,
                  BucketType = <<"typey">>,
                  Bucket2 = {BucketType, <<"bucketjumpy">>},
-                 riak_core_bucket:set_bucket(Bucket1, []),
+                 riak_core_bucket:set_bucket(Bucket1, [{allow_mult, true}]),
                  riak_core_bucket_type:create(BucketType, []),
                  riak_core_bucket_type:activate(BucketType),
-                 ?assertEqual([{name, Bucket1}],
-                              riak_core_bucket:get_bucket(Bucket1)),
-                 BTProps = riak_core_bucket:get_bucket(Bucket2),
-                 ?assertEqual(Bucket2, proplists:get_value(name, BTProps)),
-                 [?assertNot(is_datatype_or_consistent(riak_object:new(B, K, V)))
-                  || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
-                                 {Bucket2, <<"k2">>, hey}]]
+                 BTProps1 = riak_core_bucket:get_bucket(Bucket1),
+                 BTProps2 = riak_core_bucket:get_bucket(Bucket2),
+                 ?assertEqual(Bucket1, proplists:get_value(name, BTProps1)),
+                 ?assertEqual(Bucket2, proplists:get_value(name, BTProps2)),
+                 ?assertEqual(true, proplists:get_bool(allow_mult, BTProps2)),
+                 [begin
+                      Object = riak_object:new(B, K, V),
+                      CheckBucket = riak_object:bucket(Object),
+                      CheckBucketProps = riak_core_bucket:get_bucket(CheckBucket),
+                      ?assert(should_have_siblings(CheckBucketProps))
+                  end || {B, K, V} <- [{Bucket1, <<"k1">>, hi},
+                                     {Bucket2, <<"k2">>, hey}]]
              end)]}.
 
 -endif.

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -386,7 +386,7 @@ encode_delete({id, Id}) ->
     {struct, [{id, Id}]}.
 
 encode_doc({doc, Fields}) ->
-    {struct, [{doc, lists:map(fun encode_field/1,Fields)}]}.
+    {struct, [{doc, lists:map(fun encode_field/1, Fields)}]}.
 
 encode_field({Name,Value}) when is_list(Value) ->
     {Name, list_to_binary(Value)};


### PR DESCRIPTION
Start by handling search delete operations for crdts/lww=true/allow_mult=false/sc by checking for tombstones exist, so we don't have to wait for the reap. 

related for crdts/datatypes -> https://github.com/basho/riak_test/pull/862/files.

More prs to come w/ delete-path cleanup... this moves to solve: https://github.com/basho/yokozuna/issues/423.
