### PR TITLE
Deals w/ bug FL Sort w/o Score / RIAK-1696

### DIFF
--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -42,6 +42,7 @@ confirm() ->
     confirm_admin_bad_index_name(Cluster),
     confirm_basic_search(Cluster),
     confirm_fl_search_without_score(Cluster),
+    confirm_fl_search_without_score_without_sort(Cluster),
     confirm_encoded_search(Cluster),
     confirm_search_to_test_max_score_defaults(Cluster),
     confirm_multivalued_field(Cluster),
@@ -206,6 +207,16 @@ confirm_fl_search_without_score(Cluster) ->
     Params = [{sort, <<"age_i asc">>}, {fl, ["*"]}],
     store_and_search(Cluster, Bucket, "test_fl_search_without_score", Body,
                      "application/json", <<"age_i:5">>, Params).
+
+confirm_fl_search_without_score_without_sort(Cluster) ->
+    Index = <<"fl_search_without_score_without_sort">>,
+    Bucket = {Index, <<"b1">>},
+    create_index(Cluster, Index, Index),
+    lager:info("confirm_fl_search_without_score ~p", [Bucket]),
+    Body = <<"{\"age_i\":5}">>,
+    Params = [{fl, ["age_i", "_yz_rk"]}],
+    store_and_search(Cluster, Bucket, "test_fl_search_without_score_without_sort",
+                     Body, "application/json", <<"age_i:5">>, Params).
 
 confirm_encoded_search(Cluster) ->
     Index = <<"encoded">>,

--- a/riak_test/yz_pb.erl
+++ b/riak_test/yz_pb.erl
@@ -41,6 +41,7 @@ confirm() ->
     confirm_admin_index(Cluster),
     confirm_admin_bad_index_name(Cluster),
     confirm_basic_search(Cluster),
+    confirm_fl_search_without_score(Cluster),
     confirm_encoded_search(Cluster),
     confirm_search_to_test_max_score_defaults(Cluster),
     confirm_multivalued_field(Cluster),
@@ -195,6 +196,16 @@ confirm_basic_search(Cluster) ->
     Body = "herp derp",
     Params = [{sort, <<"score desc">>}, {fl, ["*","score"]}],
     store_and_search(Cluster, Bucket, "test", Body, <<"text:herp">>, Params).
+
+confirm_fl_search_without_score(Cluster) ->
+    Index = <<"fl_search_without_score">>,
+    Bucket = {Index, <<"b1">>},
+    create_index(Cluster, Index, Index),
+    lager:info("confirm_fl_search_without_score ~p", [Bucket]),
+    Body = <<"{\"age_i\":5}">>,
+    Params = [{sort, <<"age_i asc">>}, {fl, ["*"]}],
+    store_and_search(Cluster, Bucket, "test_fl_search_without_score", Body,
+                     "application/json", <<"age_i:5">>, Params).
 
 confirm_encoded_search(Cluster) ->
     Index = <<"encoded">>,


### PR DESCRIPTION
handle score field when fl does not supply it, but requests a sort on it. Current workaround to our issues w/ erlang_protobufs/optional-fields/backwards-compat w/ old riak_search.

https://github.com/basho/yokozuna/issues/372 | RIAK-1696.
