### PR TITLE
Mark new Cuttlefish elements as commented

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -158,6 +158,7 @@
 %%      "search.queue.batch.flush_interval".
 {mapping, "search.queue.batch.minimum", "yokozuna.solrq_batch_min", [
   {default, 1},
+  {commented, 1},
   {datatype, integer},
   {validators, ["positive_integer"]}
 ]}.
@@ -171,6 +172,7 @@
 %%      given request.
 {mapping, "search.queue.batch.maximum", "yokozuna.solrq_batch_max", [
   {default, 100},
+  {commented, 100},
   {datatype, integer},
   {validators, ["positive_integer"]}
 ]}.
@@ -187,6 +189,7 @@
 {mapping, "search.queue.batch.flush_interval",
  "yokozuna.solrq_batch_flush_interval", [
   {default, "1s"},
+  {commented, "1s"},
   {datatype, [{duration, ms}, {atom, infinity}]}
 ]}.
 
@@ -197,6 +200,7 @@
 %%      Search batching subsystem if writes into Solr start to fall behind.
 {mapping, "search.queue.high_watermark", "yokozuna.solrq_hwm", [
   {default, 0},
+  {commented, 0},
   {datatype, integer},
   {validators, ["non_negative_integer"]}
 ]}.
@@ -249,6 +253,7 @@
 %%      and retried at a later time.
 {mapping, "search.queue.drain.timeout", "yokozuna.solrq_drain_timeout", [
   {default, "1m"},
+  {commented, "1m"},
   {datatype, {duration, ms}},
   hidden
 ]}.
@@ -259,6 +264,7 @@
 %%      is cancelled and retried at a later time.
 {mapping, "search.queue.drain.cancel.timeout", "yokozuna.solrq_drain_cancel_timeout", [
   {default, "5s"},
+  {commented, "5s"},
   {datatype, {duration, ms}},
   hidden
 ]}.
@@ -269,6 +275,7 @@
 %%      behavior. Users generally have little reason to disable draining.
 {mapping, "search.queue.drain.enable", "yokozuna.solrq_drain_enable", [
   {default, on},
+  {commented, on},
   {datatype, flag},
   hidden
 ]}.


### PR DESCRIPTION
New search.queue.\* configuration elements were added to the Yokozuna Cuttlefish schema. Although these new config elements had default values associated with them, they would still cause certain tests to fail. Specifically, tests that performed a "downgrade" operation would fail because the downgraded node would still have the config file with the new elements and would therefore fail to start due to validation errors. Therefore, we need to mark the new config elements as commented in Cuttlefish so that tests that perform a downgrade can function properly.
