### PR TITLE
Encapsulated default values for several new configuration variables into macros.

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -494,12 +494,13 @@
 %%%===================================================================
 
 -define(SOLRQ_BATCH_MIN, solrq_batch_min).
+-define(SOLRQ_BATCH_MIN_DEFAULT, 10).
 -define(SOLRQ_BATCH_MAX, solrq_batch_max).
+-define(SOLRQ_BATCH_MAX_DEFAULT, 500).
 -define(SOLRQ_BATCH_FLUSH_INTERVAL, solrq_batch_flush_interval).
+-define(SOLRQ_BATCH_FLUSH_INTERVAL_DEFAULT, 1000).
 -define(SOLRQ_HWM, solrq_hwm).
--define(SOLRQ_HWM_PURGE, solrq_hwm_purge).
--define(SOLRQ_WORKER_COUNT, solrq_worker_count).
--define(SOLRQ_HELPER_COUNT, solrq_helper_count).
+-define(SOLRQ_HWM_DEFAULT, 1000).
 -define(SOLRQ_HWM_PURGE_STRATEGY, solrq_hwm_purge_strategy).
 -define(PURGE_NONE, off).
 -define(PURGE_ONE, purge_one).
@@ -520,8 +521,12 @@
 -define(YZ_INDEX_HASHTREE_PARAMS, yz_index_hashtree_update_params).
 -define(DRAIN_PARTITION, drain_partition).
 -define(SOLRQ_DRAIN_TIMEOUT, solrq_drain_timeout).
+-define(SOLRQ_DRAIN_TIMEOUT_DEFAULT, 60000).
 -define(SOLRQ_DRAIN_ENABLE, solrq_drain_enable).
+-define(SOLRQ_DRAIN_ENABLE_DEFAULT, true).
 -define(SOLRQ_DRAIN_CANCEL_TIMEOUT, solrq_drain_cancel_timeout).
+-define(SOLRQ_DRAIN_CANCEL_TIMEOUT_DEFAULT, 5000).
+
 
 -type drain_param() ::
     {?EXCHANGE_FSM_PID, pid()} |

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -292,8 +292,8 @@
 %%      while the drain is happening, but can reduce AAE repairs when the
 %%      High Water Mark is set higher than the default.
 {mapping, "search.queue.drain.enable", "yokozuna.solrq_drain_enable", [
-  {default, off},
-  {commented, off},
+  {default, on},
+  {commented, on},
   {datatype, flag},
   hidden
 ]}.

--- a/riak_test/yz_rt.erl
+++ b/riak_test/yz_rt.erl
@@ -51,6 +51,7 @@ prepare_cluster(NumNodes, Config) ->
     Cluster = join_all(Nodes),
     wait_for_joins(Cluster),
     rt:wait_for_cluster_service(Cluster, yokozuna),
+    lager:info("Cluster ~p is prepared.", [Cluster]),
     Cluster.
 
 -spec connection_info(list()) -> orddict:orddict().
@@ -595,8 +596,10 @@ create_indexed_bucket(PBConn, Cluster, Bucket, Index) ->
                             {binary(), binary()},
                             index_name(),
                             pos_integer()) -> ok.
-create_indexed_bucket(PBConn, Cluster, {BType, _Bucket}, Index, NVal) ->
+create_indexed_bucket(PBConn, Cluster, {BType, Bucket}, Index, NVal) ->
+    lager:info("Creating index ~p", [Index]),
     ok = riakc_pb_socket:create_search_index(PBConn, Index, <<>>, [{n_val, NVal}]),
+    lager:info("Binding index ~p to bucket ~p", [Index, {BType, Bucket}]),
     ok = set_bucket_type_index(Cluster, BType, Index, NVal).
 
 -spec solr_http({node(), orddict:orddict()}) -> {host(), portnum()}.

--- a/riak_test/yz_stat_test.erl
+++ b/riak_test/yz_stat_test.erl
@@ -29,7 +29,6 @@
     ]},
     {yokozuna, [
         {enabled, true},
-        {?SOLRQ_WORKER_COUNT, 1},
         {?SOLRQ_BATCH_MIN, 6},
         {?SOLRQ_BATCH_FLUSH_INTERVAL, 100000},
         {?SOLRQ_HWM, 10},

--- a/src/yz_solrq.erl
+++ b/src/yz_solrq.erl
@@ -168,10 +168,10 @@ queue_total_length() ->
     lists:sum([yz_solrq_worker:all_queue_len(Index, Partition) || {Index, Partition} <- yz_solrq_sup:active_queues()]).
 
 get_max_batch_size() ->
-    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MAX, ?SOLRQ_BATCH_MIN_DEFAULT).
+    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MAX, ?SOLRQ_BATCH_MAX_DEFAULT).
 
 get_min_batch_size() ->
