### PR TITLE
Speed up partition_list query

### DIFF
--- a/src/yz_solr.erl
+++ b/src/yz_solr.erl
@@ -279,8 +279,11 @@ prepare_json(Docs) ->
 -spec partition_list(index_name()) -> {ok, Resp::binary()} | {error, term()}.
 partition_list(Core) ->
     Params = [{q, "*:*"},
+              {rows, 0},
+              {omitHeader, <<"true">>},
               {facet, "on"},
               {"facet.mincount", "1"},
+              {"facet.method", <<"enum">>},
               {"facet.field", ?YZ_PN_FIELD_S},
               {wt, "json"}],
     Encoded = mochiweb_util:urlencode(Params),


### PR DESCRIPTION
Use 'facet.method=enum' for much reduced query times, and avoid overhead
of returning unused actual query results and headers.

Fixes https://github.com/basho/yokozuna/issues/720