### PR TITLE
Yokozuna/KV isolation

### DIFF
--- a/priv/yokozuna.schema
+++ b/priv/yokozuna.schema
@@ -332,6 +332,14 @@
   hidden
 ]}.
 
+%% @doc Set the riak_kv update hook to be the yokozuna module, which
+%%      implements the `riak_kv_update_hook` behavior
+{mapping, "search.update_hook", "riak_kv.update_hook", [
+    {datatype, atom},
+    {default, yokozuna},
+    hidden
+]}.
+
 %%===========================================================
 %% Validators
 %%===========================================================

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {deps,
  [
   {kvc, ".*", {git, "git://github.com/etrepum/kvc.git", {tag, "v1.5.0"}}},
-  {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop-2.9"}}},
+  {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "fd-remove-yz-dep-develop29"}}},
   {ibrowse, "4.0.2", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
   {fuse, "2.1.0", {git, "https://github.com/jlouis/fuse.git", {tag, "v2.1.0"}}},
   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop-2.2"}}}

--- a/src/yokozuna.erl
+++ b/src/yokozuna.erl
@@ -23,6 +23,51 @@
 
 -type fold_fun() :: fun(([term()], Acc::term()) -> Acc::term()).
 
+-behaviour(riak_kv_update_hook).
+
+%% riak_kv_update_hook behaviors
+-export([
+    update/3,
+    update_binary/5,
+    requires_existing_object/1,
+    should_handoff/1
+]).
+
+%%%===================================================================
+%% riak_kv_update_hook behavior
+%%%===================================================================
+
+%% @doc see riak_kv_update_hook:update/3
+-spec update(
+    riak_kv_update_hook:object_pair(),
+    riak_kv_update_hook:update_reason(),
+    riak_kv_update_hook:partition()
+) -> ok.
+update(RObjPair, Reason, Idx) ->
+    yz_kv:index(RObjPair, Reason, Idx).
+
+%% @doc see riak_kv_update_hook:update_binary/5
+-spec update_binary(
+    riak_core_bucket:bucket(),
+    riak_object:key(),
+    binary(),
+    riak_kv_update_hook:update_reason(),
+    riak_kv_update_hook:partition()
+) -> ok.
+update_binary(Bucket, Key, Bin, Reason, P) ->
+    yz_kv:index_binary(Bucket, Key, Bin, Reason, P).
+
+%% @doc see riak_kv_update_hook:requires_existing_object/1
+-spec requires_existing_object(riak_kv_bucket:props()) -> boolean().
+requires_existing_object(BProps) ->
+    yz_kv:is_search_enabled_for_bucket(BProps).
+
+%% @doc see riak_kv_update_hook:should_handoff/1
+-spec should_handoff(riak_kv_update_hook:handoff_dest()) -> boolean().
+should_handoff(HandoffSpec) ->
+    yz_kv:should_handoff(HandoffSpec).
+
+
 %%%===================================================================
 %%% API
 %%%===================================================================

--- a/test/yokozuna_schema_tests.erl
+++ b/test/yokozuna_schema_tests.erl
@@ -78,6 +78,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "yokozuna.aae_throttle_enabled", true),
     cuttlefish_unit:assert_not_configured(Config, "yokozuna.aae_throttle_limits"),
     cuttlefish_unit:assert_config(Config, "yokozuna.enable_dist_query", true),
+    cuttlefish_unit:assert_config(Config, "riak_kv.update_hook", yokozuna),
     ok.
 
 override_schema_test() ->


### PR DESCRIPTION
Cherry pick of https://github.com/basho/yokozuna/commit/b71590608fc8b1950c19a824fc88ed498bf41c2b

This adds the hook code so that yokozuna can be used with the isolated hooks in https://github.com/basho/riak_kv/tree/fd-remove-yz-dep-develop29

This a feature that was previously merged in to develop by basho old.  It allows for the removal of yokozuna references from riak_kv.  This will then allow in the future for riak_kv to be packaged without yokozuna in environments where solr is not used, and there is no future intention of using it.

The combined branches pass all yoko_all tests (except the solr_upgrade_downgrade test which tests and upgrade from a legacy solr version - but this also fails in develop-2.9).  Packaging riak without yokozuna passes all kv_all riak_test tests.