### PR TITLE
Add yz_fuse_upgrade test

### DIFF
--- a/riak_test/yz_fuse_upgrade.erl
+++ b/riak_test/yz_fuse_upgrade.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%-------------------------------------------------------------------
+
+%% @doc Confirm that fuses are created for Solr indexes across upgrades.
+
+-module(yz_fuse_upgrade).
+-export([confirm/0]).
+-include("yokozuna.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(OLD_BUCKET, <<"old_bucket">>).
+-define(OLD_INDEX, <<"old_index">>).
+-define(NEW_BUCKET, <<"new_bucket">>).
+-define(NEW_INDEX, <<"new_index">>).
+-define(CLUSTER_SIZE, 2).
+-define(CONFIG,
+        [{riak_core,
+          [{ring_creation_size, 16}]},
+         {riak_search,
+          [{enabled, true}]}
+        ]).
+
+confirm() ->
+    TestMetaData = riak_test_runner:metadata(),
+    OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+
+    Cluster = rt:build_cluster(lists:duplicate(?CLUSTER_SIZE,
+                                               {OldVsn, ?CONFIG})),
+    Node1 = hd(Cluster),
+
+    yz_rt:create_index(Node1, ?OLD_INDEX),
+    yz_rt:set_index(Node1, ?OLD_BUCKET, ?OLD_INDEX),
+
+    yz_rt:rolling_upgrade(Cluster, current),
+
+    yz_rt:create_index(Node1, ?NEW_INDEX),
+    yz_rt:set_index(Node1, ?NEW_BUCKET, ?NEW_INDEX),
+
+    verify_fuse_for_index(Node1, ?OLD_INDEX),
+    verify_fuse_for_index(Node1, ?NEW_INDEX),
+
+    pass.
+
+verify_fuse_for_index(Node, Index) ->
+    Result = rpc:call(Node, yz_fuse, check, [Index]),
+    ?assertMatch(ok, Result).

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -418,6 +418,14 @@ set_bucket_type_index(Node, BucketType, Index, NVal) ->
     lager:info("Set bucket type ~s index to ~s [~p]", [BucketType, Index, Node]),
     create_bucket_type(Node, BucketType, [{?YZ_INDEX, Index},{n_val,NVal}]).
 
+-spec create_indexed_bucket(pid(),
+                            cluster(),
+                            {binary(), binary()},
+                            index_name()) -> ok.
+create_indexed_bucket(PBConn, [Node|_], {BType, _Bucket}, Index) ->
+    ok = riakc_pb_socket:create_search_index(PBConn, Index, <<>>, [{n_val, 1}]),
+    ok = yz_rt:set_bucket_type_index(Node, BType, Index, 1).
+
 solr_http({_Node, ConnInfo}) ->
     solr_http(ConnInfo);
 solr_http(ConnInfo) ->
@@ -607,6 +615,11 @@ commit(Nodes, Index) ->
     rpc:multicall(Nodes, yz_solr, commit, [Index]),
     ok.
 
+-spec drain_solrqs([node()]) -> ok.
+drain_solrqs(Nodes) ->
+    {_ResL, []} = rpc:multicall(Nodes, yz_solrq_drain_mgr, drain, []),
+    ok.
+
 -spec load_intercept_code(node()) -> ok.
 load_intercept_code(Node) ->
     CodePath = filename:join([rt_config:get(yz_dir),
@@ -615,3 +628,25 @@ load_intercept_code(Node) ->
                               "*.erl"]),
     rt_intercept:load_code(Node, [CodePath]).
 
+-spec rolling_upgrade([node()], current | previous | legacy) -> ok.
+rolling_upgrade(Cluster, Vsn) ->
+    lager:info("Perform rolling upgrade on cluster ~p", [Cluster]),
+    SolrPorts = lists:seq(11000, 11000 + length(Cluster) - 1),
+    Cluster2 = lists:zip(SolrPorts, Cluster),
+    [begin
+         Cfg = [{riak_kv, [{anti_entropy, {on, [debug]}},
+                           {anti_entropy_concurrency, 12},
+                           {anti_entropy_build_limit, {6,500}}
+                          ]},
+                {yokozuna, [{anti_entropy, {on, [debug]}},
+                            {anti_entropy_concurrency, 12},
+                            {anti_entropy_build_limit, {6,500}},
+                            {anti_entropy_tick, 1000},
+                            {enabled, true},
+                            {solr_port, SolrPort}]}],
+         rt:upgrade(Node, Vsn, Cfg),
+         rt:wait_for_service(Node, riak_kv),
+         rt:wait_for_service(Node, riak_search),
+         rt:wait_for_service(Node, yokozuna)
+     end || {SolrPort, Node} <- Cluster2],
+    ok.

--- a/riak_test/yz_solrq_test.erl
+++ b/riak_test/yz_solrq_test.erl
@@ -52,9 +52,9 @@ confirm() ->
     Cluster = yz_rt:prepare_cluster(1, ?CONFIG),
     [PBConn|_] = PBConns = yz_rt:open_pb_conns(Cluster),
 
-    ok = create_indexed_bucket(PBConn, Cluster, ?BUCKET1, ?INDEX1),
-    ok = create_indexed_bucket(PBConn, Cluster, ?BUCKET2, ?INDEX2),
-    ok = create_indexed_bucket(PBConn, Cluster, ?BUCKET3, ?INDEX3),
+    ok = yz_rt:create_indexed_bucket(PBConn, Cluster, ?BUCKET1, ?INDEX1),
+    ok = yz_rt:create_indexed_bucket(PBConn, Cluster, ?BUCKET2, ?INDEX2),
+    ok = yz_rt:create_indexed_bucket(PBConn, Cluster, ?BUCKET3, ?INDEX3),
     confirm_batching(Cluster, PBConn, ?BUCKET1, ?INDEX1),
     confirm_draining(Cluster, PBConn, ?BUCKET2, ?INDEX2),
 
@@ -64,10 +64,6 @@ confirm() ->
 
     yz_rt:close_pb_conns(PBConns),
     pass.
-
-create_indexed_bucket(PBConn, [Node|_], {BType, _Bucket}, Index) ->
-    ok = riakc_pb_socket:create_search_index(PBConn, Index, <<>>, [{n_val, 1}]),
-    ok = yz_rt:set_bucket_type_index(Node, BType, Index, 1).
 
 confirm_batching(Cluster, PBConn, BKey, Index) ->
     %% First, put one less than the min batch size and expect that there are no


### PR DESCRIPTION
This test confirms that fuses become associated with indexes that were
created either before or after a rolling upgrade. This commit also
contains a small amount of refactoring to move some useful functions
out of specific tests and into the yz_rt module where they can be reused
by other tests.
