### PR TITLE
Added handling of JSON encoding errors

### DIFF
--- a/src/yz_doc.erl
+++ b/src/yz_doc.erl
@@ -152,16 +152,18 @@ extract_fields({MD, V}) ->
         ExtractorDef = yz_extractor:get_def(CT, [check_default]),
         case yz_extractor:run(V, ExtractorDef) of
             {error, Reason} ->
+                %% TODO is this an index failure, or should we track this with a different stat?
                 yz_stat:index_fail(),
-                ?ERROR("Failed to index fields from value with reason ~p.  Value: ~p", [Reason, V]),
+                ?ERROR("Failed to extract fields from value with reason ~p.  Value: ~p", [Reason, V]),
                 [{?YZ_ERR_FIELD_S, 1}];
             Fields ->
                 Fields
         end
     catch _:Err ->
+            %% TODO is this an index failure, or should we track this with a different stat?
             yz_stat:index_fail(),
             Trace = erlang:get_stacktrace(),
-            ?ERROR("An exception occurred indexing fields from value with reason ~p. Trace: ~p.  Value: ~p", [Err, Trace, V]),
+            ?ERROR("An exception occurred extracting fields from value with reason ~p. Trace: ~p.  Value: ~p", [Err, Trace, V]),
             [{?YZ_ERR_FIELD_S, 1}]
     end.
 

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -211,7 +211,11 @@ index(Core, Docs, DelOps) ->
     end.
 
 index_batch(Core, Ops) ->
-    JSON = mochijson2:encode({struct, Ops}),
+    JSON = try
+               mochijson2:encode({struct, Ops})
+           catch _:E ->
+               throw({"Failed to encode ops", bad_data, E})
+           end,
     URL = ?FMT("~s/~s/update", [base_url(), Core]),
     Headers = [{content_type, "application/json"}],
     Opts = [{response_format, binary}],

--- a/test/yz_solrq_eqc.erl
+++ b/test/yz_solrq_eqc.erl
@@ -216,13 +216,14 @@ prop_ok() ->
 
 setup() ->
     %% Todo: Try trapping lager_msg:new/4 instead
-    %% meck:new(lager, [passthrough]),
-    %% meck:expect(lager, log, fun(_,_,Fmt,Args) ->
-    %%                                 io:format(user, "LAGER: " ++ Fmt, Args)
+    meck:new(lager, [passthrough]),
+    meck:expect(lager, log,
+        fun(_, _, Fmt, Args) ->
+            io:format(user, "LAGER: " ++ Fmt, Args)
+        end),
     application:start(syntax_tools),
     application:start(compiler),
     application:start(goldrush),
-    application:start(lager),
 
     yz_solrq:set_solrq_worker_tuple(1), % for yz_solrq_sup:regname
     yz_solrq:set_solrq_helper_tuple(1), % for yz_solrq_helper_sup:regname
@@ -293,7 +294,6 @@ cleanup() ->
 
     catch application:stop(fuse),
 
-    catch application:stop(lager),
     catch application:stop(goldrush),
     catch application:stop(compiler),
     catch application:stop(syntax_tools),
@@ -567,13 +567,13 @@ drain([P | Rest] = _Partitions) ->
                 {error, Info}
         after 10000 ->
             erlang:demonitor(Reference),
-            lager:error("Warning!  Drain timed out.  Cancelling..."),
+            %lager:error("Warning!  Drain timed out.  Cancelling..."),
             yz_solrq_drain_fsm:cancel(),
             {error, timeout}
         end
     catch
         _:badarg ->
-            lager:error("Error! Drain in progress."),
+            %lager:error("Error! Drain in progress."),
             {error, in_progress}
     end,
     timer:sleep(500),


### PR DESCRIPTION
(e.g., if operations contain non-unicode binary data) and treating such bad data in the same way we handle bad requests on the Solr side, in other words, drop the message, and keep chugging along on the rest of the messages, and make sure the object associated with the bad data makes its way into the YZ AAE tree.  Also changed debug logs for failures to error, so that the customer will actually see the error, and added code to handle the case where we try to purge an entry with an empty queue.

A test for this condition has been added to riak_test.  See https://github.com/basho/riak_test/pull/1092
