### PR TITLE
Clean up startup/shutdown sequence for yokozuna

### DIFF
--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -606,3 +606,12 @@ commit(Nodes, Index) ->
                [Index, ?SOFTCOMMIT]),
     rpc:multicall(Nodes, yz_solr, commit, [Index]),
     ok.
+
+-spec load_intercept_code(node()) -> ok.
+load_intercept_code(Node) ->
+    CodePath = filename:join([rt_config:get(yz_dir),
+                              "riak_test",
+                              "intercepts",
+                              "*.erl"]),
+    rt_intercept:load_code(Node, [CodePath]).
+

--- a/riak_test/yz_solrq_test.erl
+++ b/riak_test/yz_solrq_test.erl
@@ -106,7 +106,7 @@ confirm_draining(Cluster, PBConn, BKey, Index) ->
     ok.
 
 confirm_requeue_undelivered([Node|_] = Cluster, PBConn, BKey, Index) ->
-    load_intercept_code(Node),
+    yz_rt:load_intercept_code(Node),
     intercept_index_batch(Node, index_batch_throw_exception),
 
     Count = ?SOLRQ_BATCH_MIN,
@@ -146,13 +146,6 @@ verify_search_count(PBConn, Index, Count) ->
 
 drain_solrqs(Node) ->
     rpc:call(Node, yz_solrq_drain_mgr, drain, []).
