### PR TITLE
Removing the logging of DOWN messages from processes we are monitoring.

### DIFF
--- a/src/yz_index_hashtree.erl
+++ b/src/yz_index_hashtree.erl
@@ -262,8 +262,7 @@ handle_cast(_Msg, S) ->
 
 handle_info({'EXIT', _SomeOtherProc, normal}, S) ->
     {noreply, S};
-handle_info({'DOWN', Ref, _, _, _} = Message, S) ->
-    lager:notice("Received DOWN message: ~p", [Message]),
+handle_info({'DOWN', Ref, _, _, _}, S) ->
     S2 = maybe_release_lock(Ref, S),
     {noreply, S2};
 handle_info(Message, S) ->


### PR DESCRIPTION
The rationale for this change is as follows:

If the Info passed in the DOWN message is 'normal', then there is nothing to log, and it's just an annoyance to the user.
Otherwise, if the Info is "non-normal", it should be picked up by SASL logging elsewhere, so logging it is not providing any additional information for diagnostics.
