### PR TITLE
Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {deps,
  [
   {kvc, ".*", {git, "git://github.com/etrepum/kvc.git", {tag, "v1.5.0"}}},
-  {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {tag, "2.1.7-226"}}},
+  {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop-2.9"}}},
   {ibrowse, "4.0.2", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
   {fuse, "2.1.0", {git, "https://github.com/jlouis/fuse.git", {tag, "v2.1.0"}}},
   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.5.5"}}}


### PR DESCRIPTION
Switch to develop-2.9 reference of riak_kv.  Stop confusion with wrong repo potentially being pulled if locked-deps not used