-
-load_intercept_code(Node) ->
-    CodePath = filename:join([rt_config:get(yz_dir),
-                              "riak_test",
-                              "intercepts",
-                              "*.erl"]),
-    rt_intercept:load_code(Node, [CodePath]).
 
 intercept_index_batch(Node, Intercept) ->
     rt_intercept:add(

--- a/riak_test/yz_startup_shutdown.erl
+++ b/riak_test/yz_startup_shutdown.erl
@@ -15,7 +15,7 @@ confirm() ->
     verify_yz_components_enabled(Cluster),
     verify_yz_services_registered(Cluster),
 
-    intercept_yz_solrq_sup_drain(Cluster),
+    intercept_yz_solrq_drain_mgr_drain(Cluster),
     stop_yokozuna(Cluster),
 
     verify_drain_called(Cluster),
@@ -86,23 +86,23 @@ are_services_registered(Services, Node) ->
 %% @private
 %%
 %% @doc Install an intercept on all of the given nodes, which intercepts the
-%% yz_solrq_sup:drain/0 function and sends a message to the riak_test process
-%% indicating that the function was actually called on a given node. The
-%% message is of the form {Node, drain_called}, where `Node' identifies the
+%% yz_solrq_drain_mgr:drain/0 function and sends a message to the riak_test
+%% process indicating that the function was actually called on a given node.
+%% The message is of the form {Node, drain_called}, where `Node' identifies the
 %% node.
-intercept_yz_solrq_sup_drain([]) ->
+intercept_yz_solrq_drain_mgr_drain([]) ->
     ok;
-intercept_yz_solrq_sup_drain([Node|Rest]) ->
+intercept_yz_solrq_drain_mgr_drain([Node|Rest]) ->
     RiakTestProcess = self(),
     rt_intercept:add(
       Node,
-      {yz_solrq_sup,
+      {yz_solrq_drain_mgr,
        [{{drain, 0},
          {[Node, RiakTestProcess],
           fun() ->
                   RiakTestProcess ! {Node, drain_called}
           end}}]}),
-    intercept_yz_solrq_sup_drain(Rest).
+    intercept_yz_solrq_drain_mgr_drain(Rest).
 
 %% @private
 %%

--- a/riak_test/yz_startup_shutdown.erl
+++ b/riak_test/yz_startup_shutdown.erl
@@ -1,0 +1,146 @@
+%% @doc Test the startup and shutdown sequence.
+-module(yz_startup_shutdown).
+-export([confirm/0]).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-compile({parse_transform, rt_intercept_pt}).
+
+-define(CONFIG, [{yokozuna, [{enabled, true}]}]).
+
+confirm() ->
+    Cluster = rt:build_cluster(2, ?CONFIG),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+
+    %% compile(rt_intercept_pt, Cluster, [{parse_transform, rt_intercept_pt}]),
+    verify_yz_components_enabled(Cluster),
+
+    intercept_yz_solrq_sup_drain(Cluster),
+    stop_yokozuna(Cluster),
+
+    verify_drain_called(Cluster),
+    %% assert yz_pb_search service is deregistered?
+    %% assert yz_pb_admin service is deregistered?
+    verify_yz_components_disabled(Cluster),
+    pass.
+
+verify_yz_components_enabled(Cluster) ->
+    check_yz_components(Cluster, true).
+
+verify_yz_components_disabled(Cluster) ->
+    check_yz_components(Cluster, false).
+
+check_yz_components([], _) ->
+    ok;
+check_yz_components([Node|Rest], Enabled) ->
+    Components = yz_app:components(),
+    lists:all(
+      fun(Component) ->
+              Enabled =:= rpc:call(Node, yokozuna, is_enabled, [Component])
+      end,
+      Components),
+    check_yz_components(Rest, Enabled).
+
+intercept_yz_solrq_sup_drain([]) ->
+    ok;
+intercept_yz_solrq_sup_drain([Node|Rest]) ->
+    RiakTestProcess = self(),
+    rt_intercept:add(
+      Node,
+      {yz_solrq_sup,
+       [{{drain, 0},
+         {[Node, RiakTestProcess],
+          fun() ->
+                  RiakTestProcess ! {Node, drain_called}
+          end}}]}),
+    intercept_yz_solrq_sup_drain(Rest).
+
+stop_yokozuna([]) ->
+    ok;
+stop_yokozuna([Node|Rest]) ->
+    ok = rpc:call(Node, application, stop, [yokozuna]),
+    stop_yokozuna(Rest).
+
+verify_drain_called(Cluster) ->
+    Results = [begin
+                   receive
+                       {Node, drain_called} ->
+                           ok
+                   after
+                       10000 ->
+                           {fail, timeout}
+                   end
+               end
+               || Node <- Cluster],
+
+    true = lists:all(fun(Result) ->
+                             ok =:= Result
+                     end,
+                     Results).
+
+%% compile(Module, Cluster) ->
+%%     compile(Module, Cluster, []).
+%%
+%% compile(Module, Cluster, UserOptions) ->
+%%     %% Trigger load if not present
+%%     _ = Module:module_info(),
+%%
+%%     ?INFO("Hello Fuckers ~p", [proplists:get_value(Module, code:all_loaded())]),
+%%     %% Then work out where we loaded it from
+%%     case proplists:get_value(Module, code:all_loaded()) of
+%%         undefined ->
+%%             {error, not_loaded};
+%%         BeamName ->
+%%             do_compile_beam(Module, BeamName, Cluster, UserOptions)
+%%     end.
+%%
+%% %% Beam is a binary or a .beam file name
+%% do_compile_beam(Module, Beam, Cluster, UserOptions) ->
+%%     ?INFO("Abstract code: ~p", [get_abstract_code(Module, Beam)]),
+%%     case get_abstract_code(Module, Beam) of
+%%         no_abstract_code=E ->
+%%             {error,E};
+%%         encrypted_abstract_code=E ->
+%%             {error,E};
+%%         {_Vsn,Code} ->
+%%             Forms0 = epp:interpret_file_attribute(Code),
+%%             Forms = Module:parse_transform(Forms0, UserOptions),
+%%
+%%             %% We need to recover the source from the compilation
+%%             %% info otherwise the newly compiled module will have
+%%             %% source pointing to the current directory
+%%             SourceInfo = get_source_info(Module, Beam),
+%%
+%%             %% Compile and load the result
+%%             %% It's necessary to check the result of loading since it may
+%%             %% fail, for example if Module resides in a sticky directory
+%%             {ok, Module, Binary} = compile:forms(Forms, SourceInfo ++ UserOptions),
+%%             ?INFO("load_binary: ~p", [code:load_binary(Module, Beam, Binary)]),
+%%             [begin
+%%                  case rpc:call(Node, code, load_binary, [Module, Beam, Binary]) of
+%%                      {module, Module} ->
+%%                          {ok, Module};
+%%                      Error ->
+%%                          Error
+%%                  end
+%%              end || Node <- Cluster]
+%%     end.
+%%
+%% get_abstract_code(Module, Beam) ->
+%%     case beam_lib:chunks(Beam, [abstract_code]) of
+%%         {ok, {Module, [{abstract_code, AbstractCode}]}} ->
+%%             AbstractCode;
+%%         {error,beam_lib,{key_missing_or_invalid,_,_}} ->
+%%             encrypted_abstract_code;
+%%         Error -> Error
+%%     end.
+%%
+%% get_source_info(Module, Beam) ->
+%%     case beam_lib:chunks(Beam, [compile_info]) of
+%%         {ok, {Module, [{compile_info, Compile}]}} ->
+%%             case lists:keyfind(source, 1, Compile) of
+%%                 { source, _ } = Tuple -> [Tuple];
+%%                 false -> []
+%%             end;
+%%         _ ->
+%%             []
+%%     end.

--- a/src/rt_intercept_pt.erl
+++ b/src/rt_intercept_pt.erl
@@ -1,0 +1,91 @@
+%% XXX
+%% -------------------------------------------------------------------
+%% TODO: This file was copied from riak_test in order to allow for using
+%% the parse transform from a riak_test whose source code is in the
+%% Yokozuna repository. This file should be deleted if or when a better
+%% mechanism is found for using the rt_intercept_pt parse transform
+%% external to the riak_test repository.
+%% -------------------------------------------------------------------
+%% XXX
+
+-module(rt_intercept_pt).
+-export([parse_transform/2]).
+
+%% This parse transform looks for calls to rt_intercept:add/2, and if found
+%% potentially modifies the second argument. The second argument can be a
+%% list of intercept tuples or a single intercept tuple. An intercept tuple
+%% can have either 2 or 3 elements, but either way, a final element of the
+%% form
+%%
+%%   [{{F,Arity},{[var], fun()}}]
+%%
+%% is transformed into
+%%
+%%   [{{F,Arity},{[{varname, var}], tuple()}}]
+%%
+%% Only the second element of this tuple is modified. In the first form the
+%% fun() is an anonymous interceptor function and [var] represents the list
+%% of free variables used within the function but defined in the context in
+%% which the function is defined. The list of vars is transformed into a
+%% list of 2-tuples of var name and var, while the function is replaced
+%% with its abstract format (which, since we are already dealing with
+%% abstract format, is actually the abstract format of its abstract
+%% format). If the final element of the argument tuple (or list of argument
+%% tuples) is instead
+%%
+%%   [{{F,Arity}, fun()}]
+%%
+%% then the fun() is assumed to not use any free variables from the context
+%% in which the function is defined. This is transformed to
+%%
+%%   [{{F,Arity},{[], tuple()}}]
+%%
+%% which is the same as the prior transformation but with an empty list of
+%% free variables. A final element of any other form is left as is.
+
+parse_transform(Forms, _) ->
+    forms(Forms).
+
+forms([F|Forms]) ->
+    [form(F)|forms(Forms)];
+forms(F) ->
+    form(F).
+
+form({function,LF,F,A,Clauses}) ->
+    {function,LF,F,A,forms(Clauses)};
+form({clause,L,H,G,B}) ->
+    {clause,L,H,G,forms(B)};
+form({match,L,Lhs,Rhs}) ->
+    {match,L,forms(Lhs),forms(Rhs)};
+form({call,L,{remote,_,{atom,_,rt_intercept},{atom,_,AddFunction}}=Fun,Args})
+  when AddFunction == add; AddFunction == add_and_save ->
+    [Node, Intercept] = Args,
+    {call,L,Fun,[Node,intercept(Intercept)]};
+form(F) when is_tuple(F) ->
+    list_to_tuple(forms(tuple_to_list(F)));
+form(F) ->
+    F.
+
+intercept({tuple,L,[Mod,Intercepts]}) ->
+    {tuple,L,[Mod,intercepts(Intercepts)]};
+intercept({tuple,L,[Mod,ModInt,Intercepts]}) ->
+    {tuple,L,[Mod,ModInt,intercepts(Intercepts)]}.
+
+intercepts({cons,L1,{tuple,L2,[FA,Int]},T}) ->
+    {cons,L1,{tuple,L2,[FA,intercepts(Int)]},intercepts(T)};
+intercepts({tuple,L,[FreeVars,{'fun',LF,_}=Fun]}) ->
+    {tuple,L,[freevars(FreeVars),erl_parse:abstract(Fun, LF)]};
+intercepts({'fun',L,_}=Fun) ->
+    {tuple,L,[{nil,L},erl_parse:abstract(Fun, L)]};
+intercepts(F) ->
+    F.
+
+freevars({cons,L,H,T}) ->
+    {cons,L,freevar(H),freevars(T)};
+freevars({nil,_}=Nil) ->
+    Nil.
+
+freevar({var,L,V}=Var) ->
+    {tuple,L,[{atom,L,V},Var]};
+freevar(Term) ->
+    Term.

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -73,7 +73,7 @@ prep_stop(State) ->
         lager:info("Stopping application yokozuna.\n", []),
         ok = riak_api_pb_service:deregister(?QUERY_SERVICES),
         ok = riak_api_pb_service:deregister(?ADMIN_SERVICES),
-        ok = yz_solrq_sup:drain(),
+        ok = yz_solrq_drain_mgr:drain(),
         ok = disable_components()
     catch
         Type:Reason ->

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -70,20 +70,20 @@ start(_StartType, _StartArgs) ->
 prep_stop(State) ->
     try %% wrap with a try/catch - application carries on regardless,
         %% no error message or logging about the failure otherwise.
-        lager:info("Stopping application yokozuna.\n", []),
-        ok = riak_api_pb_service:deregister(?QUERY_SERVICES),
-        ok = riak_api_pb_service:deregister(?ADMIN_SERVICES),
-        ok = yz_solrq_drain_mgr:drain(),
-        ok = disable_components()
+        lager:info("Stopping application yokozuna.", []),
+        riak_api_pb_service:deregister(?QUERY_SERVICES),
+        riak_api_pb_service:deregister(?ADMIN_SERVICES),
+        yz_solrq_drain_mgr:drain(),
+        disable_components()
     catch
         Type:Reason ->
-            lager:error("Stopping application yokozuna - ~p:~p.\n",
+            lager:error("Stopping application yokozuna - ~p:~p.",
                         [Type, Reason])
     end,
     State.
 
 stop(_State) ->
-    lager:info("Stopped application yokozuna.\n", []),
+    lager:info("Stopped application yokozuna.", []),
     ok.
 
 %% @private


### PR DESCRIPTION
See issue https://github.com/basho/yokozuna/issues/581 for background.
- Ensure that all of the solrqs are drained at shutdown.
- Move shutdown logic to `yz_app:prep_stop` function.
- General cleanup of the startup and shutdown code.
- Add a new riak_test (`yz_startup_shutdown`) that tests all of the above.
