### PR TITLE
Fix unexpected operator errors when grabbing solr

### DIFF
--- a/tools/build-jar.sh
+++ b/tools/build-jar.sh
@@ -3,7 +3,7 @@
 # Build JAR file containing customer Solr request handlers.
 set -eu
 
-[ $(basename $PWD) == "tools" ] || cd tools
+[ $(basename $PWD) = "tools" ] || cd tools
 . ./common.sh
 
 

--- a/tools/copy-jars.sh
+++ b/tools/copy-jars.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-[ $(basename $PWD) == "tools" ] || cd tools
+[ $(basename $PWD) = "tools" ] || cd tools
 . ./common.sh
 
 JAVA_LIB=../priv/java_lib

--- a/tools/grab-solr.sh
+++ b/tools/grab-solr.sh
@@ -10,7 +10,7 @@
 
 set    -eu
 
-[ $(basename $PWD) == "tools" ] || cd tools
+[ $(basename $PWD) = "tools" ] || cd tools
 . ./common.sh
 
 


### PR DESCRIPTION
The shell scripts in the `tools` directory are executed via `#!/usr/bin/env sh`. Three of them--`build-jar.sh`, `copy-jars.sh`, and `grab_solr.sh`--use a bash idiom which is a double equal inside of a single bracket `[ "$something" == "otherthing" ]`.

In `bash` `==` and `=` are equivalent inside of `[]`. In `sh` that is not the case. In `sh` checking for equality inside of single brackets can only be done with a single equal sign. Using a double-equal results in an `unexpected operator` error, and the left hand side of the conditional statement always fails.

```shell
$ Y="yokozuna"
$ [ $Y == "yokozuna" ] || echo yokozuna
/bin/sh: 6: [: yokozuna: unexpected operator
yokozuna
$
```

```shell
$ Y="yokozuna"
$ [ $Y = "yokozuna" ] || echo yokozuna
$
```