### PR TITLE
HLLs extracted for search

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -96,6 +96,7 @@
    <!-- Riak datatypes default fields-->
    <field name="counter" type="int"    indexed="true" stored="true" multiValued="false" />
    <field name="set"     type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="hll"     type="int"    indexed="true" stored="true" multiValued="false" />
 
    <!-- Riak datatypes embedded fields -->
    <dynamicField name="*_flag"     type="boolean" indexed="true" stored="true" multiValued="false" />

--- a/src/yz_extractor.erl
+++ b/src/yz_extractor.erl
@@ -25,12 +25,13 @@
 -type register_opts() :: [overwrite].
 -type get_def_opts() :: [check_default].
 
-%% NOTE: The map is treated as an orddict so these entries must be
+%% NOTE: The map is treated as an orddict so these entries *MUST BE*
 %%       ordered correctly or `get_def' may report no extractor is
 %%       registered when there is one.
 -define(DEFAULT_MAP, [{default, yz_noop_extractor},
                       {"application/json",yz_json_extractor},
                       {"application/riak_counter", yz_dt_extractor},
+                      {"application/riak_hll", yz_dt_extractor},
                       {"application/riak_map", yz_dt_extractor},
                       {"application/riak_set", yz_dt_extractor},
                       {"application/xml",yz_xml_extractor},

--- a/test/yz_dt_extractor_tests.erl
+++ b/test/yz_dt_extractor_tests.erl
@@ -22,6 +22,14 @@ set_test() ->
 
     valid_extraction(Result, Expect).
 
+%% Test hll extract
+hll_test() ->
+    HllBin = binary_crdt(hll),
+    Result = yz_dt_extractor:extract(HllBin),
+    Expect = [{<<"hll">>, <<"9">>}],
+
+    valid_extraction(Result, Expect).
+
 %% Test map extract
 map_test() ->
     MapBin = binary_crdt(map),
@@ -82,4 +90,10 @@ raw_type(set) ->
       );
 raw_type(counter) ->
     ?COUNTER_TYPE(
-       element(2,?COUNTER_TYPE:update({increment, 10}, <<0>>, ?COUNTER_TYPE:new()))).
+       element(2,?COUNTER_TYPE:update({increment, 10}, <<0>>, ?COUNTER_TYPE:new())));
+raw_type(hll) ->
+    ?HLL_TYPE(
+       element(2,?HLL_TYPE:update({add_all, [<<"T">>, <<"h">>, <<"r">>, <<"i">>,
+                                             <<"l">>, <<"l">>, <<"a">>, <<"s">>,
+                                             <<"f">>, <<"u">>, <<"h">>]},
+                                  <<0>>, ?HLL_TYPE:new()))).


### PR DESCRIPTION
- extract hyperloglog(set) datatypes to search on hll values, e.g. range (similar to counters)
- update default schema for hll(s)
- rebar.config (for now) set to feature-zl-hll_datatypes of riak_kv
  until reviewed/merged correctly
- add r_t and eunit tests respectively
