### PR TITLE
handle fuse events for recovered and make yz_events a gen_event behavior

### DIFF
--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -78,6 +78,7 @@ maybe_setup(true) ->
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
+    ok = yz_events:add_handler(yz_events, []),
     yz_fuse:setup(),
     setup_stats(),
     ok = riak_core_capability:register(?YZ_CAPS_CMD_EXTRACTORS, [true, false],

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -20,19 +20,25 @@
 
 %% @doc Functionality related to events.  This is the single producer of
 %% writes to the ETS table `yz_events'.
-%%
-%% NOTE: Store the raw ring in the state because that is what is being
-%%       delivered during a ring event.
 
 -module(yz_events).
--behavior(gen_server).
--compile(export_all).
+-behavior(gen_event).
+
+%% API
+-export([start_link/0,
+         add_handler/2,
+         add_sup_handler/2,
+         add_callback/1,
+         add_sup_callback/1]).
+
+%% gen_event callbacks
 -export([code_change/3,
-         handle_call/3,
-         handle_cast/2,
+         handle_call/2,
+         handle_event/2,
          handle_info/2,
          init/1,
          terminate/2]).
+
 -include("yokozuna.hrl").
 
 -define(NUM_TICKS_START, 1).
@@ -50,7 +56,6 @@
           prev_index_hash = undefined   :: term()
          }).
 
-
 -define(DEFAULT_EVENTS_FULL_CHECK_AFTER, 60).
 -define(DEFAULT_EVENTS_TICK_INTERVAL, 1000).
 
@@ -59,7 +64,20 @@
 %%%===================================================================
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_event:start_link({local, ?MODULE}).
+
+add_handler(Handler, Args) ->
+    gen_event:add_handler(?MODULE, Handler, Args),
+    create_table().
+
+add_sup_handler(Handler, Args) ->
+    gen_event:add_sup_handler(?MODULE, Handler, Args).
+
+add_callback(Fn) when is_function(Fn) ->
+    gen_event:add_handler(?MODULE, {?MODULE, make_ref()}, [Fn]).
+
+add_sup_callback(Fn) when is_function(Fn) ->
+    gen_event:add_sup_handler(?MODULE, {?MODULE, make_ref()}, [Fn]).
 
 %%%===================================================================
 %%% Callbacks
@@ -69,8 +87,19 @@ init([]) ->
     ok = set_tick(),
     {ok, #state{}}.
 
-handle_cast(Msg, _S) ->
-    ?WARN("unknown message ~p", [Msg]).
+handle_event({Index, blown}, S) ->
+    handle_index_recovered(Index, down),
+    {ok, S};
+handle_event({Index, ok}, S) ->
+    handle_index_recovered(Index, up),
+    {ok, S};
+handle_event({Index, reset}, S) ->
+    %% TODO: We are currently using reset when an Index is removed, but there
+    %% should be a true removal of fuse eventually.
+    handle_index_recovered(Index, removed),
+    {ok, S};
+handle_event(_Msg, S) ->
+    {ok, S}.
 
 handle_info(tick, S) ->
     PrevHash = S#state.prev_index_hash,
@@ -90,11 +119,11 @@ handle_info(tick, S) ->
     NumTicks2 = incr_or_wrap(NumTicks, get_full_check_after()),
     S2 = S#state{num_ticks=NumTicks2,
                  prev_index_hash=CurrHash},
-    {noreply, S2}.
+    {ok, S2}.
 
-handle_call(Req, _, S) ->
+handle_call(Req, S) ->
     ?WARN("unexpected request ~p", [Req]),
-    {noreply, S}.
+    {ok, ok, S}.
 
 code_change(_, S, _) ->
     {ok, S}.
@@ -105,6 +134,17 @@ terminate(_Reason, _S) ->
 %%%===================================================================
 %%% Private
 %%%===================================================================
+
+%% @doc Called by {@link yz_general_sup} to create the p ETS table used to
+%% track registered events. Created when we add the handler after the supervisor
+%% is already up for yz_events.
+-spec create_table() -> ok.
+create_table() ->
+    _ = ets:new(?MODULE, [named_table, public, set,
+                          {write_concurrency, true},
+                          {read_concurrency, true},
+                          {keypos, 1}]),
+    ok.
 
 -spec add_index(index_name()) -> ok.
 add_index(Name) ->
@@ -237,3 +277,20 @@ sync_indexes() ->
 sync_indexes(Removed, Added, Same) ->
     ok = remove_indexes(Removed),
     ok = add_indexes(Added ++ Same).
+
+%% @private
+%% @doc Check and update `yz_events' ETS if the index has recovered from it's
+%%      fuse being blown or has been reset/removed.
+handle_index_recovered(Index, down) ->
+    ets:insert(?MODULE, {Index, {state, down}});
+handle_index_recovered(Index, removed) ->
+    ets:delete(Index);
+handle_index_recovered(Index, up) ->
+    Recovered = ets:lookup(?MODULE, Index),
+    case proplists:get_value(Index, Recovered, []) of
+        {state, down} ->
+            yz_stat:fuse_recovered(Index),
+            ets:insert(?MODULE, {Index, {state, up}});
+        _ ->
+            ets:insert(?MODULE, {Index, {state, up}})
+    end.


### PR DESCRIPTION
- an idea ;) which still needs a test. 
- Make yz_events into a gen_event behavior.
- Handle fuse events
- Create recovered statistic through track of index state when fuses go from blown->ok via a yz_events ets table. 
