### PR TITLE
fix issue #691: building may fail due to bad /var/tmp/yokozuna permissions

### DIFF
--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -56,7 +56,7 @@ get_solr()
                 if [ -d $TMP_DIR ]; then
                     cp $FILENAME $TMP_DIR
                 else
-                    mkdir $TMP_DIR
+                    mkdir -m 1777 $TMP_DIR
                     cp $FILENAME $TMP_DIR
                 fi
             fi


### PR DESCRIPTION
When building yokozuna on a shared machine by multiple users, the build may fail with the following error:

cp: cannot create regular file `/var/tmp/yokozuna/solr-4.7.0-yz-1.tgz': Permission denied

This happens because the tools/grab-solr.sh script creates /var/tmp/yokozuna to cache a copy of the solr tarball, but creates /var/tmp/yokozuna using the umask for the current user, which (typically) prevents other users from writing to the cache directory. If a different user tries to build and the grab-solr.sh script needs to write a tarball to the directory because their build needs a different version of solr, the build will fail with an error similar to the above.

Temporary workaround:

$ chmod 1777 /var/tmp/yokozuna

Permanent fix is ensure grab-solr.sh creates the directory with mode 1777.
