### PR TITLE
Fixes for failing riak tests.

### DIFF
--- a/riak_test/yz_crdt.erl
+++ b/riak_test/yz_crdt.erl
@@ -256,6 +256,7 @@ test_and_validate_delete_aae(Pid, Cluster, Bucket, Index) ->
 
     [make_intercepts_tab(ANode) || ANode <- Cluster],
 
+    yz_rt:load_intercept_code(Cluster),
     [rt_intercept:add(ANode, {yz_solrq_helper, [{{get_ops_for_no_sibling_deletes, 3},
                                         handle_get_ops_for_no_sibling_deletes}]})
      || ANode <- Cluster],

--- a/riak_test/yz_extractors.erl
+++ b/riak_test/yz_extractors.erl
@@ -155,7 +155,12 @@
            {anti_entropy_concurrency, 8},
            {anti_entropy_tick, 1000},
            %% but start with AAE turned off so as not to interfere with earlier parts of the test
-           {anti_entropy, {off, []}}
+           {anti_entropy, {off, []}},
+           %% speed up AAE tree rebuilds, now that we are using sweeper
+           {sweep_concurrency, 8},
+           {sweep_tick, 1023},
+           %% don't let hashtree upgrades delay exchanges
+           {force_hashtree_upgrade, true}
           ]},
          {yokozuna,
           [
@@ -335,7 +340,7 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
     rpc:multicall(Cluster, riak_kv_entropy_manager, enable, []),
 
     yz_rt:expire_trees(Cluster),
-    yz_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
+    yz_rt:wait_for_aae(Cluster),
 
     yz_rt:search_expect(ANode, Index, <<"host">>,
                               <<"www*">>, 1),
@@ -357,7 +362,7 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
                               <<"GET">>, 1),
 
     yz_rt:expire_trees(Cluster),
-    yz_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
+    yz_rt:wait_for_aae(Cluster),
 
     yz_rt:search_expect(ANode, Index, <<"method">>,
                               <<"GET">>, 1),


### PR DESCRIPTION
yz_crdt was moved over from riak_test but did not include a call to yz_rt:load_intercept_code(Cluster), so the intercepts never loaded properly.

yz_extractors was failing to converge on AAE.  Bumped up sweep tick and concurrency to make AAE tree rebuilds occur more quickly, and forced version 1 hash trees at start.