### PR TITLE
handle fuse events for recovered and make yz_events a gen_event behavior

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,8 +16,8 @@
    {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},
   {ibrowse, "4.0.1",
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.1"}}},
-  {fuse, "2.0.0",
-   {git, "git@github.com:jlouis/fuse.git", {tag, "v2.0.0"}}}
+  {fuse, "2.1.0",
+   {git, "git@github.com:jlouis/fuse.git", {tag, "v2.1.0"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -95,7 +95,7 @@ maybe_setup(true) ->
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
-    ok = yz_events:add_handler(yz_events, []),
+    ok = yz_events:add_guarded_handler(yz_events, []),
     yz_fuse:setup(),
     setup_stats(),
     ok = riak_core_capability:register(?YZ_CAPS_CMD_EXTRACTORS, [true, false],

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -95,6 +95,7 @@ maybe_setup(true) ->
 	yz_wm_index:routes() ++ yz_wm_schema:routes(),
     yz_misc:add_routes(Routes),
     maybe_register_pb(RSEnabled),
+    ok = yz_events:add_handler(yz_events, []),
     yz_fuse:setup(),
     setup_stats(),
     ok = riak_core_capability:register(?YZ_CAPS_CMD_EXTRACTORS, [true, false],

--- a/src/yz_eventhandler_guard.erl
+++ b/src/yz_eventhandler_guard.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%% yz_eventhandler_guard: Guard process for persistent event handlers.
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc yz_eventhandler_guard processes.
+%%      Same as riak_core_eventhandler_guard.erl.
+%%      TODO: Create generic eventhandler_sup and eventhandler_guard templates.
+
+-module(yz_eventhandler_guard).
+-behaviour(gen_server).
+-export([start_link/3, start_link/4]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+-record(state, {handlermod, handler, exitfun}).
+
+start_link(HandlerMod, Handler, Args) ->
+    start_link(HandlerMod, Handler, Args, undefined).
+
+start_link(HandlerMod, Handler, Args, ExitFun) ->
+    gen_server:start_link(?MODULE, [HandlerMod, Handler, Args, ExitFun], []).
+
+init([HandlerMod, Handler, Args, ExitFun]) ->
+    ok = gen_event:add_sup_handler(HandlerMod, Handler, Args),
+    {ok, #state{handlermod=HandlerMod, handler=Handler, exitfun=ExitFun}}.
+
+handle_call(_Request, _From, State) -> {reply, ok, State}.
+
+handle_cast(_Msg, State) -> {noreply, State}.
+
+handle_info({gen_event_EXIT, _Handler, shutdown}, State) ->
+    {stop, normal, State};
+handle_info({gen_event_EXIT, _Handler, normal}, State) ->
+    {stop, normal, State};
+handle_info({gen_event_EXIT, Handler, _Reason}, State=#state{exitfun=undefined}) ->
+    {stop, {gen_event_EXIT, Handler}, State};
+handle_info({gen_event_EXIT, Handler, Reason}, State=#state{exitfun=ExitFun}) ->
+    ExitFun(Handler, Reason),
+    {stop, {gen_event_EXIT, Handler}, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, #state{}) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) -> {ok, State}.

--- a/src/yz_eventhandler_sup.erl
+++ b/src/yz_eventhandler_sup.erl
@@ -1,0 +1,54 @@
+%% -------------------------------------------------------------------
+%%
+%% yz_eventhandler_sup: Supervise processes for persistent event handlers.
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervise yz_eventhandler_guard processes.
+%%      Akin to (and wraps some of) riak_core_eventhandler_sup.erl and uses
+%%      TODO: Create generic eventhandler_sup and eventhandler_guard templates.
+
+-module(yz_eventhandler_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+-export([start_guarded_handler/3, start_guarded_handler/4, stop_guarded_handler/3]).
+
+start_guarded_handler(HandlerMod, Handler, Args) ->
+    start_guarded_handler(HandlerMod, Handler, Args, undefined).
+
+start_guarded_handler(HandlerMod, Handler, Args, ExitFun) ->
+    case supervisor:start_child(?MODULE, handler_spec(HandlerMod, Handler, Args, ExitFun)) of
+        {ok, _Pid} -> ok;
+        Other -> Other
+    end.
+
+stop_guarded_handler(HandlerMod, Handler, Args) ->
+    %% reuse already generic riak_core_eventhandler_sup:stop_guarded_handler
+    riak_core_eventhandler_sup:stop_guarded_handler(HandlerMod, Handler, Args).
+
+handler_spec(HandlerMod, Handler, Args, ExitFun) ->
+    {{HandlerMod, Handler},
+     {yz_eventhandler_guard, start_link, [HandlerMod, Handler, Args, ExitFun]},
+     transient, 5000, worker, [yz_eventhandler_guard]}.
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    {ok, {{one_for_one, 10, 10}, []}}.

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -93,9 +93,7 @@ handle_event({Index, blown}, S) ->
 handle_event({Index, ok}, S) ->
     handle_index_recovered(Index, up),
     {ok, S};
-handle_event({Index, reset}, S) ->
-    %% TODO: We are currently using reset when an Index is removed, but there
-    %% should be a true removal of fuse eventually.
+handle_event({Index, removed}, S) ->
     handle_index_recovered(Index, removed),
     {ok, S};
 handle_event(_Msg, S) ->
@@ -206,7 +204,7 @@ remove_index(Name) ->
     case yz_solr:ping(Name) of
         true ->
             ok = yz_index:local_remove(Name),
-            yz_fuse:reset(Name);
+            yz_fuse:remove(Name);
         _ -> ok
     end.
 

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -20,19 +20,25 @@
 
 %% @doc Functionality related to events.  This is the single producer of
 %% writes to the ETS table `yz_events'.
-%%
-%% NOTE: Store the raw ring in the state because that is what is being
-%%       delivered during a ring event.
 
 -module(yz_events).
--behavior(gen_server).
--compile(export_all).
+-behavior(gen_event).
+
+%% API
+-export([start_link/0,
+         add_handler/2,
+         add_sup_handler/2,
+         add_callback/1,
+         add_sup_callback/1]).
+
+%% gen_event callbacks
 -export([code_change/3,
-         handle_call/3,
-         handle_cast/2,
+         handle_call/2,
+         handle_event/2,
          handle_info/2,
          init/1,
          terminate/2]).
+
 -include("yokozuna.hrl").
 
 -define(NUM_TICKS_START, 1).
@@ -50,7 +56,6 @@
           prev_index_hash = undefined   :: term()
          }).
 
-
 -define(DEFAULT_EVENTS_FULL_CHECK_AFTER, 60).
 -define(DEFAULT_EVENTS_TICK_INTERVAL, 1000).
 
@@ -59,7 +64,20 @@
 %%%===================================================================
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_event:start_link({local, ?MODULE}).
+
+add_handler(Handler, Args) ->
+    gen_event:add_handler(?MODULE, Handler, Args),
+    create_table().
+
+add_sup_handler(Handler, Args) ->
+    gen_event:add_sup_handler(?MODULE, Handler, Args).
+
+add_callback(Fn) when is_function(Fn) ->
+    gen_event:add_handler(?MODULE, {?MODULE, make_ref()}, [Fn]).
+
+add_sup_callback(Fn) when is_function(Fn) ->
+    gen_event:add_sup_handler(?MODULE, {?MODULE, make_ref()}, [Fn]).
 
 %%%===================================================================
 %%% Callbacks
@@ -69,8 +87,19 @@ init([]) ->
     ok = set_tick(),
     {ok, #state{}}.
 
-handle_cast(Msg, _S) ->
-    ?WARN("unknown message ~p", [Msg]).
+handle_event({Index, blown}, S) ->
+    handle_index_recovered(Index, down),
+    {ok, S};
+handle_event({Index, ok}, S) ->
+    handle_index_recovered(Index, up),
+    {ok, S};
+handle_event({Index, reset}, S) ->
+    %% TODO: We are currently using reset when an Index is removed, but there
+    %% should be a true removal of fuse eventually.
+    handle_index_recovered(Index, removed),
+    {ok, S};
+handle_event(_Msg, S) ->
+    {ok, S}.
 
 handle_info(tick, S) ->
     PrevHash = S#state.prev_index_hash,
@@ -90,11 +119,11 @@ handle_info(tick, S) ->
     NumTicks2 = incr_or_wrap(NumTicks, get_full_check_after()),
     S2 = S#state{num_ticks=NumTicks2,
                  prev_index_hash=CurrHash},
-    {noreply, S2}.
+    {ok, S2}.
 
-handle_call(Req, _, S) ->
+handle_call(Req, S) ->
     ?WARN("unexpected request ~p", [Req]),
-    {noreply, S}.
+    {ok, ok, S}.
 
 code_change(_, S, _) ->
     {ok, S}.
@@ -105,6 +134,17 @@ terminate(_Reason, _S) ->
 %%%===================================================================
 %%% Private
 %%%===================================================================
+
+%% @doc Called by {@link yz_general_sup} to create the p ETS table used to
+%% track registered events. Created when we add the handler after the supervisor
+%% is already up for yz_events.
+-spec create_table() -> ok.
+create_table() ->
+    _ = ets:new(?MODULE, [named_table, public, set,
+                          {write_concurrency, true},
+                          {read_concurrency, true},
+                          {keypos, 1}]),
+    ok.
 
 -spec add_index(index_name()) -> ok.
 add_index(Name) ->
@@ -237,3 +277,20 @@ sync_indexes() ->
 sync_indexes(Removed, Added, Same) ->
     ok = remove_indexes(Removed),
     ok = add_indexes(Added ++ Same).
+
+%% @private
+%% @doc Check and update `yz_events' ETS if the index has recovered from it's
+%%      fuse being blown or has been reset/removed.
+handle_index_recovered(Index, down) ->
+    ets:insert(?MODULE, {Index, {state, down}});
+handle_index_recovered(Index, removed) ->
+    ets:delete(Index);
+handle_index_recovered(Index, up) ->
+    Recovered = ets:lookup(?MODULE, Index),
+    case proplists:get_value(Index, Recovered, []) of
+        {state, down} ->
+            yz_stat:fuse_recovered(Index),
+            ets:insert(?MODULE, {Index, {state, up}});
+        _ ->
+            ets:insert(?MODULE, {Index, {state, up}})
+    end.

--- a/src/yz_fuse.erl
+++ b/src/yz_fuse.erl
@@ -23,7 +23,7 @@
 -export([setup/0]).
 
 %% api
--export([create/1, check/1, melt/1, reset/1]).
+-export([create/1, check/1, melt/1, remove/1, reset/1]).
 
 %% helpers
 -export([fuse_context/0]).
@@ -71,13 +71,17 @@ create(Index) ->
         _ -> ok
 end.
 
-%% TODO: We are currently using reset when an Index is removed, but there should
-%% be a true removal of fuse eventually.
+-spec remove(index_name()) -> ok | {error, not_found}.
+remove(Index) ->
+    IndexName = ?BIN_TO_ATOM(Index),
+    fuse:remove(IndexName),
+    yz_stat:delete_dynamic_stats(IndexName, ?DYNAMIC_STATS),
+    ok.
+
 -spec reset(index_name()) -> ok | {error, not_found}.
 reset(Index) ->
     IndexName = ?BIN_TO_ATOM(Index),
     fuse:reset(IndexName),
-    yz_stat:delete_dynamic_stats(IndexName, ?DYNAMIC_STATS),
     ok.
 
 -spec check(index_name()|atom()) -> ok | blown | {error, not_found}.

--- a/src/yz_general_sup.erl
+++ b/src/yz_general_sup.erl
@@ -42,6 +42,9 @@ start_link() ->
 %%%===================================================================
 
 init([]) ->
+    %% Create yz_events ETS table
+    yz_events:create_table(),
+
     SolrQ = {yz_solrq_sup,
              {yz_solrq_sup, start_link, []},
              permanent, infinity, supervisor, [yz_solrq_sup]},

--- a/src/yz_general_sup.erl
+++ b/src/yz_general_sup.erl
@@ -49,6 +49,10 @@ init([]) ->
              {yz_solrq_sup, start_link, []},
              permanent, infinity, supervisor, [yz_solrq_sup]},
 
+    EventHandlerSup = {yz_eventhandler_sup,
+                       {yz_eventhandler_sup, start_link, []},
+                      permanent, infinity, supervisor, [yz_eventhandler_sup]},
+
     Events = {yz_events,
               {yz_events, start_link, []},
               permanent, 5000, worker, [yz_events]},
@@ -65,6 +69,6 @@ init([]) ->
              {yz_cover, start_link, []},
              permanent, 5000, worker, [yz_cover]},
 
-    Children = [SolrQ, Events, HashtreeSup, EntropyMgr, Cover],
+    Children = [SolrQ, EventHandlerSup, Events, HashtreeSup, EntropyMgr, Cover],
 
     {ok, {{one_for_one, 5, 10}, Children}}.


### PR DESCRIPTION
- allows for recover stat
- changes yz_events from gen_server to gen_events behavior and adds sup needs
- includes the move to fuse 2.1.0 and code around removal, which was added recently: https://github.com/jlouis/fuse/pull/8. 
