### PR TITLE
Refresh default schema

### DIFF
--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -21,8 +21,6 @@
    <!-- TODO: is this needed? -->
    <field name="_version_" type="long" indexed="true" stored="true"/>
 
-   <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
-
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"  multiValued="false"/>
    <dynamicField name="*_is" type="int"    indexed="true"  stored="true"  multiValued="true"/>
    <dynamicField name="*_l"  type="long"   indexed="true"  stored="true"  multiValued="false"/>
@@ -135,6 +133,12 @@
    <field name="_yz_err" type="_yz_str" indexed="true" stored="false" multiValued="false"/>
 
  <uniqueKey>_yz_id</uniqueKey>
+
+  <!-- Enable only if the client does not know what fields may be
+       searched because it's very expensive to index everything
+       twice. -->
+  <!-- <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/> -->
+  <!-- <copyField source="*" dest="_text_"/> -->
 
     <!-- YZ String: Used for non-analyzed fields -->
     <fieldType name="_yz_str" class="solr.StrField" sortMissingLast="true" />

--- a/priv/default_schema.xml
+++ b/priv/default_schema.xml
@@ -17,7 +17,6 @@
 -->
 
 <schema name="default" version="1.5">
- <fields>
 
    <!-- TODO: is this needed? -->
    <field name="_version_" type="long" indexed="true" stored="true"/>
@@ -134,11 +133,9 @@
 
    <!-- Flag indicating if this doc is the product of a failed object extraction -->
    <field name="_yz_err" type="_yz_str" indexed="true" stored="false" multiValued="false"/>
- </fields>
 
  <uniqueKey>_yz_id</uniqueKey>
 
-  <types>
     <!-- YZ String: Used for non-analyzed fields -->
     <fieldType name="_yz_str" class="solr.StrField" sortMissingLast="true" />
 
@@ -803,6 +800,5 @@
         <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
       </analyzer>
     </fieldType>
- </types>
 
 </schema>


### PR DESCRIPTION
I tried full text search and I ended up reviewing the default schema.

If you want to keep the default schema compatible with Riak 2.0.7 for another while you need to reject this PR as it removes tags.