### PR TITLE
Update ibrowse

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
  [
   {kvc, ".*", {git, "git://github.com/etrepum/kvc.git", {tag, "v1.5.0"}}},
   {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop-2.9"}}},
-  {ibrowse, "4.3", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.3"}}},
+  {ibrowse, ".*", {git, "git://github.com/basho/ibrowse.git", {branch, "develop-2.9"}}},
   {fuse, "2.1.0", {git, "https://github.com/jlouis/fuse.git", {tag, "v2.1.0"}}},
   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop-2.9"}}}
  ]}.


### PR DESCRIPTION
Switch back to basho ibrowse with resolution to intermittent unit test failures.

`develop-2.9` is essentially `develop-3.0`, but with workarounds for two places not compatible with pre-OTP18.