### PR TITLE
Replace dist_query CLI command with config change callbacks

### DIFF
--- a/src/yz_app.erl
+++ b/src/yz_app.erl
@@ -60,6 +60,7 @@ start(_StartType, _StartArgs) ->
 
             %% Now everything is started, permit usage by KV/query
             enable_components(),
+            clique:register([yz_console]),
             {ok, Pid};
         Error ->
             Error

--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -331,7 +331,7 @@ solr_jvm_opts() ->
                        solr_jvm_opts,
                        ?YZ_DEFAULT_SOLR_JVM_OPTS).
 
--spec solr_is_up(#state{}) -> #state{}.
+-spec solr_is_up(#state{}) -> {noreply, #state{}}.
 solr_is_up(S) ->
     %% solr finished its startup, be merry
     ?INFO("solr is up", []),


### PR DESCRIPTION
Rather than adding a custom command for enabling/disabling dist-query on a node, we can simply use the builtin clique "set" command to directly update the setting, and we can use config callbacks to ensure the new setting takes effect immediately on the live node.

Note: these changes require the latest version of clique from the develop branch.
