### PR TITLE
Removed explicit YZ dependency in riak_kv

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -332,8 +332,9 @@
   hidden
 ]}.
 
-%% @doc Add yokozuna to the riak_kv index modules
-{mapping, "search.index_module", "riak_kv.index_module", [
+%% @doc Set the riak_kv update hook to be the yokozuna module, which
+%%      implements the `riak_kv_update_hook` behavior
+{mapping, "search.update_hook", "riak_kv.update_hook", [
     {datatype, atom},
     {default, yokozuna},
     hidden

--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -332,6 +332,13 @@
   hidden
 ]}.
 
+%% @doc Add yokozuna to the riak_kv index modules
+{mapping, "search.index_module", "riak_kv.index_module", [
+    {datatype, atom},
+    {default, yokozuna},
+    hidden
+]}.
+
 %%===========================================================
 %% Validators
 %%===========================================================

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -27,6 +27,26 @@
 %%% API
 %%%===================================================================
 
+%% @doc Index a Riak object, given a reason and partition under which
+%%      the object is being indexed.  The object pair contains the new
+%%      and old objects, in the case where a read-before-write resulted
+%%      in an old object we can use to delete siblings before updating.
+-spec index(object_pair(), write_reason(), p()) -> ok.
+index(RObjPair, Reason, Idx) ->
+    yz_kv:index(RObjPair, Reason, Idx).
+
+%% @doc Index a Riak object encoded as a n erlang binary.  This function
+%%      is typically called from the write-once path, where there is no
+%%      old object to
+-spec index_binary(bucket(), key(), binary(), write_reason(), p()) -> ok.
+index_binary(Bucket, Key, Bin, Reason, P) ->
+    yz_kv:index_binary(Bucket, Key, Bin, Reason, P).
+
+%% @doc Determine whether a bucket is searchable, based on its properties.
+-spec is_searchable(riak_kv_bucket:props()) -> boolean().
+is_searchable(BProps) ->
+    yz_kv:is_search_enabled_for_bucket(BProps).
+
 %% @doc Disable the given `Component'.  The main reason for disabling
 %%      a component is to help in diagnosing issues in a live,
 %%      production environment.  E.g. the `search' component may be

--- a/test/eqc_util.erl
+++ b/test/eqc_util.erl
@@ -113,6 +113,7 @@ start_mock_components(Options) ->
     riak_core_ring_manager:setup_ets(test),
     setup_mockring(RingSize),
     riak_kv_entropy_info:create_table(),
+    riak_core_capability:start_link(),
     riak_kv_entropy_manager:start_link(),
     ok.
 

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -78,6 +78,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled", true),
     cuttlefish_unit:assert_not_configured(Config, "yokozuna.aae_throttle_limits"),
     cuttlefish_unit:assert_config(Config, "yokozuna.enable_dist_query", true),
+    cuttlefish_unit:assert_config(Config, "riak_kv.index_module", yokozuna),
     ok.
 
 override_schema_test() ->

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -78,7 +78,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled", true),
     cuttlefish_unit:assert_not_configured(Config, "yokozuna.aae_throttle_limits"),
     cuttlefish_unit:assert_config(Config, "yokozuna.enable_dist_query", true),
-    cuttlefish_unit:assert_config(Config, "riak_kv.index_module", yokozuna),
+    cuttlefish_unit:assert_config(Config, "riak_kv.update_hook", yokozuna),
     ok.
 
 override_schema_test() ->


### PR DESCRIPTION
This PR is coupled with https://github.com/basho/riak_kv/pull/1571, which removes the explicit compile- and run-time dependency on yokozuna from riak_kv_vnode.

In the Yokozuna repo, this means adding indexing operations now expected by riak_kv_vnode, and consolidating them in the yokozuna module, as a reasonable entry point into the application.  This PR also Adds hidden configuration into cuttlefish which will configure riak_kv to send indexing operations through this module.

C.f. https://github.com/basho/riak_kv/pull/1571 for PR checklist.