### PR TITLE
Use correct yokozuna environment variable for Solr entropy data timeout

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -70,9 +70,9 @@
 ]}.
 
 %% @doc The timeout for ibrowse (ibrowse:send_req) requests to Solr's
-%% entrop_data endpoints. Defaults to 60 seconds. It will always round up to the
+%% entropy_data endpoints. Defaults to 60 seconds. It will always round up to the
 %% nearest second, e.g. 1ms = 999 ms = 1s.
-{mapping, "search.solr.request_ed_timeout", "yokozuna.solr_request_ed_timeout",
+{mapping, "search.solr.ed_request_timeout", "yokozuna.solr_ed_request_timeout",
 [
   {default, "60s"},
   {datatype, {duration, ms}},


### PR DESCRIPTION
Also fix typo in related documentation.

In yokozuna.hrl the variable is called `solr_ed_request_timeout`. Make the cuttlefish mapping match this.
