### PR TITLE
Fix deadlock between yz_entropy_mgr and yz_index_hashtree

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -258,6 +258,9 @@
             app_helper:get_env(riak_kv, anti_entropy_build_limit, {1, 3600000})
         )).
 
+-define(YZ_ENTROPY_LOCK_TIMEOUT,
+    app_helper:get_env(?YZ_APP_NAME, anti_entropy_lock_timeout, 10000)).
+
 -type hashtree() :: hashtree:hashtree().
 -type exchange() :: {p(), {p(), n()}}.
 -type exchange_mode() :: automatic | manual.

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -52,7 +52,6 @@ start_link() ->
 get_lock(Type) ->
     get_lock(Type, self()).
 
--define(YZ_ENTROPY_LOCK_TIMEOUT, 10000).
 -spec get_lock(term(), pid()) -> ok | max_concurrency.
 get_lock(Type, Pid) ->
     gen_server:call(?MODULE, {get_lock, Type, Pid}, ?YZ_ENTROPY_LOCK_TIMEOUT).

--- a/src/yz_events.erl
+++ b/src/yz_events.erl
@@ -37,8 +37,7 @@
          terminate/2]).
 
 %% other
--export([create_table/0,
-         in_sync_with_metadata/0]).
+-export([create_table/0]).
 
 -include("yokozuna.hrl").
 
@@ -74,8 +73,6 @@ start_link() ->
 add_guarded_handler(Handler, Args) ->
     riak_core:add_guarded_event_handler(?MODULE, Handler, Args).
 
-in_sync_with_metadata() ->
-    gen_event:call(whereis(yz_events), yz_events, in_sync_with_metadata).
 %%%===================================================================
 %%% Callbacks
 %%%===================================================================
@@ -118,10 +115,6 @@ handle_info(tick, S) ->
     S2 = S#state{num_ticks=NumTicks2,
                  prev_index_hash=CurrHash},
     {ok, S2}.
-
-handle_call(in_sync_with_metadata, S) ->
-    IndexHash = riak_core_metadata:prefix_hash(?YZ_META_INDEXES),
-    {ok, S#state.prev_index_hash == IndexHash, S};
 
 handle_call(Req, S) ->
     ?WARN("unexpected request ~p", [Req]),

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -124,6 +124,10 @@ prepare_exchange(start_exchange, S) ->
         error:{badmatch, Reason} ->
             lager:debug("An error occurred preparing exchange ~p", [Reason]),
             send_exchange_status(Reason, S),
+            {stop, normal, S};
+        error:{timeout, Reason} ->
+            lager:debug("Timed out attempting to get a lock: ~p", [Reason]),
+            send_exchange_status(build_limit_reached, S),
             {stop, normal, S}
     end;
 


### PR DESCRIPTION
- Add timeout to yz_entropy_mgr:get_lock
- If lock acquisition times out, added yz_entropy_mgr:release_lock, which casts a release message back to make sure we don't hold the lock after the timeout.
- Make yz_index_hashtree:expire a cast rather than call, as that's the way it's really used (and only for testing/diagnostics).
- Removing ill-advised code that attempted to synchronize yz_events with yz_index_hashtree - test had bad configuration options so it would fail, but the code itself handles the situation properly.
