### PR TITLE
Features+fixes/zl/cuttlefishisms+fuse handling around ed

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -96,3 +96,4 @@ Unknown functions:
   rt:heal/1
   rt:partition/2
   rt:wait_until_transfers_complete/1
+  yz_solr_orig:index_batch_orig/2

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -177,6 +177,9 @@
 -define(YZ_SOLR_ED_REQUEST_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
                                                     solr_ed_request_timeout,
                                                     ?YZ_SOLR_REQUEST_TIMEOUT)).
+-define(YZ_SOLR_PORT_RPC_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
+                                                    solr_port_rpc_timeout,
+                                                    3000)).
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).
 -define(YZ_CORE_CFG_FILE, "solrconfig.xml").
 -define(YZ_INDEX_CMD, #yz_index_cmd).

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -159,7 +159,7 @@
   {validators, ["positive_integer"]}
 ]}.
 
-%% @doc The maximim batch size, in number of Riak objects. Any batches that are
+%% @doc The maximum batch size, in number of Riak objects. Any batches that are
 %%      larger than this amount will be split, where the first solrq_batch_max
 %%      objects will be flushed to Solr, and the remaining objects enqueued for
 %%      that index will be retained until the next batch is delivered. This
@@ -199,8 +199,8 @@
 ]}.
 
 %% @doc The number of solr queue workers to instantiate in the Yokozuna
-%%      application. Solr queue workers are responsible for enqueing objects for
-%%      insertion or update into Solr. Increasing the number of solrq
+%%      application. Solr queue workers are responsible for enqueuing objects
+%%      for insertion or update into Solr. Increasing the number of solrq
 %%      distributes the queuing of objects, and can lead to greater throughput
 %%      under high load, potentially at the expense of smaller batch sizes.
 {mapping, "search.num_solrq", "yokozuna.num_solrq", [

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -101,3 +101,132 @@
     end
   end
 }.
+
+%%===========================================================
+%% Fuse-related settings
+%%===========================================================
+
+%% @doc The number of melts within the melt_time_window before a fuse will blow.
+{mapping, "search.melt_attempts", "yokozuna.melt_attempts", [
+  {default, 3},
+  {datatype, integer},
+  hidden,
+  {validators, ["integer"]}
+]}.
+
+%% @doc The window of time in which melt_attempts melts
+%%      will cause a fuse to blow.
+{mapping, "search.melt_time_window", "yokozuna.melt_time_window", [
+  {default, "5s"},
+  {datatype, {duration, ms}},
+  hidden
+]}.
+
+%% @doc The amount of elapsed time without a fuse blown event before a fuse
+%%      will automatically heal.
+{mapping, "search.melt_reset_refresh", "yokozuna.melt_reset_refresh", [
+  {default, "30s"},
+  {datatype, {duration, ms}},
+  hidden
+]}.
+
+%% @doc Determins how fuse is called.
+{mapping, "search.fuse_context", "yokozuna.fuse_context", [
+  {default, async},
+  {datatype, {flag, {sync, sync}, {async, async_dirty}}},
+  hidden
+]}.
+
+%% @doc If true, then buffered data may be discarded from indices with blown
+%%      fuses, if the solrq_queue_hwm is reached.
+{mapping, "search.purge_blown_indices", "yokozuna.purge_blown_indices", [
+  {default, on},
+  {datatype, flag},
+  hidden
+]}.
+
+%%===========================================================
+%% Batching-related mappings for SolrQ workers
+%%===========================================================
+
+%% @doc The minimum batch size, in number of Riak objects. Any batches that
+%%      are smaller than this amount will not be immediately flushed to Solr,
+%%      but are guaranteed to be flushed within solrq_delayms_max milliseconds.
+{mapping, "search.solrq_batch_min", "yokozuna.solrq_batch_min", [
+  {default, 1},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}
+]}.
+
+%% @doc The maximim batch size, in number of Riak objects. Any batches that are
+%%      larger than this amount will be split, where the first solrq_batch_max
+%%      objects will be flushed to Solr, and the remaining objects enqueued for
+%%      that index will be retained until the next batch is delivered. This
+%%      parameter ensures that at most solrq_batch_max objects will be delivered
+%%      into Solr in any given request.
+{mapping, "search.solrq_batch_max", "yokozuna.solrq_batch_max", [
+  {default, 100},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}
+]}.
+
+%% @doc The maximim delay between notification to flush batches to Solr. This
+%%      setting is used to increase or decrease the frequency of batch delivery
+%%      into Solr, specifically for relatively low-volume input into Riak. This
+%%      setting ensures that data will be delivered into Solr in accordance with
+%%      the solrq_batch_min and solrq_batch_max settings within the specified
+%%      interval. Batches that are smaller than solrq_batch_min will be
+%%      delivered to Solr within this interval. This setting will generally have
+%%      no effect on heavily loaded systems.
+{mapping, "search.solrq_delayms_max", "yokozuna.solrq_delayms_max", [
+  {default, "1000ms"},
+  {datatype, [{duration, ms}, {atom, infinity}]},
+  hidden
+]}.
+
+%% @doc The queue high water mark. If the total number of queued messages in a
+%%      Solrq worker instance exceed this limit, then the calling vnode will be
+%%      blocked until the total number falls below this limit. This parameter
+%%      exercises flow control between Riak and the Yokozuna batching subsystem,
+%%      if writes into Solr start to fall behind.
+{mapping, "search.solrq_queue_hwm", "yokozuna.solrq_queue_hwm", [
+  {default, 10000},
+  {datatype, integer},
+  hidden,
+  {validators, ["integer"]}
+]}.
+
+%% @doc The number of solr queue workers to instantiate in the Yokozuna
+%%      application. Solr queue workers are responsible for enqueing objects for
+%%      insertion or update into Solr. Increasing the number of solrq
+%%      distributes the queuing of objects, and can lead to greater throughput
+%%      under high load, potentially at the expense of smaller batch sizes.
+{mapping, "search.num_solrq", "yokozuna.num_solrq", [
+  {default, 10},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}
+]}.
+
+%% @doc The number of solr queue helpers to instantiate in the Yokozuna
+%%      application. Solr queue helpers are responsible for delivering batches
+%%      of data into Solr. Increasing the number of solrq helpers will
+%%      increase concurrent writes into Solr.
+{mapping, "search.num_solrq_helpers", "yokozuna.num_solrq_helpers", [
+  {default, 10},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}
+]}.
+
+%%===========================================================
+%% Validators
+%%===========================================================
+
+{validator, "positive_integer", "must be a positive integer > 0",
+  fun(X) -> X > 0 end}.
+
+{validator, "integer", "must be an integer >= 0",
+  fun(X) -> X >= 0 end}.

