### PR TITLE
Update defaults for soft commit and batching flush interval to more closely match pre-batching behavior

### DIFF
--- a/include/yokozuna.hrl
+++ b/include/yokozuna.hrl
@@ -498,7 +498,7 @@
 -define(SOLRQ_BATCH_MAX, solrq_batch_max).
 -define(SOLRQ_BATCH_MAX_DEFAULT, 500).
 -define(SOLRQ_BATCH_FLUSH_INTERVAL, solrq_batch_flush_interval).
--define(SOLRQ_BATCH_FLUSH_INTERVAL_DEFAULT, 1000).
+-define(SOLRQ_BATCH_FLUSH_INTERVAL_DEFAULT, 500).
 -define(SOLRQ_HWM, solrq_hwm).
 -define(SOLRQ_HWM_DEFAULT, 1000).
 -define(SOLRQ_HWM_PURGE_STRATEGY, solrq_hwm_purge_strategy).

--- a/priv/conf/solrconfig.xml
+++ b/priv/conf/solrconfig.xml
@@ -187,7 +187,7 @@
       -->
 
        <autoSoftCommit>
-         <maxTime>1000</maxTime>
+         <maxTime>500</maxTime>
        </autoSoftCommit>
 
     <!-- Update Related Event Listeners

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -228,8 +228,8 @@
 %%      systems.
 {mapping, "search.queue.batch.flush_interval",
  "yokozuna.solrq_batch_flush_interval", [
-  {default, "1s"},
-  {commented, "1s"},
+  {default, "500ms"},
+  {commented, "500ms"},
   {datatype, [{duration, ms}, {atom, infinity}]}
 ]}.
 

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -68,7 +68,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_min", 10),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_max", 500),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_batch_flush_interval",
-                                  1000),
+                                  500),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_hwm", 1000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_timeout", 60000),
     cuttlefish_unit:assert_config(Config, "yokozuna.solrq_drain_cancel_timeout", 5000),


### PR DESCRIPTION
This commit makes the combination of Solr's `softCommit` and our `solrq_batch_flush_interval` add up to 1 second, which was previously the interval for the `softCommit` before we introduced batching to Yokozuna. This will make a default installation more closely match the previous behavior of 1 second maximum delay between `put` and searchability.
