### PR TITLE
Bring sidejob back for stats

### DIFF
--- a/src/yz_fuse.erl
+++ b/src/yz_fuse.erl
@@ -59,7 +59,7 @@ setup() ->
     ok = fuse_event:add_handler(yz_events, []),
 
     %% Set up fuse stats
-    application:set_env(fuse, stats_plugin, fuse_stats_exometer).
+    application:set_env(fuse, stats_plugin, yz_fuse_stats_sidejob).
 
 %%%===================================================================
 %%% API

--- a/src/yz_fuse_stats_sidejob.erl
+++ b/src/yz_fuse_stats_sidejob.erl
@@ -1,0 +1,40 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc yz_fuse_stats_sidejob is a module implementing for offloading
+%%      statistics updates to a background worker pool maintained by sidejob
+%%      so that the calls to exometer don't slow down indexing work.
+%%      All operations are pass-through to yz_stat to keep the "how" of stats
+%%      updates in one place.
+
+-module(yz_fuse_stats_sidejob).
+-behaviour(fuse_stats_plugin).
+-export([init/1, increment/2]).
+
+%% @doc Initialize exometer for `Name'.
+-spec init(Name :: atom()) -> ok.
+init(Name) ->
+    yz_stat:initialize_fuse_stats(Name),
+    ok.
+
+%% @doc Increment `Name's `Counter' spiral.
+-spec increment(Name :: atom(), Counter :: ok | blown | melt) -> ok.
+increment(Name, Counter) ->
+    _ = yz_stat_worker:update({update_fuse_stat, Name, Counter}),
+    ok.

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -39,6 +39,7 @@
     drain_timeout/0,
     drain_cancel_timeout/0,
     detected_repairs/1,
+    initialize_fuse_stats/1,
     search_fail/0,
     search_end/1,
     blocked_vnode/1,
@@ -80,6 +81,11 @@ register_stats() ->
 -spec get_stats() -> proplists:proplist() | {error, Reason :: term()}.
 get_stats() ->
     riak_core_stat:get_stats(?APP).
+
+%% @doc Initialize the Fuse stats subsystem for a given fuse.
+-spec initialize_fuse_stats(Name :: atom()) -> ok.
+initialize_fuse_stats(Name) ->
+    fuse_stats_exometer:init(Name).
 
 %% @doc Send stat updates for an index failure.
 -spec index_fail() -> ok.
@@ -218,7 +224,9 @@ perform_update(search_fail) ->
 perform_update({fuse_recovered, Index}) ->
     exometer:update([yz_fuse, yz_fuse:fuse_name_for_index(Index), recovered], 1);
 perform_update({fuse_blown, Index}) ->
-    exometer:update([yz_fuse, yz_fuse:fuse_name_for_index(Index), blown], 1).
+    exometer:update([yz_fuse, yz_fuse:fuse_name_for_index(Index), blown], 1);
+perform_update({update_fuse_stat, Name, Counter}) ->
+    fuse_stats_exometer:increment(Name, Counter).
 
 
 %% -------------------------------------------------------------------

--- a/src/yz_stat_worker.erl
+++ b/src/yz_stat_worker.erl
@@ -45,7 +45,7 @@ handle_call(_Req, _From, S) ->
     {reply, unexpected_req, S}.
 
 handle_cast({update, StatUpdate}, S) ->
-    yz_stat:update(StatUpdate),
+    yz_stat:perform_update(StatUpdate),
     {noreply, S};
 handle_cast(_Req, S) ->
     ?WARN("Unexpected request received ~p", [_Req]),


### PR DESCRIPTION
Writing to Exometer can slow down the batching to Solr. Rather than do this synchronously while batching information to Solr, use sidejob to make the exometer updates asynchronous. Also, build a simple fuse_stats_plugin implementation so that Fuse can also use Sidejob for stats updates.

Requires basho/sidejob#14 in order to pass tests.
