### PR TITLE
Fix node crash issue caused by unhandled non-error [JIRA: RIAK-2891]

### DIFF
--- a/src/yz_index.erl
+++ b/src/yz_index.erl
@@ -366,7 +366,10 @@ remove_non_owned_data(Index, Ring) ->
     LNonOwned = yz_cover:logical_partitions(Ring, NonOwned),
     Queries = [{'query', <<?YZ_PN_FIELD_S, ":", (?INT_TO_BIN(LP))/binary>>}
                || LP <- LNonOwned],
-    ok = yz_solr:delete(Index, Queries),
+    case yz_solr:delete(Index, Queries) of
+      ok -> ok;
+      {error, nothing_to_delete} -> ok
+    end,
     NonOwned.
 
 -spec schema_name(index_info()) -> schema_name().

--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -172,6 +172,7 @@ delete(Index, Ops) ->
     case ibrowse:send_req(URL, Headers, post, JSON, Opts,
                           ?YZ_SOLR_REQUEST_TIMEOUT) of
         {ok, "200", _, _} -> ok;
+        {ok, "404", _, _} -> {error, nothing_to_delete};
         Err -> {error, Err}
     end.
 


### PR DESCRIPTION
When deleting an index, we were only considering 200 a success.
However, if we tried to delete an index that didn't exist, solr
would return a 404, which we didn't handle. Now we consider that
a success as well.
