### PR TITLE
Fixed wedged YZ AAE hash tree exchanges

### DIFF
--- a/src/yz_entropy_mgr.erl
+++ b/src/yz_entropy_mgr.erl
@@ -647,9 +647,9 @@ maybe_exchange(Ring, S) ->
             S2;
         {NextExchange, S2} ->
             {Index, IndexN} = NextExchange,
-            case already_exchanging(Index, S) of
+            case already_exchanging(Index, S2) of
                 true ->
-                    requeue_exchange(Index, IndexN, S2);
+                    S2;
                 false ->
                     case start_exchange(Index, IndexN, Ring, S2) of
                         {ok, S3} -> S3;


### PR DESCRIPTION
This PR addresses two bugs that result in the following symptom:
- A Yokozuna AAE hash tree exchange gets wedged indefinitely
- All other YZ AAE exchanges appear wedged

The outward appearance is that all AAE exchanges seem to be wedged.  This can happen in may 1:20 runs of the yz_extractors riak test.

The root cause of the bug is that when an exchange occurs, an Exchange FSM is fired up and requests a compare via a gen_server call to the `yz_index_hashtree` that includes the hashtree the being exchanged with Riak K/V.  The implementation of this call is, in the normal case, to `spawn_link` a function to do the actual comparison asynchronously, and defer the reply back to the Exchange FSM when the actual comparison is complete.  This is a common technique used in this subsystem, and allows the `yz_index_hashtree` to continue servicing requests (even if it's currently only being used by the Exchange FSM).

The problem is that in rare cases, this processes that is spawned will crash before it has replied back to the Exchange FSM, thus leaving the FSM in a state where it is waiting for a reply.  (The gen_server call uses a timeout of `infinity`).

How can it crash?  Well it turns out that this process is itself doing a gen_server:call on the associated riak_kv_index_hashtree, and in rare cases, this process can terminate via  a close operation.  If this happens, the call to get_server:call can actually exit the process (via `erlang:exit`), which results in an `{'EXIT', From, normal}` being sent back to the yz index hash tree, and not completing the reply back to the Exchange FSM.

The solution is to wrap the async process in a try-catch, and to deliver an `{error, Reason}` back to the ExchangeFSM, in case this process dies prematurely.

This PR also addresses the bug whereby all ExchangeFSMs wedge if one does.  This happens because the `yz_entropy_mgr` will re-queue an exchange if it detects that it is already active.  But the exchange manager will only add new entries to the queue when the queue of pending exchanges runs empty.  So by requeing, we are never giving other exchanges the opportunity to exchange in the future (or at least while a long-lived exchange is going on).

The solution to this bug is to NOT re-queue an exchange if it is active, but instead to wait until all exchanges have at least been tried.

Detailed notes from commit:

Wrapped asynchronous compare process in a try-catch in order to prevent spawn-linked compare proc from crashing (and not replying back to the exchange FSM) when the riak_kv_index_hashtree being compared with is terminated.

Also addressed a bug which prevented exchanges from proceeding if one exchange is wedged, by not immediately requeing the exchange, but instead waiting for the next full cycle of additions to the exchange queue (on the yz_entropy_mgr).
