### PR TITLE
Fixed test failures due to setting default draining to false

### DIFF
--- a/riak_test/yz_aae_test.erl
+++ b/riak_test/yz_aae_test.erl
@@ -26,6 +26,7 @@
          {yokozuna,
           [
            {enabled, true},
+           {?SOLRQ_DRAIN_ENABLE, true},
            {anti_entropy_tick, 1000},
            %% allow AAE to build trees and exchange rapidly
            {anti_entropy_build_limit, {100, 1000}},

--- a/riak_test/yz_rs_migration_test.erl
+++ b/riak_test/yz_rs_migration_test.erl
@@ -55,7 +55,8 @@
          {riak_search,
           [
            {enabled, true}
-          ]}
+          ]},
+          {yokozuna, [{?SOLRQ_DRAIN_ENABLE, true}]}
         ]).
 -define(FRUIT_BUCKET, <<"fruit">>).
 

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -669,7 +669,7 @@ wait_for_index(Cluster, Index) ->
         fun(Node) ->
                 lager:info("Waiting for index ~s to be avaiable on node ~p",
                            [Index, Node]),
-                rpc:call(Node, yz_solr, ping, [Index])
+                rpc:call(Node, yz_index, exists, [Index])
         end,
     wait_until(Cluster, IsIndexUp),
     ok.

--- a/riak_test/yz_solrq_test.erl
+++ b/riak_test/yz_solrq_test.erl
@@ -76,6 +76,7 @@
            {?SOLRQ_HWM, 1000},
            {?ERR_THRESH_FAIL_COUNT, 1},
            {?ERR_THRESH_RESET_INTERVAL, ?MELT_RESET_REFRESH},
+           {?SOLRQ_DRAIN_ENABLE, true},
            {anti_entropy, {off, []}}
           ]}]).
 

--- a/riak_test/yz_startup_shutdown.erl
+++ b/riak_test/yz_startup_shutdown.erl
@@ -10,6 +10,7 @@
 -define(MAX_PIPELINE_SIZE, 9).
 -define(CONFIG,
         [{yokozuna, [{enabled, true},
+                     {?SOLRQ_DRAIN_ENABLE, true},
                      {?YZ_CONFIG_IBROWSE_MAX_SESSIONS, ?MAX_SESSIONS},
                      {?YZ_CONFIG_IBROWSE_MAX_PIPELINE_SIZE, ?MAX_PIPELINE_SIZE}]}]
 ).

--- a/riak_test/yz_stat_test.erl
+++ b/riak_test/yz_stat_test.erl
@@ -35,6 +35,7 @@
         {?SOLRQ_HWM, 10},
         {?ERR_THRESH_FAIL_COUNT, 1},
         {?ERR_THRESH_RESET_INTERVAL, 3000},
+        {?SOLRQ_DRAIN_ENABLE, true},
         %% allow AAE to build trees and exchange rapidly
         {anti_entropy_tick, 1000},
         {anti_entropy_build_limit, {100, 1000}},


### PR DESCRIPTION
Added draining to tests that need it and fixed yz_rt to wait for an index to be created by calling yz_index:exists instead of (just) yz_solr:ping
