### PR TITLE
Make ibrowse max_sessions and max_pipeline_size configurable

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -180,6 +180,11 @@
 -define(YZ_SOLR_PORT_RPC_TIMEOUT, app_helper:get_env(?YZ_APP_NAME,
                                                     solr_port_rpc_timeout,
                                                     3000)).
+-define(YZ_SOLR_MAX_SESSIONS, max_sessions).
+-define(YZ_SOLR_MAX_PIPELINE_SIZE, max_pipeline_size).
+-define(YZ_CONFIG_IBROWSE_MAX_SESSIONS, ibrowse_max_sessions).
+-define(YZ_CONFIG_IBROWSE_MAX_PIPELINE_SIZE, ibrowse_max_pipeline_size).
+
 -define(YZ_PRIV, code:priv_dir(?YZ_APP_NAME)).
 -define(YZ_CORE_CFG_FILE, "solrconfig.xml").
 -define(YZ_INDEX_CMD, #yz_index_cmd).

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -221,6 +221,22 @@
   {validators, ["positive_integer"]}
 ]}.
 
+%% @doc The value to use for the `max_sessions' configuration for the ibrowse
+%% process used by Yokozuna.
+{mapping, "search.ibrowse_max_sessions", "yokozuna.ibrowse_max_sessions",
+ [{default, 100},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}]}.
+
+%% @doc The value to use for the `max_pipeline_size' configuration for the
+%% ibrowse process used by Yokozuna.
+{mapping, "search.ibrowse_max_pipeline_size", "yokozuna.ibrowse_max_pipeline_size",
+ [{default, 1},
+  {datatype, integer},
+  hidden,
+  {validators, ["positive_integer"]}]}.
+
 %%===========================================================
 %% Validators
 %%===========================================================

--- a/riak_test/yz_startup_shutdown.erl
+++ b/riak_test/yz_startup_shutdown.erl
@@ -5,7 +5,13 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile({parse_transform, rt_intercept_pt}).
 
--define(CONFIG, [{yokozuna, [{enabled, true}]}]).
+-define(MAX_SESSIONS, 11).
+-define(MAX_PIPELINE_SIZE, 9).
+-define(CONFIG,
+        [{yokozuna, [{enabled, true},
+                     {?YZ_CONFIG_IBROWSE_MAX_SESSIONS, ?MAX_SESSIONS},
+                     {?YZ_CONFIG_IBROWSE_MAX_PIPELINE_SIZE, ?MAX_PIPELINE_SIZE}]}]
+).
 -define(YZ_SERVICES, [yz_pb_search, yz_pb_admin]).
 
 confirm() ->
@@ -14,6 +20,7 @@ confirm() ->
 
     verify_yz_components_enabled(Cluster),
     verify_yz_services_registered(Cluster),
+    verify_ibrowse_config(Cluster),
 
     intercept_yz_solrq_drain_mgr_drain(Cluster),
     stop_yokozuna(Cluster),
@@ -134,3 +141,29 @@ verify_drain_called(Cluster) ->
                              ok =:= Result
                      end,
                      Results).
+
+%% @private
+%% @doc For each node in `Cluster', verify that the ibrowse configuration has
+%% been applied.
+verify_ibrowse_config([Node1|_] = Cluster) ->
+    {ResL, []} = rpc:multicall(Cluster, yz_solr, get_ibrowse_config, []),
+    lists:foreach(
+      fun(Config) ->
+              MaxSessions = proplists:get_value(?YZ_SOLR_MAX_SESSIONS, Config),
+              MaxPipelineSize = proplists:get_value(?YZ_SOLR_MAX_PIPELINE_SIZE, Config),
+              ?assert(MaxSessions =:= ?MAX_SESSIONS),
+              ?assert(MaxPipelineSize =:= ?MAX_PIPELINE_SIZE)
+      end,
+      ResL),
+
+    %% Now verify setting these config values programmatically...
+    NewMaxSessions = 42,
+    NewMaxPipelineSize = 64,
+    ok = rpc:call(Node1, yz_solr, set_ibrowse_config,
+                  [[{?YZ_SOLR_MAX_SESSIONS, NewMaxSessions},
+                    {?YZ_SOLR_MAX_PIPELINE_SIZE, NewMaxPipelineSize}]]),
+    NewConfig = rpc:call(Node1, yz_solr, get_ibrowse_config, []),
+    ?assert(NewMaxSessions =:= proplists:get_value(?YZ_SOLR_MAX_SESSIONS, NewConfig)),
+    ?assert(NewMaxPipelineSize =:=
+            proplists:get_value(?YZ_SOLR_MAX_PIPELINE_SIZE, NewConfig)).
+

--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -139,6 +139,7 @@ maybe_setup(true) ->
     ok = riak_core:register(yokozuna, [{bucket_validator, yz_bucket_validator}]),
     ok = riak_core:register(search, [{permissions, ['query',admin]}]),
     ok = yz_schema:setup_schema_bucket(),
+    ok = set_ibrowse_config(),
     ok.
 
 %% @doc Conditionally register PB service IFF Riak Search is not
@@ -163,3 +164,13 @@ setup_stats() ->
         false -> sidejob:new_resource(yz_stat_sj, yz_stat_worker, 10000)
     end,
     ok = riak_core:register(yokozuna, [{stat_mod, yz_stat}]).
+
+set_ibrowse_config() ->
+    Config = [{?YZ_SOLR_MAX_SESSIONS,
+               app_helper:get_env(?YZ_APP_NAME,
+                                  ?YZ_CONFIG_IBROWSE_MAX_SESSIONS)},
+              {?YZ_SOLR_MAX_PIPELINE_SIZE,
+               app_helper:get_env(?YZ_APP_NAME,
+                                  ?YZ_CONFIG_IBROWSE_MAX_PIPELINE_SIZE)}
+             ],
+    yz_solr:set_ibrowse_config(Config).

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -34,6 +34,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_queue_hwm", 10000),
     cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq", 10),
     cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq_helpers", 10),
+    cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 100),
+    cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 1),
     ok.
 
 override_schema_test() ->
@@ -61,6 +63,8 @@ override_schema_test() ->
             {["search", "solrq_batch_max"], 10000},
             {["search", "solrq_delayms_max"], infinity},
             {["search", "solrq_queue_hwm"], 100000},
+            {["search", "ibrowse_max_sessions"], 101},
+            {["search", "ibrowse_max_pipeline_size"], 11},
             {["search", "num_solrq"], 5},
             {["search", "num_solrq_helpers"], 20}
     ],
@@ -88,6 +92,8 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_max", 10000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_delayms_max", infinity),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_queue_hwm", 100000),
+    cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 101),
+    cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 11),
     cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq", 5),
     cuttlefish_unit:assert_config(Config, "yokozuna.num_solrq_helpers", 20),
     ok.


### PR DESCRIPTION
- Introduce two new elements to yokozuna schema:
  - `yokozuna.ibrowse_max_sessions` (default 100)
  - `yokozuna.ibrowse_max_pipeline_size` (default 1)
- Add some new functions in `yz_solr` that get/set these values on the
  ibrowse process used therein.
- In `yz_app` setup sequence, apply these settings to `yz_solr` using
  the functions mentioned above.
- Test that the configuration values are applied to ibrowse in the
  `yz_startup_shutdown` riak_test.
