### PR TITLE
Prevent fallback vnodes' solrqs from stopping if they are still needed

### DIFF
--- a/test/yz_solrq_eqc.erl
+++ b/test/yz_solrq_eqc.erl
@@ -572,8 +572,10 @@ wait_for_vnodes_msgs([Pid | Pids], Ref) ->
 
 start_solrqs(Partitions, Indexes) ->
     %% Ring retrieval for required workers
-    meck:expect(riak_core_ring_manager, get_my_ring, fun() -> {ok, not_a_real_ring} end),
-    meck:expect(yz_misc, owned_and_next_partitions, fun(_, _) -> unique_entries(Partitions) end),
+    UniquePartitions = unique_entries(Partitions),
+    meck:expect(riak_core_vnode_manager, all_vnodes, fun(riak_kv_vnode) ->
+        [{riak_kv_vnode, Idx, fake_pid} || Idx <- UniquePartitions]
+                                                     end),
     meck:expect(yz_index, get_indexes_from_meta, fun() -> unique_entries(Indexes) -- [?YZ_INDEX_TOMBSTONE] end),
     %% And start up supervisors to own the solrq/solrq helper
     _ = yz_solrq_sup:start_link(),


### PR DESCRIPTION
Before, we used the "current and next" vnode list according to the ring
to determine which partitions were needed for solrq start/stop. This
change simply asks `riak_core_vnode_manager` which `riak_kv_vnode`
vnodes are currently running, and uses that list to figure out which
queues we need to have running.
This should prevent issues where fallback vnodes currently running on a
node would create many short-lived solrqs, which would start on demand
when an index call was made that needed them, and stop every tick.