--- a/src/yz_entropy.erl
+++ b/src/yz_entropy.erl
@@ -73,7 +73,7 @@ get_entropy_data(Index, Filter) ->
         {error, {error, req_timedout}} ->
             ?ERROR("failed to iterate over entropy data due to request"
                    ++ " exceeding timeout ~b for filter params ~p",
-                   [?YZ_SOLR_REQUEST_TIMEOUT, Filter]),
+                   [?YZ_SOLR_ED_REQUEST_TIMEOUT, Filter]),
             {error, #entropy_data{more=false, pairs=[]}};
         {error, Err} ->
             ?ERROR("failed to iterate over entropy data due to request"

--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -312,11 +312,10 @@ load_built(#state{trees=Trees}) ->
         _ -> false
     end.
 
--spec fold_keys(p(), tree()) -> [ok|timeout|not_available].
-fold_keys(Partition, Tree) ->
+-spec fold_keys(p(), tree(), [index_name()]) -> [ok|timeout|not_available].
+fold_keys(Partition, Tree, Indexes) ->
     LI = yz_cover:logical_index(yz_misc:get_ring(transformed)),
     LogicalPartition = yz_cover:logical_partition(LI, Partition),
-    Indexes = yz_index:get_indexes_from_meta(),
     F = fun({BKey, Hash}) ->
                 %% TODO: return _yz_fp from iterator and use that for
                 %%       more efficient get_index_N
@@ -588,8 +587,16 @@ build_or_rehash(Tree, Locked, Type, #state{index=Index, trees=Trees}) ->
     case {Locked, Type} of
         {true, build} ->
             lager:debug("Starting YZ AAE tree build: ~p", [Index]),
-            IterKeys = fold_keys(Index, Tree),
-            handle_iter_keys(Tree, Index, IterKeys);
+            Indexes = yz_index:get_indexes_from_meta(),
+            case yz_fuse:check_all_fuses_ok(Indexes) of
+                true ->
+                    IterKeys = fold_keys(Index, Tree, Indexes),
+                    handle_iter_keys(Tree, Index, IterKeys);
+                false ->
+                    ?ERROR("YZ AAE did not run due to blown fuses/solr_cores."),
+                    lager:debug("YZ AAE tree build failed: ~p", [Index]),
+                    gen_server:cast(Tree, build_failed)
+            end;
         {true, rehash} ->
             lager:debug("Starting YZ AAE tree rehash: ~p", [Index]),
             _ = [hashtree:rehash_tree(T) || {_,T} <- Trees],
@@ -645,13 +652,13 @@ maybe_expire_caps_check(S) ->
         false -> S
     end.
 
--spec handle_iter_keys(pid(), p(), []| [ok|timeout|not_available]) -> ok.
+-spec handle_iter_keys(pid(), p(), [ok|timeout|not_available|error]) -> ok.
 handle_iter_keys(Tree, Index, []) ->
     lager:debug("Finished YZ AAE tree build: ~p", [Index]),
     gen_server:cast(Tree, build_finished),
     ok;
 handle_iter_keys(Tree, Index, IterKeys) ->
-    case lists:all(fun(V) -> V =:= ok end, IterKeys)  of
+    case lists:all(fun(V) -> V == ok end, IterKeys)  of
         true ->
             lager:debug("Finished YZ AAE tree build: ~p", [Index]),
             gen_server:cast(Tree, build_finished);

--- a/src/yz_pb_admin.erl
+++ b/src/yz_pb_admin.erl
@@ -110,7 +110,7 @@ process(#rpbyokozunaindexputreq{
                 name = IndexName,
                 schema = SchemaName,
                 n_val = Nval}}, State) ->
-    Timeout = app_helper:get_env(yokozuna, index_put_timeout_ms,
+    Timeout = app_helper:get_env(?YZ_APP_NAME, index_put_timeout_ms,
                                  ?DEFAULT_IDX_CREATE_TIMEOUT),
 
     case maybe_create_index(IndexName, SchemaName, Nval, Timeout) of

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -336,7 +336,7 @@ build_shard_fq(LCoverSet, Mapping) ->
 %% the port if the RPC fails.
 -spec host_port(node()) -> {string(), string() | unknown}.
 host_port(Node) ->
-    case rpc:call(Node, yz_solr, port, [], 1000) of
+    case rpc:call(Node, yz_solr, port, [], ?YZ_SOLR_PORT_RPC_TIMEOUT) of
         {badrpc, Reason} ->
             ?DEBUG("error retrieving Solr port ~p ~p", [Node, Reason]),
             {yz_misc:hostname(Node), unknown};

--- a/src/yz_solrq.erl
+++ b/src/yz_solrq.erl
@@ -43,7 +43,10 @@
 -define(PULSE_DEBUG(S,F), ok).
 -endif.
 
--type solrq_message() :: tuple().  % {BKey, Docs, Reason, P}.
+-type solrq_message()     :: tuple().  % {BKey, Docs, Reason, P}.
+-type solrq_batch_min()   :: pos_integer().
+-type solrq_batch_max()   :: pos_integer().
+-type solrq_delayms_max() :: non_neg_integer()|infinity.
 
 -record(
     indexq, {
@@ -51,14 +54,15 @@
         queue_len = 0           :: non_neg_integer(),
         href                    :: reference(),
         pending_helper = false  :: boolean(),
-        batch_min = 1           :: non_neg_integer(),
-        batch_max = 100         :: non_neg_integer(),
-        delayms_max = 100       :: non_neg_integer(),
+        batch_min = 1           :: solrq_batch_min(),
+        batch_max = 100         :: solrq_batch_max(),
+        delayms_max = 1000      :: solrq_delayms_max(),
         aux_queue = queue:new() :: yz_queue(),
         draining = false        :: boolean() | wait_for_drain_complete,
         fuse_blown = false      :: boolean()
     }
 ).
+
 -record(
     state, {
         indexqs = dict:new()    :: yz_dict(),
@@ -70,7 +74,7 @@
     }
 ).
 
-
+%% TODO: Clean this up w/ proper type naming conventions.
 -type internal_status() :: [{atom()|indexqs,
                              non_neg_integer() | [{pid(), atom()}] |
                              [{index_name(), {atom(), non_neg_integer() |
@@ -108,10 +112,10 @@ index(Index, BKey, Obj, Reason, P) ->
 set_hwm(QPid, HWM) ->
     gen_server:call(QPid, {set_hwm, HWM}).
 
--spec set_index(pid(), index_name(), non_neg_integer(), non_neg_integer(),
-                non_neg_integer()) -> {ok, {non_neg_integer(),
-                                           non_neg_integer(),
-                                           non_neg_integer()}}.
+-spec set_index(pid(), index_name(), solrq_batch_min(), solrq_batch_max(),
+                solrq_delayms_max()) -> {ok, {solrq_batch_min(),
+                                             solrq_batch_max(),
+                                             solrq_delayms_max()}}.
 set_index(QPid, Index, Min, Max, DelayMax) ->
     gen_server:call(QPid, {set_index, Index, Min, Max, DelayMax}).
 
@@ -179,7 +183,8 @@ handle_call(status, _From, #state{} = State) ->
     {reply, internal_status(State), State};
 handle_call({set_hwm, NewHWM}, _From, #state{queue_hwm = OldHWM} = State) ->
     {reply, {ok, OldHWM}, maybe_unblock_vnodes(State#state{queue_hwm = NewHWM})};
-handle_call({set_index, Index, Min, Max, DelayMS}, _From, State) ->
+handle_call({set_index, Index, Min, Max, DelayMS}, _From, State) when
+      Min > 0, Min =< Max, DelayMS >= 0 orelse DelayMS == infinity ->
     IndexQ = get_indexq(Index, State),
     IndexQ2 = maybe_request_worker(Index,
                                    IndexQ#indexq{batch_min = Min,
@@ -189,12 +194,17 @@ handle_call({set_index, Index, Min, Max, DelayMS}, _From, State) ->
                  IndexQ#indexq.batch_max,
                  IndexQ#indexq.delayms_max},
     {reply, {ok, OldParams}, update_indexq(Index, IndexQ2, State)};
+handle_call({set_index, Index, _Min, _Max, _DelayMS}, _From, State) ->
+    IndexQ = get_indexq(Index, State),
+    OldParams = {IndexQ#indexq.batch_min,
+                 IndexQ#indexq.batch_max,
+                 IndexQ#indexq.delayms_max},
+    {reply, {{error, bad_index_params}, OldParams}, State};
 handle_call(cancel_drain, _From, State) ->
     {noreply, NewState} = handle_cast(drain_complete, State),
     {reply, ok, NewState};
 handle_call(reload_appenv, _From, State) ->
     {reply, ok, read_appenv(State)}.
-
 handle_cast({request_batch, Index, HPid}, State) ->
     State2 = send_entries(HPid, Index, State),
     {noreply, State2};
@@ -585,7 +595,12 @@ maybe_start_timer(Index, #indexq{href = undefined, queue_len = L,
                                  fuse_blown = false,
                                  delayms_max = DelayMS} = IndexQ) when L > 0 ->
     HRef = make_ref(),
-    erlang:send_after(DelayMS, self(), {flush, Index, HRef}),
+    case DelayMS of
+        infinity ->
+            lager:debug("Infinite delay, will not start timer and flush.");
+        _ ->
+            erlang:send_after(DelayMS, self(), {flush, Index, HRef})
+    end,
     IndexQ#indexq{href = HRef};
 maybe_start_timer(_Index, IndexQ) ->
     IndexQ.
@@ -606,10 +621,19 @@ get_indexq(Index, #state{indexqs = IndexQs}) ->
             new_indexq()
     end.
 
+set_new_index(Min, Max, DelayMS)
+  when Min =< Max, DelayMS >= 0 orelse DelayMS == infinity ->
+    #indexq{batch_min = Min,
+            batch_max = Max,
+            delayms_max = DelayMS};
+set_new_index(_, _, _) ->
+    #indexq{}.
+
 new_indexq() ->
-    #indexq{batch_min = app_helper:get_env(yokozuna, solrq_batch_min, 1),
-            batch_max = app_helper:get_env(yokozuna, solrq_batch_max, 100),
-            delayms_max = app_helper:get_env(yokozuna, solrq_delayms_max, 1000)}.
+    BatchMin = app_helper:get_env(?YZ_APP_NAME, solrq_batch_min, 1),
+    BatchMax = app_helper:get_env(?YZ_APP_NAME, solrq_batch_max, 100),
+    DelayMS = app_helper:get_env(?YZ_APP_NAME, solrq_delayms_max, 1000),
+    set_new_index(BatchMin, BatchMax, DelayMS).
 
 update_indexq(Index, IndexQ, #state{indexqs = IndexQs} = State) ->
     State#state{indexqs = dict:store(Index, IndexQ, IndexQs)}.
@@ -620,8 +644,8 @@ update_indexq(Index, IndexQ, #state{indexqs = IndexQs} = State) ->
 
 %% @doc Read settings from the application environment
 read_appenv(State) ->
-    HWM = app_helper:get_env(yokozuna, solrq_queue_hwm, 10000),
-    PBI = application:get_env(yokozuna, purge_blown_indices, true),
+    HWM = app_helper:get_env(?YZ_APP_NAME, solrq_queue_hwm, 10000),
+    PBI = application:get_env(?YZ_APP_NAME, purge_blown_indices, true),
     State#state{queue_hwm = HWM, purge_blown_indices=PBI}.
 
 %%

--- a/src/yz_wm_index.erl
+++ b/src/yz_wm_index.erl
@@ -192,7 +192,7 @@ create_index(RD, S) ->
     Timeout =
         case S#ctx.timeout of
             undefined -> app_helper:get_env(
-                          yokozuna,
+                          ?YZ_APP_NAME,
                           index_put_timeout_ms,
                           ?DEFAULT_IDX_CREATE_TIMEOUT);
             Set -> Set

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -23,6 +23,17 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 60000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_ed_timeout", 60000),
     cuttlefish_unit:assert_config(Config, "yokozuna.anti_entropy", {on, []}),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_attempts", 3),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_time_window", 5000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_reset_refresh", 30000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.fuse_context", async_dirty),
+    cuttlefish_unit:assert_config(Config, "yokozuna.purge_blown_indices", true),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_min", 1),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_max", 100),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_delayms_max", 1000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_queue_hwm", 10000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq", 10),
+    cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq_helpers", 10),
     ok.
 
 override_schema_test() ->
@@ -40,7 +51,18 @@ override_schema_test() ->
             {["search", "temp_dir"], "/some/other/volume_temp"},
             {["search", "solr", "request_timeout"], "90s"},
             {["search", "solr", "request_ed_timeout"], "90s"},
-            {["search", "anti_entropy"], "passive"}
+            {["search", "anti_entropy"], "passive"},
+            {["search", "melt_attempts"], 5},
+            {["search", "melt_time_window"], "10s"},
+            {["search", "melt_reset_refresh"], "60s"},
+            {["search", "fuse_context"], "sync"},
+            {["search", "purge_blown_indices"], "off"},
+            {["search", "solrq_batch_min"], 10},
+            {["search", "solrq_batch_max"], 10000},
+            {["search", "solrq_delayms_max"], infinity},
+            {["search", "solrq_queue_hwm"], 100000},
+            {["search", "num_solrq"], 5},
+            {["search", "num_solrq_helpers"], 20}
     ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
@@ -57,6 +79,48 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_timeout", 90000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solr_request_ed_timeout", 90000),
     cuttlefish_unit:assert_config(Config, "yokozuna.anti_entropy", {off, []}),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_attempts", 5),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_time_window", 10000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.melt_reset_refresh", 60000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.fuse_context", sync),
+    cuttlefish_unit:assert_config(Config, "yokozuna.purge_blown_indices", false),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_min", 10),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_max", 10000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_delayms_max", infinity),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_queue_hwm", 100000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq", 5),
+    cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq_helpers", 20),
+    ok.
+
+validations_test() ->
+    %% Conf represents the riak.conf file that would be read in by
+    %% cuttlefish.  this proplists is what would be output by the
+    %% conf_parse module
+    Conf = [
+            {["search"], on},
+            {["search", "melt_attempts"], 0},
+            {["search", "solrq_batch_min"], -1},
+            {["search", "solrq_batch_max"], -10},
+            {["search", "num_solrq"], 0},
+            {["search", "num_solrq_helpers"], 20}
+    ],
+    Config = cuttlefish_unit:generate_templated_config(
+               "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
+    cuttlefish_unit:assert_error_in_phase(Config, validation),
+    ?assertEqual({error,validation, {errorlist,
+                  [{error,
+                    {validation,
+                     {"search.solrq_batch_min",
+                      "must be a positive integer > 0"}}},
+                  {error,
+                    {validation,
+                     {"search.solrq_batch_max",
+                      "must be a positive integer > 0"}}},
+                   {error,
+                    {validation,
+                     {"search.num_solrq",
+                      "must be a positive integer > 0"}}}]}},
+                 Config),
     ok.
 
 %% this context() represents the substitution variables that rebar


### PR DESCRIPTION
- Adds fuse/batch settings to cuttlefish w/ a few validations
- More types... one TODO for @fadushin as well!
- Don't attempt to build tree if Indexes are blowing during folding of keys for a partition. 
- This also includes the logging fix which is part of #565 now. 
- Cherry-picked @jonmeredith's addition/patch to our hotfix branch -> Make rpc timeout for SOLR port configurable. 
