### PR TITLE
Better handling of errors around badrequest/single-ops and making ops - entries 1:1 w/ better list processing

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -23,6 +23,7 @@ yz_search_http.erl:80: The variable _ can never match since previous clauses com
 yz_search_http.erl:87: The variable _ can never match since previous clauses completely covered the type 'false'
 yz_solr_start_timeout.erl:28: The variable _ can never match since previous clauses completely covered the type 'false'
 yz_wm_extract_test.erl:45: The variable _ can never match since previous clauses completely covered the type 'false'
+yz_siblings.erl:141: The variable _ can never match since previous clauses completely covered the type 'false'
 Unknown functions:
   make_certs:endusers/3
   make_certs:rootCA/2
@@ -92,3 +93,6 @@ Unknown functions:
   rt_config:get/1
   rt_intercept:add/2
   rt_intercept:load_code/2
+  rt:heal/1
+  rt:partition/2
+  rt:wait_until_transfers_complete/1

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -204,8 +204,10 @@ index(Core, Docs, DelOps) ->
         Err -> throw({"Failed to index docs", Err})
     end.
 
-index_batch(Core, Ops) ->
-    JSON = mochijson2:encode({struct, Ops}),
+index_batch(Core, Ops0) ->
+    %% Flatten and Reverse Ops (Making sure deletes occurr first for combined operators)
+    Ops1 = lists:reverse(lists:flatten(Ops0)),
+    JSON = mochijson2:encode({struct, Ops1}),
     URL = ?FMT("~s/~s/update", [base_url(), Core]),
     Headers = [{content_type, "application/json"}],
     Opts = [{response_format, binary}],

--- a/src/yz_solrq.erl
+++ b/src/yz_solrq.erl
@@ -39,7 +39,7 @@
                  queue_len = 0          :: non_neg_integer(),
                  href                   :: reference(),
                  pending_helper = false :: boolean(),
-                 batch_min = 10         :: non_neg_integer(),
+                 batch_min = 1          :: non_neg_integer(),
                  batch_max = 100        :: non_neg_integer(),
                  delayms_max = 100      :: non_neg_integer()}).
 -record(state, {indexqs = dict:new()    :: yz_dict(),


### PR DESCRIPTION
^^ @jvoegele @fadushin 
- Make rt dialyzer thangs work
- rename send_solr_ops to send_solr_ops_for_entries
- Make Ops return 1:1 w/ Entries for Entry cleanup needs and handling
- Make sure to flatten Ops within index_batch
- Cleaner Type Specs
- Remove Ops from Error logging
- Better handling of errors within send_solr_single_ops to let
  badrequests through to prevent forever repair, but also handle other
  possible errors in Solr by stopping the list processing and sending only
  the successful (and special badrequest handling) op-entries to the tree
