### PR TITLE
depend on fuse to unbreak make devrel

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,9 @@
   {riak_kv, ".*",
    {git, "git://github.com/basho/riak_kv.git", {branch, "riak_ts-develop"}}},
   {ibrowse, "4.0.2",
-   {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
+   {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
+  {fuse, "2.1.0",
+   {git, "git@github.com:jlouis/fuse.git", {tag, "v2.1.0"}}}
  ]}.
 
 {pre_hooks, [{compile, "./tools/grab-solr.sh"}]}.


### PR DESCRIPTION
Because of https://github.com/basho/riak/pull/812, `make devrel` now needs fuse, which it cannot find as no deps in riak TS seems to depend on fuse.

It would, in theory, be more appropriate to rebase riak_ts-develop onto whatever is current in yokozuna, but because yokozuna is not used in riak TS, we should be good with this surgical change.

Let @javajolt the branch master decide on the fate of this PR (or do a rebase/merge).