-    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MIN, ?SOLRQ_BATCH_MAX_DEFAULT).
+    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MIN, ?SOLRQ_BATCH_MIN_DEFAULT).
 
 get_flush_interval() ->
     app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_FLUSH_INTERVAL,

--- a/src/yz_solrq.erl
+++ b/src/yz_solrq.erl
@@ -168,14 +168,14 @@ queue_total_length() ->
     lists:sum([yz_solrq_worker:all_queue_len(Index, Partition) || {Index, Partition} <- yz_solrq_sup:active_queues()]).
 
 get_max_batch_size() ->
-    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MAX, 100).
+    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MAX, ?SOLRQ_BATCH_MIN_DEFAULT).
 
 get_min_batch_size() ->
-    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MIN, 1).
+    app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_MIN, ?SOLRQ_BATCH_MAX_DEFAULT).
 
 get_flush_interval() ->
     app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_BATCH_FLUSH_INTERVAL,
-        1000).
+        ?SOLRQ_BATCH_FLUSH_INTERVAL_DEFAULT).
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================

--- a/src/yz_solrq_drain_mgr.erl
+++ b/src/yz_solrq_drain_mgr.erl
@@ -140,7 +140,7 @@ maybe_drain(false, ExchangeFSMPid, Params) ->
 
 actual_drain(Params, ExchangeFSMPid) ->
     DrainTimeout = application:get_env(?YZ_APP_NAME,
-                                       ?SOLRQ_DRAIN_TIMEOUT, 60000),
+                                       ?SOLRQ_DRAIN_TIMEOUT, ?SOLRQ_DRAIN_TIMEOUT_DEFAULT),
     {ok, Pid} = yz_solrq_sup:start_drain_fsm(Params),
     Reference = erlang:monitor(process, Pid),
     yz_solrq_drain_fsm:start_prepare(Pid),
@@ -166,11 +166,11 @@ actual_drain(Params, ExchangeFSMPid) ->
     end.
 
 enabled() ->
-    application:get_env(?YZ_APP_NAME, ?SOLRQ_DRAIN_ENABLE, true).
+    application:get_env(?YZ_APP_NAME, ?SOLRQ_DRAIN_ENABLE, ?SOLRQ_DRAIN_ENABLE_DEFAULT).
 
 cancel(Reference, Pid) ->
     CancelTimeout = application:get_env(
-        ?YZ_APP_NAME, ?SOLRQ_DRAIN_CANCEL_TIMEOUT, 5000),
+        ?YZ_APP_NAME, ?SOLRQ_DRAIN_CANCEL_TIMEOUT, ?SOLRQ_DRAIN_CANCEL_TIMEOUT_DEFAULT),
     case yz_solrq_drain_fsm:cancel(Pid, CancelTimeout) of
         timeout ->
             lager:warning("Drain cancel timed out.  Killing FSM pid ~p...", [Pid]),

--- a/src/yz_solrq_worker.erl
+++ b/src/yz_solrq_worker.erl
@@ -696,7 +696,7 @@ maybe_start_timer(State) ->
 %% @doc Read settings from the application environment
 %% TODO: Update HWM for each Index when Ring-Resize occurrs
 read_appenv(State) ->
-    HWM = app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_HWM, 1),
+    HWM = app_helper:get_env(?YZ_APP_NAME, ?SOLRQ_HWM, ?SOLRQ_HWM_DEFAULT),
     PBIStrategy = application:get_env(?YZ_APP_NAME, ?SOLRQ_HWM_PURGE_STRATEGY,
                                       ?PURGE_ONE),
     State#state{queue_hwm = HWM,

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -72,7 +72,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_hwm", 1000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_timeout", 60000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_cancel_timeout", 5000),
-    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", false),
+    cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_enable", true),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_sessions", 100),
     cuttlefish_unit:assert_config(Config, "yokozuna.ibrowse_max_pipeline_size", 1),
     cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled", true),


### PR DESCRIPTION
This PR was motivated by inconsistent default values for configuration variables in cuttlefish and in the code (and with different defaults in some parts of the code!).  This can cause unwanted behavior when cuttlefish is not being used, for example, in an upgrade case where the user is still using the older app.config style configuration.  Technically, we should also be prepared for the case where the library is NOT being used in the context of cuttlefish configuration, even through practically speaking cuttlefish is (almost) always in effect.

This allows any unspecified values take on consistent defaults.  There is still a point of management between the defaults in code and the cuttlefish defaults, but these can now be tracked in two files.  Also removed some stale macro definitions that were no longer used.
