### PR TITLE
Changes job control settings to be commented.

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -318,7 +318,8 @@
 {mapping, "cluster.job.yokozuna.query", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Enable or disable this node in distributed query plans.  If enabled,


### PR DESCRIPTION
This PR changes the job control settings added in 2.2 so that they are commented with their associated default values. Doing so reduces friction in the (unlikely) case that a new install is downgraded to a previous version.
