### PR TITLE
Replace shasum with sha1sum and sha512sum

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -18,8 +18,8 @@ mk_sha()
 
     if type sha512t256 &>/dev/null; then
         sha512t256 $file > $file.sha512
-    elif type shasum &>/dev/null; then
-        shasum -a 512256 $file > $file.sha512
+    elif type sha512sum &>/dev/null; then
+        sha512sum $file > $file.sha512
     else
         echo "Unable to locate program to compute SHA"
         exit 1

--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -59,7 +59,7 @@ get_solr()
             echo "Downloading original Solr..."
             download "${ARTIFACT_URL_PREFIX}/$FILENAME"
             download "${ARTIFACT_URL_PREFIX}/$FILENAME.sha1"
-            set -u; shasum -s -c $FILENAME.sha1
+            set -u; sha1sum --status -c $FILENAME.sha1
             mkdir -p -m 1777 $TMP_DIR
             cp $FILENAME $TMP_DIR
         fi


### PR DESCRIPTION
`/home/martincox/code/riak/_build/default/lib/yokozuna/tools/grab-solr.sh: line 62: shasum: command not found
===> Hook for compile failed!
`
https://github.com/basho/yokozuna/blob/8ac890cdb6f2859d35eed174a194f6112a0b530d/tools/grab-solr.sh#L62

I was seeing build errors in centos for yoko and it looked to be from the use of shasum, which as far as I can tell, isn't present in rhel/centos. I've replaced the calls with the appropriate sha*sum call.