### PR TITLE
Add throttling to AAE repairs

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -263,11 +263,11 @@
 -define(YZ_ENTROPY_LOCK_TIMEOUT,
     app_helper:get_env(?YZ_APP_NAME, anti_entropy_lock_timeout, 10000)).
 
--define(YZ_ENTROPY_THROTTLE_KEY, yokozuna_aae).
+-define(YZ_ENTROPY_THROTTLE_KEY, aae_throttle).
 -define(YZ_ENTROPY_THROTTLE_LIMITS_KEY, aae_throttle_limits).
 -define(YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS,
         [{-1,0}, {500,10}, {1000,50}, {5000,250}, {10000,1000}, {50000,3000}]).
--define(YZ_ENTROPY_THROTTLE_KILL_KEY, yokozuna_aae_throttle_kill_switch).
+-define(YZ_ENTROPY_THROTTLE_ENABLED_KEY, aae_throttle_enabled).
 
 -type hashtree() :: hashtree:hashtree().
 -type exchange() :: {p(), {p(), n()}}.

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -263,6 +263,10 @@
 -define(YZ_ENTROPY_LOCK_TIMEOUT,
     app_helper:get_env(?YZ_APP_NAME, anti_entropy_lock_timeout, 10000)).
 
+-define(YZ_ENTROPY_THROTTLE_KEY, yokozuna_aae).
+-define(YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS,
+        [{-1,0}, {500,10}, {1000,50}, {5000,250}, {10000,1000}, {50000,3000}]).
+
 -type hashtree() :: hashtree:hashtree().
 -type exchange() :: {p(), {p(), n()}}.
 -type exchange_mode() :: automatic | manual.

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -264,8 +264,10 @@
     app_helper:get_env(?YZ_APP_NAME, anti_entropy_lock_timeout, 10000)).
 
 -define(YZ_ENTROPY_THROTTLE_KEY, yokozuna_aae).
+-define(YZ_ENTROPY_THROTTLE_LIMITS_KEY, yokozuna_aae_throttle_limits).
 -define(YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS,
         [{-1,0}, {500,10}, {1000,50}, {5000,250}, {10000,1000}, {50000,3000}]).
+-define(YZ_ENTROPY_THROTTLE_KILL_KEY, yokozuna_aae_throttle_kill_switch).
 
 -type hashtree() :: hashtree:hashtree().
 -type exchange() :: {p(), {p(), n()}}.

--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -264,7 +264,7 @@
     app_helper:get_env(?YZ_APP_NAME, anti_entropy_lock_timeout, 10000)).
 
 -define(YZ_ENTROPY_THROTTLE_KEY, yokozuna_aae).
--define(YZ_ENTROPY_THROTTLE_LIMITS_KEY, yokozuna_aae_throttle_limits).
+-define(YZ_ENTROPY_THROTTLE_LIMITS_KEY, aae_throttle_limits).
 -define(YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS,
         [{-1,0}, {500,10}, {1000,50}, {5000,250}, {10000,1000}, {50000,3000}]).
 -define(YZ_ENTROPY_THROTTLE_KILL_KEY, yokozuna_aae_throttle_kill_switch).

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -104,7 +104,7 @@
 }.
 
 %% @doc Whether the throttle for Yokozuna active anti-entropy is enabled.
