### PR TITLE
hashtree:flush_buffer before finishing build of hashtree

### DIFF
--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -374,12 +374,7 @@ apply_tree(Id, Fun, S=#state{trees=Trees}) ->
 do_build_finished(S=#state{index=Index, built=_Pid, trees=Trees0}) ->
     lager:debug("Finished YZ build: ~p", [Index]),
     Trees = orddict:map(fun(_Id, Tree) ->
-                            try
-                                hashtree:flush_buffer(Tree)
-                            catch _:_ ->
-                                lager:warning("Failed to flush trees during build_finish"),
-                                Tree
-                            end
+                            hashtree:flush_buffer(Tree)
                         end, Trees0),
     {_, Tree0} = hd(Trees),
     BuildTime = yz_kv:get_tree_build_time(Tree0),


### PR DESCRIPTION
simple fix, but make sure to call hashtree:flush_buffer before buildtime, meta for build_finished

^^ @jonmeredith 
