### PR TITLE
Upgrade ibrowse to 4.0.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,8 +14,8 @@
    {git, "git://github.com/etrepum/kvc.git", {tag, "v1.5.0"}}},
   {riak_kv, ".*",
    {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},
-  {ibrowse, "4.0.1",
-   {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.1"}}},
+  {ibrowse, "4.0.2",
+   {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
   {fuse, "2.1.0",
    {git, "git@github.com:jlouis/fuse.git", {tag, "v2.1.0"}}}
  ]}.


### PR DESCRIPTION
In Riak-2.0.x yokozuna uses ibrowse-4.0.1. On heavily loaded servers
ibrowse eventually crashes due to overflowing a counter:

```
2016-08-27 22:03:53.361 [error] <0.5628.0> gen_server <0.5628.0> terminated with reason: bad argument in call to ets:update_counter(235767857484, <0.1149.1954>, {3,1,9999999,9999999}) in ibrowse_lb:find_best_connection/3 line 242
2016-08-27 22:03:53.361 [error] <0.5628.0> CRASH REPORT Process <0.5628.0> with 15 neighbours exited with reason: bad argument in call to ets:update_counter(235767857484, <0.1149.1954>, {3,1,9999999,9999999}) in ibrowse_lb:find_best_connection/3 line 242 in gen_server:terminate/6 line 744
```

A fix for this exists in ibrowse-4.0.2, which is already in use in
Riak 2.1.4 and Riak 2.2.

Fixes https://github.com/basho/yokozuna/issues/687