-{mapping, "anti_entropy.throttle", "yokozuna.aae_throttle_kill_switch", [
+{mapping, "search.anti_entropy.throttle", "yokozuna.aae_throttle_kill_switch", [
   {default, on},
   {datatype, {flag, off, on}},
   hidden
@@ -114,25 +114,25 @@
 %% is a minimum solrq queue size and a time-delay that the throttle
 %% should observe at that size and above. For example:
 %%
-%%     anti_entropy.throttle.tier1.solrq_queue_length = 0
-%%     anti_entropy.throttle.tier1.delay = 0ms
-%%     anti_entropy.throttle.tier2.solrq_queue_length = 40
-%%     anti_entropy.throttle.tier2.delay = 5ms
+%%     search.anti_entropy.throttle.tier1.solrq_queue_length = 0
+%%     search.anti_entropy.throttle.tier1.delay = 0ms
+%%     search.anti_entropy.throttle.tier2.solrq_queue_length = 40
+%%     search.anti_entropy.throttle.tier2.delay = 5ms
 %%
 %% If configured, there must be a tier which includes a mailbox size
 %% of 0. Both .solrq_queue_length and .delay must be set for each tier.
-%% @see anti_entropy.throttle
+%% @see search.anti_entropy.throttle
 {mapping,
- "anti_entropy.throttle.$tier.solrq_queue_length",
+ "search.anti_entropy.throttle.$tier.solrq_queue_length",
  "yokozuna.aae_throttle_limits", [
   {datatype, integer},
   hidden,
   {validators, ["non_negative_integer"]}
 ]}.
 
-%% @see anti_entropy.throttle.$tier.solrq_queue_length
+%% @see search.anti_entropy.throttle.$tier.solrq_queue_length
 {mapping,
- "anti_entropy.throttle.$tier.delay",
+ "search.anti_entropy.throttle.$tier.delay",
  "yokozuna.aae_throttle_limits", [
   {datatype, {duration, ms}},
   hidden
@@ -140,7 +140,7 @@
 
 {translation,
  "yokozuna.aae_throttle_limits",
- riak_core_throttle:create_limits_translator_fun("anti_entropy", "solrq_queue_length")
+ riak_core_throttle:create_limits_translator_fun("search.anti_entropy", "solrq_queue_length")
 }.
 
 %%===========================================================

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -104,9 +104,9 @@
 }.
 
 %% @doc Whether the throttle for Yokozuna active anti-entropy is enabled.
-{mapping, "search.anti_entropy.throttle", "yokozuna.aae_throttle_kill_switch", [
+{mapping, "search.anti_entropy.throttle", "yokozuna.aae_throttle_enabled", [
   {default, on},
-  {datatype, {flag, off, on}},
+  {datatype, flag},
   hidden
 ]}.
 

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -103,6 +103,46 @@
   end
 }.
 
+%% @doc Whether the throttle for Yokozuna active anti-entropy is enabled.
+{mapping, "anti_entropy.throttle", "yokozuna.aae_throttle_kill_switch", [
+  {default, on},
+  {datatype, {flag, off, on}},
+  hidden
+]}.
+
+%% @doc Sets the throttling tiers for active anti-entropy. Each tier
+%% is a minimum solrq queue size and a time-delay that the throttle
+%% should observe at that size and above. For example:
+%%
+%%     anti_entropy.throttle.tier1.solrq_queue_length = 0
+%%     anti_entropy.throttle.tier1.delay = 0ms
+%%     anti_entropy.throttle.tier2.solrq_queue_length = 40
+%%     anti_entropy.throttle.tier2.delay = 5ms
+%%
+%% If configured, there must be a tier which includes a mailbox size
+%% of 0. Both .solrq_queue_length and .delay must be set for each tier.
+%% @see anti_entropy.throttle
+{mapping,
+ "anti_entropy.throttle.$tier.solrq_queue_length",
+ "yokozuna.aae_throttle_limits", [
+  {datatype, integer},
+  hidden,
+  {validators, ["non_negative_integer"]}
+]}.
+
+%% @see anti_entropy.throttle.$tier.solrq_queue_length
+{mapping,
+ "anti_entropy.throttle.$tier.delay",
+ "yokozuna.aae_throttle_limits", [
+  {datatype, {duration, ms}},
+  hidden
+]}.
+
+{translation,
+ "yokozuna.aae_throttle_limits",
+ riak_core_throttle:create_limits_translator_fun("anti_entropy", "solrq_queue_length")
+}.
+
 %%===========================================================
 %% Fuse-related settings
 %%===========================================================

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -23,6 +23,8 @@
 -behaviour(gen_server).
 -include("yokozuna.hrl").
 
+-define(UNKNOWN_QUEUE_LENGTH, -1).
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -547,7 +549,14 @@ update_throttle(State) ->
     end.
 
 calculate_current_load(_State) ->
-    yz_solrq:queue_total_length().
+    case yz_stat:get_stat([queue, total_length]) of
+        Num when is_integer(Num) ->
+            Num;
+        Unexpected ->
+            lager:error("Unexpected value for statistic [queue, total_length]: ~p",
+                        [Unexpected]),
+            ?UNKNOWN_QUEUE_LENGTH
+    end.
 
 %%%===================================================================
 %%% Exchanging

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -521,22 +521,26 @@ maybe_poke_tree(S) ->
 %%%===================================================================
 
 throttle() ->
-    riak_core_throttle:throttle(?YZ_ENTROPY_THROTTLE_KEY).
+    riak_core_throttle:throttle(?YZ_APP_NAME, ?YZ_ENTROPY_THROTTLE_KEY).
 
 init_throttle(InitialThrottle) ->
-    riak_core_throttle:init(?YZ_ENTROPY_THROTTLE_KEY,
-                            ?YZ_APP_NAME,
+    riak_core_throttle:init(?YZ_APP_NAME,
+                            ?YZ_ENTROPY_THROTTLE_KEY,
                             {?YZ_ENTROPY_THROTTLE_LIMITS_KEY,
                              ?YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS},
                             {?YZ_ENTROPY_THROTTLE_KILL_KEY, false}),
-    ok = riak_core_throttle:set_throttle(?YZ_ENTROPY_THROTTLE_KEY,
+    ok = riak_core_throttle:set_throttle(?YZ_APP_NAME,
+                                         ?YZ_ENTROPY_THROTTLE_KEY,
                                          InitialThrottle).
 
 update_throttle(State) ->
-    case riak_core_throttle:is_throttle_enabled(?YZ_ENTROPY_THROTTLE_KEY) of
+    Enabled = riak_core_throttle:is_throttle_enabled(?YZ_APP_NAME,
+                                                     ?YZ_ENTROPY_THROTTLE_KEY),
+    case Enabled of
         true ->
             Load = calculate_current_load(State),
-            riak_core_throttle:set_throttle_by_load(?YZ_ENTROPY_THROTTLE_KEY,
+            riak_core_throttle:set_throttle_by_load(?YZ_APP_NAME,
+                                                    ?YZ_ENTROPY_THROTTLE_KEY,
                                                     Load);
         false ->
             ok

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -553,7 +553,7 @@ calculate_current_load(_State) ->
         Num when is_integer(Num) ->
             Num;
         Unexpected ->
-            lager:error("Unexpected value for statistic [queue, total_length]: ~p",
+            lager:debug("Unexpected value for statistic [queue, total_length]: ~p",
                         [Unexpected]),
             ?UNKNOWN_QUEUE_LENGTH
     end.

--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -524,11 +524,11 @@ throttle() ->
     riak_core_throttle:throttle(?YZ_APP_NAME, ?YZ_ENTROPY_THROTTLE_KEY).
 
 init_throttle(InitialThrottle) ->
-    riak_core_throttle:init(?YZ_APP_NAME,
-                            ?YZ_ENTROPY_THROTTLE_KEY,
-                            {?YZ_ENTROPY_THROTTLE_LIMITS_KEY,
-                             ?YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS},
-                            {?YZ_ENTROPY_THROTTLE_KILL_KEY, false}),
+    ok = riak_core_throttle:init(?YZ_APP_NAME,
+                                 ?YZ_ENTROPY_THROTTLE_KEY,
+                                 {?YZ_ENTROPY_THROTTLE_LIMITS_KEY,
+                                  ?YZ_ENTROPY_THROTTLE_DEFAULT_LIMITS},
+                                 {?YZ_ENTROPY_THROTTLE_ENABLED_KEY, true}),
     ok = riak_core_throttle:set_throttle(?YZ_APP_NAME,
                                          ?YZ_ENTROPY_THROTTLE_KEY,
                                          InitialThrottle).

--- a/src/yz_exchange_fsm.erl
+++ b/src/yz_exchange_fsm.erl
@@ -228,6 +228,7 @@ repair(Partition, {remote_missing, KeyBin}) ->
     BKey = binary_to_term(KeyBin),
     Index = yz_kv:get_index(BKey),
     FakeObj = fake_kv_object(BKey),
+    yz_entropy_mgr:throttle(),
     case yz_kv:should_index(Index) of
         true ->
             Repair = full_repair,
@@ -247,6 +248,7 @@ repair(Partition, {_Reason, KeyBin}) ->
     %% node is owner.
     case yz_kv:local_get(Partition, BKey) of
         {ok, Obj} ->
+            yz_entropy_mgr:throttle(),
             case yz_kv:should_index(Index) of
                 true ->
                     Repair = full_repair,

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -87,7 +87,7 @@ get_stats() ->
 %% not found.
 -spec get_stat([atom(), ...]) -> undefined | term().
 get_stat(Name) when is_list(Name) ->
-    Path = [riak_core_stat:prefix(), ?APP] ++ Name,
+    Path = [?PFX, ?APP] ++ Name,
     case exometer:get_value(Path, value) of
         {ok, [{value, Value}]} ->
             Value;

--- a/src/yz_stat.erl
+++ b/src/yz_stat.erl
@@ -31,6 +31,7 @@
 %% Public API
 -export([start_link/0,
     get_stats/0,
+    get_stat/1,
     index_fail/0,
     index_end/3,
     drain_end/1,
@@ -81,6 +82,18 @@ register_stats() ->
 -spec get_stats() -> proplists:proplist() | {error, Reason :: term()}.
 get_stats() ->
     riak_core_stat:get_stats(?APP).
+
+%% @doc Return the value for the stat with the given `Name', or `undefined' if
+%% not found.
+-spec get_stat([atom(), ...]) -> undefined | term().
+get_stat(Name) when is_list(Name) ->
+    Path = [riak_core_stat:prefix(), ?APP] ++ Name,
+    case exometer:get_value(Path, value) of
+        {ok, [{value, Value}]} ->
+            Value;
+        _ ->
+            undefined
+    end.
 
 %% @doc Initialize the Fuse stats subsystem for a given fuse.
 -spec initialize_fuse_stats(Name :: atom()) -> ok.

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -87,11 +87,11 @@ override_schema_test() ->
             {["search", "queue", "drain", "cancel", "timeout"], "10ms"},
             {["search", "ibrowse_max_sessions"], 101},
             {["search", "ibrowse_max_pipeline_size"], 11},
-            {["anti_entropy", "throttle"], off},
-            {["anti_entropy", "throttle", "tier1", "solrq_queue_length"], 0},
-            {["anti_entropy", "throttle", "tier1", "delay"], "1d"},
-            {["anti_entropy", "throttle", "tier2", "solrq_queue_length"], 11},
-            {["anti_entropy", "throttle", "tier2", "delay"], "10d"}
+            {["search", "anti_entropy", "throttle"], off},
+            {["search", "anti_entropy", "throttle", "tier1", "solrq_queue_length"], 0},
+            {["search", "anti_entropy", "throttle", "tier1", "delay"], "1d"},
+            {["search", "anti_entropy", "throttle", "tier2", "solrq_queue_length"], 11},
+            {["search", "anti_entropy", "throttle", "tier2", "delay"], "10d"}
            ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -50,7 +50,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", false),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 100),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 1),
-    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_kill_switch", false),
+    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled", true),
     cuttlefish_unit:assert_not_configured(Config, "yokozuna.aae_throttle_limits"),
     ok.
 
@@ -134,8 +134,8 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", false),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 101),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 11),
-    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_kill_switch",
-                                  true),
+    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled",
+                                  false),
     cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_limits",
                                   [{-1, 86400000}, {10, 864000000}]),
     ok.

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -50,6 +50,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", false),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 100),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 1),
+    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_kill_switch", false),
+    cuttlefish_unit:assert_not_configured(Config, "yokozuna.aae_throttle_limits"),
     ok.
 
 override_schema_test() ->
@@ -84,8 +86,13 @@ override_schema_test() ->
             {["search", "queue", "drain", "timeout"], "2m"},
             {["search", "queue", "drain", "cancel", "timeout"], "10ms"},
             {["search", "ibrowse_max_sessions"], 101},
-            {["search", "ibrowse_max_pipeline_size"], 11}
-    ],
+            {["search", "ibrowse_max_pipeline_size"], 11},
+            {["anti_entropy", "throttle"], off},
+            {["anti_entropy", "throttle", "tier1", "solrq_queue_length"], 0},
+            {["anti_entropy", "throttle", "tier1", "delay"], "1d"},
+            {["anti_entropy", "throttle", "tier2", "solrq_queue_length"], 11},
+            {["anti_entropy", "throttle", "tier2", "delay"], "10d"}
+           ],
     Config = cuttlefish_unit:generate_templated_config(
                "../priv/yokozuna.schema", Conf, context(), predefined_schema()),
 
@@ -127,6 +134,10 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", false),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 101),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 11),
+    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_kill_switch",
+                                  true),
+    cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_limits",
+                                  [{-1, 86400000}, {10, 864000000}]),
     ok.
 
 validations_test() ->


### PR DESCRIPTION
https://bashoeng.atlassian.net/browse/RIAK-2626

As per RIAK-2626, we needed throttling of Yokozuna's AAE repairs to prevent overload due to the large number of key exchanges that will result from the new hashing algorithm. Therefore, we've added configurable throttling behavior Yokozuna's AAE subsystem, using the new `riak_core_throttle` module introduced in https://github.com/basho/riak_core/pull/849 .

This throttling behavior will introduce a delay between AAE repair operations, the length of which is determined by the current level of "load" in Yokozuna. The load is defined as the current value of the `yz_solrq:queue_total_length/0` function. The mapping between the level of load and the corresponding time delay (referred to as "limits") is configurable with the `yokozuna.aae_throttle_limits` configuration element defined in `yokozuna.schema`.
