### PR TITLE
Fix the module name in yz_aae_test

### DIFF
--- a/riak_test/yz_aae_test.erl
+++ b/riak_test/yz_aae_test.erl
@@ -1,4 +1,4 @@
--module(aae_test).
+-module(yz_aae_test).
 -compile(export_all).
 -include("yokozuna.hrl").
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
Looks like this was overlooked in my original PR.  Ooops.
