### PR TITLE
Merge Riak 2.1 onto end-to-end/timeseries

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
   {kvc, ".*",
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.5.0"}}},
   {riak_kv, ".*",
-   {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
+   {git, "git://github.com/basho/riak_kv.git", {branch, "end-to-end/timeseries"}}},
   {ibrowse, "4.0.2",
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
  ]}.


### PR DESCRIPTION
Many changes to YZ happened since TS was forked in April 2015.  These include test fixes.
