### PR TITLE
Added handling for upgrades from 2.0.8 and later releases

### DIFF
--- a/src/yz_solr_proc.erl
+++ b/src/yz_solr_proc.erl
@@ -55,6 +55,7 @@
 -define(YZ_DEFAULT_SOLR_JVM_OPTS, "").
 
 -define(SOLRCONFIG_2_0_HASH, 64816669).
+-define(SOLRCONFIG_2_0_8_HASH, 7665368).
 -define(LUCENE_MATCH_4_7_VERSION, "4.7").
 -define(LUCENE_MATCH_4_10_4_VERSION, "4.10.4").
 
@@ -386,15 +387,22 @@ check_solr_index_versions(YZRootDir) ->
 check_index_solrconfig(SolrConfigIndexPath, DefaultSolrConfigPath, DefaultSolrConfigHash) ->
     case hash_file_contents(SolrConfigIndexPath) of
         DefaultSolrConfigHash ->
-            ok;
+            lager:debug("Solr config ~s appears to be up to date.", [SolrConfigIndexPath]);
         ?SOLRCONFIG_2_0_HASH ->
-            yz_misc:copy_files([DefaultSolrConfigPath], filename:dirname(SolrConfigIndexPath)),
-            lager:info(
-                "Upgraded ~s to the latest version.", [SolrConfigIndexPath]
-            );
+            upgrade_solr_config(SolrConfigIndexPath, DefaultSolrConfigPath, "2.0");
+        %% NB. Riak 2.0.8 introduced a small change to solrconfig.xml
+        ?SOLRCONFIG_2_0_8_HASH ->
+            upgrade_solr_config(SolrConfigIndexPath, DefaultSolrConfigPath, "2.0.8");
         _ ->
             check_index_solrconfig_version(SolrConfigIndexPath)
     end.
+
+-spec upgrade_solr_config(path(), path(), string()) -> ok.
+upgrade_solr_config(SolrConfigIndexPath, DefaultSolrConfigPath, Version) ->
+    yz_misc:copy_files([DefaultSolrConfigPath], filename:dirname(SolrConfigIndexPath)),
+    lager:info(
+        "Upgraded ~s from ~s (or higher) to the latest version.", [SolrConfigIndexPath, Version]
+    ).
 
 -spec check_index_solrconfig_version(path()) -> ok.
 check_index_solrconfig_version(SolrConfigIndexPath) ->


### PR DESCRIPTION
This PR adds handling for upgrade from Riak 2.0.8 and later (2.0.x) releases.

Riak 2.0.8 added a minor change to the default solrconfig.xml, which changed the hash of the config file, which prevented automatic updates.   This PR detects the hash for that specific version of the default config file, and does an upgrade, accordingly, if that version is detected.  This special case logic should ONLY be required for these two cases, and should not impose an ongoing maintenance burden.

The PR also fixes a regression in the rolling upgrade functionality in the upgrade/downgrade riak test, which now passes when run against a 2.0.x and 2.2.x devrel with fixes for the `riak-admin` tool.